### PR TITLE
Add APPLICATION_ROOT env var for subfolder deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Web SSH Terminal is a self-hosted web application that provides secure SSH acces
   <img src="https://raw.githubusercontent.com/bifrost0x/webssh/main/assets/commandlibrary.png" alt="Command Library" width="700">
 </p>
 
+### Deployment
+- **Docker & Docker Compose** - Single-command deployment with healthcheck
+- **Reverse Proxy Ready** - Traefik, nginx, and Caddy examples included
+- **Subfolder Deployment** - Host under a URL subpath like `/webssh` (see [Subfolder Deployment](#subfolder-deployment))
+- **Homelab Friendly** - Wildcard CORS mode for internal networks
+
 ## Quick Start
 
 ### Docker (Recommended)
@@ -155,6 +161,7 @@ docker build -t webssh:local .
 | `CORS_ORIGINS` | No | `localhost:5000` | Allowed origins for CORS (comma-separated) |
 | `ALLOW_CORS_WILDCARD` | No | `false` | Set `true` to allow `*` as CORS origin (homelab use) |
 | `TRUSTED_PROXIES` | No | `0` | Set `1` when behind a reverse proxy |
+| `APPLICATION_ROOT` | No | - | URL subpath when deploying under a prefix (e.g. `/webssh`). See [Subfolder Deployment](#subfolder-deployment) |
 | `DEBUG` | No | `False` | Enable debug mode (development only) |
 | `HOST` | No | `127.0.0.1` | Bind address (`0.0.0.0` in Docker) |
 | `PORT` | No | `5000` | Listen port |
@@ -192,6 +199,57 @@ location / {
 ```caddyfile
 ssh.example.com {
     reverse_proxy webssh:5000
+}
+```
+
+### Subfolder Deployment
+
+To serve the app under a URL subpath like `https://server.local/webssh`, set:
+
+```bash
+APPLICATION_ROOT=/webssh
+TRUSTED_PROXIES=1
+```
+
+Then configure your reverse proxy to strip the prefix and forward it via `X-Forwarded-Prefix`.
+
+#### Nginx (subfolder)
+
+```nginx
+location /webssh/ {
+    proxy_pass http://webssh:5000/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Prefix /webssh;
+}
+```
+
+#### Traefik (subfolder)
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.webssh.rule=Host(`server.local`) && PathPrefix(`/webssh`)"
+  - "traefik.http.middlewares.webssh-strip.stripprefix.prefixes=/webssh"
+  - "traefik.http.middlewares.webssh-prefix.headers.customrequestheaders.X-Forwarded-Prefix=/webssh"
+  - "traefik.http.routers.webssh.middlewares=webssh-strip,webssh-prefix"
+  - "traefik.http.services.webssh.loadbalancer.server.port=5000"
+```
+
+#### Caddy (subfolder)
+
+```caddyfile
+server.local {
+    handle_path /webssh/* {
+        reverse_proxy webssh:5000 {
+            header_up X-Forwarded-Prefix /webssh
+        }
+    }
 }
 ```
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,6 +34,15 @@ def create_app():
     app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
     app.config.from_object(config)
 
+    url_prefix = getattr(config, 'APPLICATION_ROOT', '')
+    if url_prefix:
+        app.config['SESSION_COOKIE_PATH'] = url_prefix
+        app.config['REMEMBER_COOKIE_PATH'] = url_prefix
+
+    @app.context_processor
+    def inject_url_prefix():
+        return {'url_prefix': url_prefix}
+
     trusted_proxies = int(os.environ.get('TRUSTED_PROXIES', '0'))
     if trusted_proxies > 0:
         app.wsgi_app = ProxyFix(

--- a/config.py
+++ b/config.py
@@ -88,6 +88,10 @@ RATELIMIT_DEFAULT = os.environ.get('RATELIMIT_DEFAULT', '200 per hour')
 
 REGISTRATION_ENABLED = os.environ.get('REGISTRATION_ENABLED', 'True') == 'True'
 
+_env_app_root = os.environ.get('APPLICATION_ROOT', '').rstrip('/')
+if _env_app_root:
+    APPLICATION_ROOT = _env_app_root
+
 # SSRF protection: block SSH connections to loopback/link-local addresses.
 # Set to 'true' in multi-tenant deployments to prevent users from probing
 # internal services via SSH. Defaults to 'false' for homelab use where

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,14 @@ services:
       # === Set to 1 if behind reverse proxy (Traefik, nginx, etc.) ===
       - TRUSTED_PROXIES=0
 
+      # === Subfolder deployment (optional) ===
+      # Set when serving the app under a URL subpath, e.g. https://server.local/webssh
+      # Requires: TRUSTED_PROXIES=1 above AND a reverse proxy that strips the
+      # prefix and forwards it via the X-Forwarded-Prefix header.
+      # Leave commented to run at the root — behavior is unchanged when unset.
+      # See README "Subfolder Deployment" section for nginx/Traefik/Caddy examples.
+      # - APPLICATION_ROOT=/webssh
+
       # === Set to false if accessing via HTTP without TLS ===
       - SESSION_COOKIE_SECURE=false
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,7 +1,9 @@
 (function() {
     'use strict';
 
-    window.socket = io();
+    const APP_ROOT = document.querySelector('meta[name="app-root"]')?.content || '';
+    window.APP_ROOT = APP_ROOT;
+    window.socket = io({ path: APP_ROOT + '/socket.io' });
 
     window.escapeHtml = function(text) {
         if (!text) return '';
@@ -1658,7 +1660,7 @@
         const changePasswordBtn = document.getElementById('changePasswordBtn');
         if (changePasswordBtn) {
             changePasswordBtn.addEventListener('click', () => {
-                window.location.href = '/change-password';
+                window.location.href = APP_ROOT + '/change-password';
             });
         }
 
@@ -1667,7 +1669,7 @@
             if (confirm(message)) {
                 const form = document.createElement('form');
                 form.method = 'POST';
-                form.action = '/logout';
+                form.action = APP_ROOT + '/logout';
                 const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
                 if (csrfToken) {
                     const input = document.createElement('input');

--- a/static/js/sftp-file-manager.js
+++ b/static/js/sftp-file-manager.js
@@ -1558,7 +1558,7 @@ class SFTPFileManager {
             headers['X-CSRFToken'] = csrfToken;
         }
 
-        fetch('/api/upload', {
+        fetch((window.APP_ROOT || '') + '/api/upload', {
             method: 'POST',
             body: formData,
             headers: headers,

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="app-root" content="{{ url_prefix }}">
     <title>Change Password - Web SSH Terminal</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="app-root" content="{{ url_prefix }}">
     <title>Web SSH Terminal</title>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="app-root" content="{{ url_prefix }}">
     <title>Login - Web SSH Terminal</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">

--- a/templates/register.html
+++ b/templates/register.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="app-root" content="{{ url_prefix }}">
     <title>Register - Web SSH Terminal</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">


### PR DESCRIPTION
Adds support for running the app under a URL subpath (e.g. `https://server.local/webssh`) behind a reverse proxy. Addresses the request in discussion #8.

## Design principle

**Strictly additive.** When `APPLICATION_ROOT` is unset or empty, every code path stays byte-for-byte identical to before. No Blueprint refactor, no URL pattern changes, no breaking changes for existing deployments. Verified via side-by-side byte-diff against `main` — only intended diffs are present.

## What's in

- New optional env var `APPLICATION_ROOT` (e.g. `/webssh`). Leave unset for current behavior.
- When set:
  - Flask's `APPLICATION_ROOT` config is applied
  - Session and remember-me cookies scope to the prefix
  - Templates expose `url_prefix` via context processor; a `<meta name="app-root">` tag carries it into the DOM
  - JS (`app.js`, `sftp-file-manager.js`) reads `APP_ROOT` from the meta tag and prefixes the SocketIO path, the two hardcoded redirects (`/change-password`, `/logout`), and the `/api/upload` fetch. Empty prefix → no-ops.
- `ProxyFix` with `x_prefix` (already present when `TRUSTED_PROXIES` is set) picks up `X-Forwarded-Prefix` from the reverse proxy, so `url_for()` and `request.script_root` work correctly.
- `docker-compose.yml` has a commented `APPLICATION_ROOT` example.
- README gets a new **Deployment** features category and a **Subfolder Deployment** section under Configuration with nginx, Traefik, and Caddy snippets.

## Deployment notes

Users who upgrade without setting `APPLICATION_ROOT` need to do nothing — identical behavior. Users who want subfolder deployment set:

```bash
APPLICATION_ROOT=/webssh
TRUSTED_PROXIES=1
```

…plus the proxy config from the README (proxy strips the prefix and forwards it via `X-Forwarded-Prefix`).

## Verified

- Baseline parity: `diff` of response bodies + headers between `main` and this branch (with `APPLICATION_ROOT` unset) shows only the intended lines added. Session cookie `Path=/` matches `main` exactly.
- Subfolder mode: full register → index → change-password → logout flow with `APPLICATION_ROOT=/webssh` and simulated `X-Forwarded-Prefix`: all redirects include the prefix, cookies scope to `/webssh`, form actions and static assets prefixed.
- JS + Python syntax checks clean; runtime imports OK in both modes.

Closes #8