### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -319,7 +319,8 @@ def create_app():
             )
 
             if error:
-                return jsonify({'error': f'Upload failed: {error}'}), 500
+                log_error("Upload failed in SFTP handler", error=str(error), user=current_user.username, path=remote_path)
+                return jsonify({'error': 'Upload failed'}), 500
 
             log_info(f"File uploaded via HTTP: {file.filename}", user=current_user.username, path=remote_path)
             return jsonify({'success': True, 'filename': file.filename}), 200


### PR DESCRIPTION
Potential fix for [https://github.com/bifrost0x/webssh/security/code-scanning/1](https://github.com/bifrost0x/webssh/security/code-scanning/1)

To fix this safely, do not return low-level exception text to API clients. Return a generic error message to the client, and log the detailed message server-side for troubleshooting.

Best single fix (minimal functional change): in `app/__init__.py` inside `api_upload`, replace the line that returns `Upload failed: {error}` with a generic `Upload failed` response, and add a server log call including `error` details. This preserves behavior (still returns HTTP 500 on failure) while removing sensitive exposure.

Changes needed:
- **File**: `app/__init__.py`
- **Region**: `api_upload()` around lines 321–323
- **Edits**:
  - Add `log_error(...)` when `error` is present.
  - Replace client response with generic message.
- No new imports/dependencies needed (uses existing `log_error` import).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
