### PR TITLE
feat: persistent tmux sessions, configurable scrollback, output buffe…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,7 +43,12 @@ def create_app():
 
     @app.context_processor
     def inject_url_prefix():
-        return {'url_prefix': url_prefix, 'registration_enabled': is_registration_enabled()}
+        return {
+            'url_prefix': url_prefix,
+            'registration_enabled': is_registration_enabled(),
+            'tmux_enabled': config.TMUX_ENABLED,
+            'tmux_default': config.TMUX_DEFAULT
+        }
 
     trusted_proxies = int(os.environ.get('TRUSTED_PROXIES', '0'))
     if trusted_proxies > 0:
@@ -76,8 +81,9 @@ def create_app():
 
     with app.app_context():
         db.create_all()
-        from .models import ensure_user_columns
+        from .models import ensure_user_columns, ensure_ssh_session_columns
         ensure_user_columns()
+        ensure_ssh_session_columns()
         from .auth import sync_admin_users
         sync_admin_users()
     cors_origins = config.CORS_ORIGINS

--- a/app/models.py
+++ b/app/models.py
@@ -107,6 +107,33 @@ class SSHSession(db.Model):
     connected = db.Column(db.Boolean, default=True, index=True)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     last_activity = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    # Persistent tmux session support
+    is_persistent = db.Column(db.Boolean, default=False, index=True)
+    key_id = db.Column(db.String(64), nullable=True)
+    tmux_session_name = db.Column(db.String(256), nullable=True)
+    display_name = db.Column(db.String(128), nullable=True)
 
     def __repr__(self):
         return f'<SSHSession id={self.session_id[:8]}... {self.username}@{self.host}:{self.port}>'
+
+
+def ensure_ssh_session_columns():
+    """Additive schema migration for persistent tmux columns on ssh_sessions."""
+    from sqlalchemy import text, inspect
+    inspector = inspect(db.engine)
+    if 'ssh_sessions' not in inspector.get_table_names():
+        return
+    existing = {c['name'] for c in inspector.get_columns('ssh_sessions')}
+    additions = []
+    if 'is_persistent' not in existing:
+        additions.append("ALTER TABLE ssh_sessions ADD COLUMN is_persistent BOOLEAN NOT NULL DEFAULT 0")
+    if 'key_id' not in existing:
+        additions.append("ALTER TABLE ssh_sessions ADD COLUMN key_id VARCHAR(64)")
+    if 'tmux_session_name' not in existing:
+        additions.append("ALTER TABLE ssh_sessions ADD COLUMN tmux_session_name VARCHAR(256)")
+    if 'display_name' not in existing:
+        additions.append("ALTER TABLE ssh_sessions ADD COLUMN display_name VARCHAR(128)")
+    for stmt in additions:
+        db.session.execute(text(stmt))
+    if additions:
+        db.session.commit()

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -307,7 +307,23 @@ def handle_ssh_connect(data, current_user=None):
                     return
 
         use_tmux = bool(data.get('use_tmux')) and config.TMUX_ENABLED
-        reconnect_tmux_name = data.get('reconnect_tmux_name') if use_tmux else None
+        reconnect_tmux_name = None
+        if use_tmux:
+            raw_name = data.get('reconnect_tmux_name')
+            if raw_name:
+                import re as _re
+                # Whitelist: alphanumeric, underscores, max 190 chars
+                if not _re.match(r'^[A-Za-z0-9_]{1,190}$', raw_name):
+                    emit_error('Invalid tmux session name')
+                    return
+                # Verify the name maps to an SSHSession owned by this user
+                existing = SSHSession.query.filter_by(
+                    user_id=current_user.id,
+                    tmux_session_name=raw_name,
+                    is_persistent=True
+                ).first()
+                if existing:
+                    reconnect_tmux_name = raw_name
 
         session_id, error = ssh_manager.create_ssh_connection(
             host=host,
@@ -336,6 +352,8 @@ def handle_ssh_connect(data, current_user=None):
             emit_error(error)
         else:
             display_name = data.get('display_name') if use_tmux else None
+            if display_name:
+                display_name = display_name.strip()[:128] or None
             try:
                 # Clean up the specific old disconnected persistent session when
                 # reconnecting to avoid ghost tabs on refresh.
@@ -1005,6 +1023,8 @@ def handle_save_session_name(data, current_user=None):
     try:
         session_id = data.get('session_id')
         display_name = data.get('display_name')
+        if display_name:
+            display_name = display_name.strip()[:128] or None
         if not session_id:
             return
         ssh_session = SSHSession.query.filter_by(

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -377,6 +377,8 @@ def handle_ssh_connect(data, current_user=None):
                 'client_request_id': client_request_id,
                 'via_jump': bastion_host,
                 'use_tmux': use_tmux,
+                'key_id': key_id if use_tmux else None,
+                'tmux_session_name': ssh_manager.get_session(session_id).get('tmux_session_name') if use_tmux else None,
                 'display_name': display_name
             })
             log_ssh_connection(current_user.username, host, port, True, request.remote_addr)

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -192,6 +192,10 @@ def handle_disconnect():
 
 def restore_user_sessions(user_id):
     """Restore active SSH sessions when user reconnects."""
+    # Clean up old disconnected non-persistent sessions
+    SSHSession.query.filter_by(user_id=user_id, connected=False, is_persistent=False).delete()
+    db.session.commit()
+
     db_sessions = SSHSession.query.filter_by(user_id=user_id, connected=True).all()
 
     room = f'user_{user_id}'
@@ -202,18 +206,41 @@ def restore_user_sessions(user_id):
         session = ssh_manager.get_session(session_id)
 
         if session and session.get('connected'):
+            buffered_output = ssh_manager.get_output_buffer(session_id)
             emit('ssh_session_restored', {
                 'session_id': session_id,
                 'host': db_session.host,
                 'port': db_session.port,
                 'username': db_session.username,
-                'via_jump': session.get('via_jump')
+                'via_jump': session.get('via_jump'),
+                'use_tmux': session.get('use_tmux', False),
+                'tmux_session_name': session.get('tmux_session_name'),
+                'display_name': db_session.display_name,
+                'buffered_output': buffered_output
             }, room=room)
             log_info(f"Restored SSH session {session_id}", user_id=user_id, room=room)
         else:
             db_session.connected = False
             db.session.commit()
             log_debug(f"SSH session {session_id} no longer active, marked disconnected")
+
+    # Restore disconnected persistent tmux sessions as reconnect candidates
+    if config.TMUX_ENABLED:
+        persistent_sessions = SSHSession.query.filter_by(
+            user_id=user_id, is_persistent=True, connected=False
+        ).all()
+        for db_session in persistent_sessions:
+            emit('persistent_session_available', {
+                'session_id': db_session.session_id,
+                'host': db_session.host,
+                'port': db_session.port,
+                'username': db_session.username,
+                'key_id': db_session.key_id,
+                'tmux_session_name': db_session.tmux_session_name,
+                'display_name': db_session.display_name
+            }, room=room)
+            log_info(f"Persistent tmux session available for reconnect",
+                     host=db_session.host, tmux_session=db_session.tmux_session_name)
 
 @socketio.on('ssh_connect')
 @socket_login_required
@@ -279,6 +306,9 @@ def handle_ssh_connect(data, current_user=None):
                     emit_error(f'Jump host SSH key error: {bastion_key_error}')
                     return
 
+        use_tmux = bool(data.get('use_tmux')) and config.TMUX_ENABLED
+        reconnect_tmux_name = data.get('reconnect_tmux_name') if use_tmux else None
+
         session_id, error = ssh_manager.create_ssh_connection(
             host=host,
             port=int(port),
@@ -292,7 +322,9 @@ def handle_ssh_connect(data, current_user=None):
             proxy_jump_port=bastion_port,
             proxy_jump_username=bastion_username,
             proxy_jump_password=bastion_password,
-            proxy_jump_key_content=bastion_key_content
+            proxy_jump_key_content=bastion_key_content,
+            use_tmux=use_tmux,
+            reconnect_tmux_name=reconnect_tmux_name
         )
 
         if password:
@@ -303,13 +335,32 @@ def handle_ssh_connect(data, current_user=None):
         if error:
             emit_error(error)
         else:
+            display_name = data.get('display_name') if use_tmux else None
             try:
+                # Clean up the specific old disconnected persistent session when
+                # reconnecting to avoid ghost tabs on refresh.
+                if use_tmux and reconnect_tmux_name:
+                    old_session = SSHSession.query.filter_by(
+                        user_id=current_user.id, host=host, port=port,
+                        is_persistent=True, connected=False,
+                        tmux_session_name=reconnect_tmux_name
+                    ).first()
+                    if old_session:
+                        db.session.delete(old_session)
+                        log_info(f"Cleaned up old persistent session",
+                                user=current_user.username, host=host,
+                                tmux_session=reconnect_tmux_name)
+
                 ssh_session = SSHSession(
                     session_id=session_id,
                     user_id=current_user.id,
                     host=host,
                     port=port,
-                    username=username
+                    username=username,
+                    is_persistent=use_tmux,
+                    key_id=key_id if use_tmux else None,
+                    tmux_session_name=ssh_manager.get_session(session_id).get('tmux_session_name') if use_tmux else None,
+                    display_name=display_name if use_tmux else None
                 )
                 db.session.add(ssh_session)
                 db.session.commit()
@@ -324,7 +375,9 @@ def handle_ssh_connect(data, current_user=None):
                 'port': port,
                 'username': username,
                 'client_request_id': client_request_id,
-                'via_jump': bastion_host
+                'via_jump': bastion_host,
+                'use_tmux': use_tmux,
+                'display_name': display_name
             })
             log_ssh_connection(current_user.username, host, port, True, request.remote_addr)
 
@@ -420,7 +473,10 @@ def handle_ssh_disconnect(data, current_user=None):
         port = ssh_session.port if ssh_session else 0
         if ssh_session:
             try:
-                ssh_session.connected = False
+                if ssh_session.is_persistent:
+                    db.session.delete(ssh_session)
+                else:
+                    ssh_session.connected = False
                 db.session.commit()
             except Exception as db_err:
                 db.session.rollback()
@@ -774,7 +830,9 @@ def handle_get_sessions(current_user=None):
                     'session_id': db_session.session_id,
                     'host': db_session.host,
                     'port': db_session.port,
-                    'username': db_session.username
+                    'username': db_session.username,
+                    'use_tmux': session.get('use_tmux', False),
+                    'tmux_session_name': session.get('tmux_session_name')
                 })
 
         emit('sessions_list', {'sessions': sessions})
@@ -937,6 +995,25 @@ def handle_delete_command(data, current_user=None):
 def handle_detect_os(data, current_user=None):
     """OS detection disabled to avoid terminal noise."""
     emit('error', {'error': 'OS detection is disabled'})
+
+@socketio.on('save_session_name')
+@socket_login_required
+def handle_save_session_name(data, current_user=None):
+    """Save session display name to database."""
+    try:
+        session_id = data.get('session_id')
+        display_name = data.get('display_name')
+        if not session_id:
+            return
+        ssh_session = SSHSession.query.filter_by(
+            session_id=session_id, user_id=current_user.id
+        ).first()
+        if ssh_session:
+            ssh_session.display_name = display_name if display_name else None
+            db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        log_error("Failed to save session name", error=str(e))
 
 def verify_session_ownership(session_id, user_id):
     """

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -503,7 +503,7 @@ def handle_ssh_disconnect(data, current_user=None):
                 log_error(f"Failed to update SSH session in database",
                           error=str(db_err), session_id=session_id)
 
-        success = ssh_manager.close_session(session_id)
+        success = ssh_manager.close_session(session_id, kill_tmux=True)
         if success:
             room = f'user_{current_user.id}'
             socketio.emit('ssh_disconnected', {

--- a/app/ssh_manager.py
+++ b/app/ssh_manager.py
@@ -39,7 +39,8 @@ class PersistentHostKeyPolicy(paramiko.MissingHostKeyPolicy):
 def create_ssh_connection(host, port, username, password=None, key_path=None, key_content=None,
                           socketio_instance=None, app=None, user_id=None,
                           proxy_jump_host=None, proxy_jump_port=None, proxy_jump_username=None,
-                          proxy_jump_password=None, proxy_jump_key_content=None):
+                          proxy_jump_password=None, proxy_jump_key_content=None,
+                          use_tmux=False, reconnect_tmux_name=None):
     """
     Create a new SSH connection and return session ID.
 
@@ -130,12 +131,33 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
         if transport:
             transport.set_keepalive(30)
 
-        channel = client.invoke_shell(
-            term='xterm-256color',
-            width=80,
-            height=24
-        )
-        channel.settimeout(0.1)
+        tmux_session_name = None
+        if use_tmux:
+            # Each new connection gets a unique tmux session name.
+            # For reconnections, use reconnect_tmux_name to attach to existing.
+            if reconnect_tmux_name:
+                tmux_session_name = reconnect_tmux_name
+                tmux_cmd = f'tmux new-session -A -s {tmux_session_name}'
+            else:
+                unique_suffix = uuid.uuid4().hex[:8]
+                tmux_session_name = f"{config.TMUX_SESSION_PREFIX}_{username}_{host}_{port}_{unique_suffix}".replace('.', '_').replace('-', '_')
+                tmux_cmd = f'tmux new-session -s {tmux_session_name}'
+
+            log_info(f"Using tmux persistent session", tmux_session=tmux_session_name, host=f"{host}:{port}")
+
+            # Use exec_command with PTY to run tmux directly.
+            # This replaces the shell with tmux, attaching to existing or creating new.
+            channel = transport.open_session()
+            channel.get_pty('xterm-256color', 80, 24)
+            channel.exec_command(tmux_cmd)
+            channel.settimeout(0.1)
+        else:
+            channel = client.invoke_shell(
+                term='xterm-256color',
+                width=80,
+                height=24
+            )
+            channel.settimeout(0.1)
 
         session_id = str(uuid.uuid4())
 
@@ -152,7 +174,12 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
                 'connected': True,
                 'last_activity': time.time(),
                 'bastion_client': bastion_client,
-                'proxy_jump_host': proxy_jump_host
+                'proxy_jump_host': proxy_jump_host,
+                'use_tmux': use_tmux,
+                'tmux_session_name': tmux_session_name,
+                'output_buffer': [],
+                'output_buffer_size': 0,
+                'output_buffer_max': 512000  # 512KB max buffer
             }
             connection_stored = True
 
@@ -225,6 +252,11 @@ def read_ssh_output(session_id, socketio_instance, app):
                 log_error(f"No DB session found for output reader", session_id=session_id)
                 return
 
+            # Buffer for partial DA responses that span across recv() boundaries.
+            # DA patterns like "0;276;0c" may be split across chunks, so we hold
+            # back trailing digits/semicolons and prepend them to the next chunk.
+            da_partial = ''
+
             while True:
                 with sessions_lock:
                     if session_id not in sessions:
@@ -237,7 +269,26 @@ def read_ssh_output(session_id, socketio_instance, app):
                 try:
                     data = channel.recv(32768)
                     if data:
+                        import re as _re
                         decoded_data = data.decode('utf-8', errors='replace')
+                        # Prepend any partial DA response from previous chunk
+                        decoded_data = da_partial + decoded_data
+                        da_partial = ''
+                        # Filter Device Attributes responses from output
+                        decoded_data = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', decoded_data)
+                        decoded_data = _re.sub(r'[0-9]+;[0-9;]*c', '', decoded_data)
+                        # Hold back trailing digits/semicolons that look like
+                        # the start of a bare DA response (e.g. "0;276;" before
+                        # the "0c" arrives in the next chunk).
+                        _tail = _re.search(r'([0-9]+;[0-9;]*)$', decoded_data)
+                        if _tail:
+                            da_partial = _tail.group(1)
+                            decoded_data = decoded_data[:-len(da_partial)]
+                        if not decoded_data:
+                            # Nothing to emit yet; wait for more data
+                            if channel.closed or channel.exit_status_ready():
+                                break
+                            continue
                         socketio_instance.emit('ssh_output', {
                             'session_id': session_id,
                             'data': decoded_data
@@ -247,6 +298,14 @@ def read_ssh_output(session_id, socketio_instance, app):
                         with sessions_lock:
                             if session_id in sessions:
                                 sessions[session_id]['last_activity'] = now
+                                buf = sessions[session_id].get('output_buffer')
+                                if buf is not None:
+                                    buf.append(decoded_data)
+                                    sessions[session_id]['output_buffer_size'] += len(decoded_data)
+                                    # Trim buffer if over max
+                                    while sessions[session_id]['output_buffer_size'] > sessions[session_id].get('output_buffer_max', 512000) and len(buf) > 1:
+                                        removed = buf.pop(0)
+                                        sessions[session_id]['output_buffer_size'] -= len(removed)
 
                         if now - last_db_update >= 10.0:
                             last_db_update = now
@@ -290,6 +349,23 @@ def read_ssh_output(session_id, socketio_instance, app):
 def send_ssh_input(session_id, data):
     """Send user input to SSH channel."""
     try:
+        import re as _re
+        # Filter Device Attributes responses that xterm.js may echo back as input.
+        # These arrive as ESC[?...c, ESC[>...c, ESC[...c, or bare patterns like
+        # "0;276;0c", "1c" and cause "command not found" errors.
+        if isinstance(data, str):
+            # Debug: log non-printable input to identify DA response patterns
+            if any(ord(c) < 32 and c not in '\r\n\t' for c in data):
+                log_debug(f"SSH input with control chars", session_id=session_id,
+                         hex=data.encode('utf-8').hex(), repr=repr(data))
+            data = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', data)
+            # Strip bare DA patterns: digits/semicolons ending with c
+            data = _re.sub(r'[0-9]+;[0-9;]*c', '', data)
+            # Strip bare DA fragments like "1c" that have no semicolons
+            data = _re.sub(r'(?<![a-zA-Z/])[0-9]+c(?![a-zA-Z/])', '', data)
+        if not data:
+            return True, None
+
         with sessions_lock:
             if session_id not in sessions:
                 return False, "Session not found"
@@ -374,9 +450,25 @@ def get_session(session_id):
                 'port': session['port'],
                 'username': session['username'],
                 'connected': session['connected'],
-                'via_jump': session.get('proxy_jump_host')
+                'via_jump': session.get('proxy_jump_host'),
+                'use_tmux': session.get('use_tmux', False),
+                'tmux_session_name': session.get('tmux_session_name')
             }
     return None
+
+def get_output_buffer(session_id):
+    """Get buffered output for a session (for replay on reconnect)."""
+    import re as _re
+    with sessions_lock:
+        if session_id in sessions:
+            buf = sessions[session_id].get('output_buffer')
+            if buf:
+                output = ''.join(buf)
+                # Filter Device Attributes responses
+                output = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', output)
+                output = _re.sub(r'[0-9]+;[0-9;]*c', '', output)
+                return output
+    return ''
 
 def cleanup_idle_sessions():
     """Clean up sessions that have been idle too long."""

--- a/app/ssh_manager.py
+++ b/app/ssh_manager.py
@@ -135,12 +135,15 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
         if use_tmux:
             # Each new connection gets a unique tmux session name.
             # For reconnections, use reconnect_tmux_name to attach to existing.
+            # Sanitize host for tmux session name: replace dots, colons (IPv6),
+            # and hyphens with underscores.
+            safe_host = host.replace('.', '_').replace(':', '_').replace('-', '_')
             if reconnect_tmux_name:
                 tmux_session_name = reconnect_tmux_name
                 tmux_cmd = f'tmux new-session -A -s {tmux_session_name}'
             else:
                 unique_suffix = uuid.uuid4().hex[:8]
-                tmux_session_name = f"{config.TMUX_SESSION_PREFIX}_{username}_{host}_{port}_{unique_suffix}".replace('.', '_').replace('-', '_')
+                tmux_session_name = f"{config.TMUX_SESSION_PREFIX}_{username}_{safe_host}_{port}_{unique_suffix}"
                 tmux_cmd = f'tmux new-session -s {tmux_session_name}'
 
             log_info(f"Using tmux persistent session", tmux_session=tmux_session_name, host=f"{host}:{port}")
@@ -151,6 +154,28 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
             channel.get_pty('xterm-256color', 80, 24)
             channel.exec_command(tmux_cmd)
             channel.settimeout(0.1)
+
+            # Check if tmux command succeeded. If the remote host doesn't have
+            # tmux installed, exec_command fails silently. Read the channel briefly
+            # to detect early exit (command not found).
+            import select
+            _r, _, _ = select.select([channel], [], [], 0.5)
+            if _r:
+                _early = channel.recv(4096).decode('utf-8', errors='replace')
+                if 'command not found' in _early or 'No such file' in _early:
+                    log_warning(f"tmux not found on target host, falling back to regular shell",
+                               host=f"{host}:{port}", tmux_session=tmux_session_name)
+                    channel.close()
+                    tmux_session_name = None
+                    channel = client.invoke_shell(
+                        term='xterm-256color',
+                        width=80,
+                        height=24
+                    )
+                    channel.settimeout(0.1)
+                    # Send the early output to the new channel so the user sees the error
+                    if _early:
+                        use_tmux = False
         else:
             channel = client.invoke_shell(
                 term='xterm-256color',
@@ -252,11 +277,6 @@ def read_ssh_output(session_id, socketio_instance, app):
                 log_error(f"No DB session found for output reader", session_id=session_id)
                 return
 
-            # Buffer for partial DA responses that span across recv() boundaries.
-            # DA patterns like "0;276;0c" may be split across chunks, so we hold
-            # back trailing digits/semicolons and prepend them to the next chunk.
-            da_partial = ''
-
             while True:
                 with sessions_lock:
                     if session_id not in sessions:
@@ -271,23 +291,12 @@ def read_ssh_output(session_id, socketio_instance, app):
                     if data:
                         import re as _re
                         decoded_data = data.decode('utf-8', errors='replace')
-                        # Prepend any partial DA response from previous chunk
-                        decoded_data = da_partial + decoded_data
-                        da_partial = ''
-                        # Filter Device Attributes responses from output
+                        # Filter Device Attributes responses (ESC[c sequences only).
+                        # Bare-pattern regexes were removed because they corrupt
+                        # legitimate output like "padding:0;color:red".
                         decoded_data = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', decoded_data)
-                        decoded_data = _re.sub(r'[0-9]+;[0-9;]*c', '', decoded_data)
-                        # Hold back trailing digits/semicolons that look like
-                        # the start of a bare DA response (e.g. "0;276;" before
-                        # the "0c" arrives in the next chunk).
-                        _tail = _re.search(r'([0-9]+;[0-9;]*)$', decoded_data)
-                        if _tail:
-                            da_partial = _tail.group(1)
-                            decoded_data = decoded_data[:-len(da_partial)]
                         if not decoded_data:
-                            # Nothing to emit yet; wait for more data
-                            if channel.closed or channel.exit_status_ready():
-                                break
+                            # Nothing to emit; skip
                             continue
                         socketio_instance.emit('ssh_output', {
                             'session_id': session_id,
@@ -350,19 +359,11 @@ def send_ssh_input(session_id, data):
     """Send user input to SSH channel."""
     try:
         import re as _re
-        # Filter Device Attributes responses that xterm.js may echo back as input.
-        # These arrive as ESC[?...c, ESC[>...c, ESC[...c, or bare patterns like
-        # "0;276;0c", "1c" and cause "command not found" errors.
+        # Filter Device Attributes responses (ESC[c sequences only) that
+        # xterm.js may echo back as input. Bare-pattern regexes were removed
+        # because they corrupt legitimate input like "100c" or "cat file".
         if isinstance(data, str):
-            # Debug: log non-printable input to identify DA response patterns
-            if any(ord(c) < 32 and c not in '\r\n\t' for c in data):
-                log_debug(f"SSH input with control chars", session_id=session_id,
-                         hex=data.encode('utf-8').hex(), repr=repr(data))
             data = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', data)
-            # Strip bare DA patterns: digits/semicolons ending with c
-            data = _re.sub(r'[0-9]+;[0-9;]*c', '', data)
-            # Strip bare DA fragments like "1c" that have no semicolons
-            data = _re.sub(r'(?<![a-zA-Z/])[0-9]+c(?![a-zA-Z/])', '', data)
         if not data:
             return True, None
 
@@ -414,6 +415,23 @@ def close_session(session_id):
             session = sessions[session_id]
             session['connected'] = False
 
+            # Kill tmux session on remote host if this was a persistent session.
+            # This prevents orphaned tmux sessions from accumulating.
+            if session.get('use_tmux') and session.get('tmux_session_name') and session['client']:
+                try:
+                    transport = session['client'].get_transport()
+                    if transport and transport.is_active():
+                        kill_channel = transport.open_session()
+                        kill_channel.exec_command(f'tmux kill-session -t {session["tmux_session_name"]}')
+                        kill_channel.settimeout(2.0)
+                        try:
+                            kill_channel.recv(1)
+                        except Exception:
+                            pass
+                        kill_channel.close()
+                except Exception as e:
+                    log_debug(f"Error killing tmux session", session_id=session_id, error=str(e))
+
             if session['channel']:
                 try:
                     session['channel'].close()
@@ -464,9 +482,8 @@ def get_output_buffer(session_id):
             buf = sessions[session_id].get('output_buffer')
             if buf:
                 output = ''.join(buf)
-                # Filter Device Attributes responses
+                # Filter Device Attributes responses (ESC[c sequences only)
                 output = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', output)
-                output = _re.sub(r'[0-9]+;[0-9;]*c', '', output)
                 return output
     return ''
 

--- a/app/ssh_manager.py
+++ b/app/ssh_manager.py
@@ -135,47 +135,51 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
         if use_tmux:
             # Each new connection gets a unique tmux session name.
             # For reconnections, use reconnect_tmux_name to attach to existing.
-            # Sanitize host for tmux session name: replace dots, colons (IPv6),
-            # and hyphens with underscores.
+            # Sanitize host and username for tmux session name: replace dots,
+            # colons (IPv6), and hyphens with underscores (tmux rejects them).
             safe_host = host.replace('.', '_').replace(':', '_').replace('-', '_')
+            safe_user = username.replace('.', '_').replace('-', '_')
             if reconnect_tmux_name:
                 tmux_session_name = reconnect_tmux_name
                 tmux_cmd = f'tmux new-session -A -s {tmux_session_name}'
             else:
                 unique_suffix = uuid.uuid4().hex[:8]
-                tmux_session_name = f"{config.TMUX_SESSION_PREFIX}_{username}_{safe_host}_{port}_{unique_suffix}"
+                tmux_session_name = f"{config.TMUX_SESSION_PREFIX}_{safe_user}_{safe_host}_{port}_{unique_suffix}"
                 tmux_cmd = f'tmux new-session -s {tmux_session_name}'
 
             log_info(f"Using tmux persistent session", tmux_session=tmux_session_name, host=f"{host}:{port}")
 
-            # Use exec_command with PTY to run tmux directly.
-            # This replaces the shell with tmux, attaching to existing or creating new.
-            channel = transport.open_session()
-            channel.get_pty('xterm-256color', 80, 24)
-            channel.exec_command(tmux_cmd)
-            channel.settimeout(0.1)
+            # Probe for tmux on a separate exec channel before opening the
+            # real session. This avoids locale-dependent error string matching
+            # and avoids swallowing tmux's initial screen draw.
+            probe_channel = transport.open_session()
+            probe_channel.exec_command('command -v tmux')
+            probe_channel.settimeout(3.0)
+            try:
+                probe_channel.recv(1)
+            except Exception:
+                pass
+            tmux_available = probe_channel.recv_exit_status() == 0
+            probe_channel.close()
 
-            # Check if tmux command succeeded. If the remote host doesn't have
-            # tmux installed, exec_command fails silently. Read the channel briefly
-            # to detect early exit (command not found).
-            import select
-            _r, _, _ = select.select([channel], [], [], 0.5)
-            if _r:
-                _early = channel.recv(4096).decode('utf-8', errors='replace')
-                if 'command not found' in _early or 'No such file' in _early:
-                    log_warning(f"tmux not found on target host, falling back to regular shell",
-                               host=f"{host}:{port}", tmux_session=tmux_session_name)
-                    channel.close()
-                    tmux_session_name = None
-                    channel = client.invoke_shell(
-                        term='xterm-256color',
-                        width=80,
-                        height=24
-                    )
-                    channel.settimeout(0.1)
-                    # Send the early output to the new channel so the user sees the error
-                    if _early:
-                        use_tmux = False
+            if not tmux_available:
+                log_warning(f"tmux not found on target host, falling back to regular shell",
+                           host=f"{host}:{port}")
+                tmux_session_name = None
+                use_tmux = False
+                channel = client.invoke_shell(
+                    term='xterm-256color',
+                    width=80,
+                    height=24
+                )
+                channel.settimeout(0.1)
+            else:
+                # Use exec_command with PTY to run tmux directly.
+                # This replaces the shell with tmux, attaching to existing or creating new.
+                channel = transport.open_session()
+                channel.get_pty('xterm-256color', 80, 24)
+                channel.exec_command(tmux_cmd)
+                channel.settimeout(0.1)
         else:
             channel = client.invoke_shell(
                 term='xterm-256color',
@@ -402,8 +406,14 @@ def resize_terminal(session_id, rows, cols):
     except Exception as e:
         return False, str(e)
 
-def close_session(session_id):
-    """Close SSH session and clean up resources."""
+def close_session(session_id, kill_tmux=False):
+    """Close SSH session and clean up resources.
+
+    kill_tmux: If True and the session uses tmux, kill the remote tmux session.
+               Default False — idle timeout and server restart detach only,
+               leaving tmux running so the session shows up as a reconnect
+               candidate. Pass True only from explicit user disconnect.
+    """
     try:
         from .sftp_handler import close_sftp_cache
         close_sftp_cache(session_id)
@@ -415,9 +425,10 @@ def close_session(session_id):
             session = sessions[session_id]
             session['connected'] = False
 
-            # Kill tmux session on remote host if this was a persistent session.
-            # This prevents orphaned tmux sessions from accumulating.
-            if session.get('use_tmux') and session.get('tmux_session_name') and session['client']:
+            # Kill tmux session on remote host only on explicit disconnect.
+            # Idle timeout and server restart leave tmux running so the
+            # session survives and appears as a reconnect candidate.
+            if kill_tmux and session.get('use_tmux') and session.get('tmux_session_name') and session['client']:
                 try:
                     transport = session['client'].get_transport()
                     if transport and transport.is_active():

--- a/app/user_lifecycle.py
+++ b/app/user_lifecycle.py
@@ -56,7 +56,7 @@ def revoke_user_access(user_id, socketio_instance=None):
 
     for session_id in ssh_session_ids:
         try:
-            if ssh_manager.close_session(session_id):
+            if ssh_manager.close_session(session_id, kill_tmux=True):
                 result['ssh_sessions'] += 1
             else:
                 result['errors'].append(f'ssh:{session_id}:close failed')

--- a/config.py
+++ b/config.py
@@ -118,3 +118,11 @@ BLOCK_INTERNAL_SSH = os.environ.get('BLOCK_INTERNAL_SSH', 'false').lower() == 't
 
 MAX_DOWNLOAD_SIZE = int(os.environ.get('MAX_DOWNLOAD_SIZE', str(MAX_UPLOAD_SIZE)))
 MAX_ZIP_DOWNLOAD_SIZE = int(os.environ.get('MAX_ZIP_DOWNLOAD_SIZE', str(500 * 1024 * 1024)))
+
+# Persistent sessions via tmux on the remote host.
+# When enabled, SSH sessions are wrapped in a tmux session on the remote host.
+# This means commands keep running even if the webssh server restarts.
+# Reconnecting to the same host/user will reattach to the existing tmux session.
+TMUX_ENABLED = os.environ.get('TMUX_ENABLED', 'false').lower() == 'true'
+TMUX_SESSION_PREFIX = os.environ.get('TMUX_SESSION_PREFIX', 'webssh')
+TMUX_DEFAULT = os.environ.get('TMUX_DEFAULT', 'false').lower() == 'true'

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -954,6 +954,29 @@ body[data-theme="obsidian"] {
     opacity: 1;
 }
 
+.tab-reconnect {
+    font-size: 16px;
+    line-height: 1;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    transition: all 0.2s ease;
+    user-select: none;
+    opacity: 0.4;
+    flex-shrink: 0;
+}
+
+.session-tab:hover .tab-reconnect {
+    opacity: 1;
+}
+
+.tab-reconnect:hover {
+    color: var(--accent-primary);
+    background: var(--accent-primary-glow);
+    opacity: 1;
+}
+
 .session-tabs-row {
     display: flex;
     align-items: flex-end;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -849,6 +849,46 @@ body[data-theme="obsidian"] {
     cursor: help;
 }
 
+.tab-tmux-badge {
+    font-size: 11px;
+    margin-left: 2px;
+    opacity: 0.85;
+    cursor: help;
+}
+
+.terminal-scrollbar {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 12px;
+    height: 100%;
+    background: rgba(0,0,0,0.15);
+    border-radius: 6px;
+    z-index: 10;
+    cursor: pointer;
+}
+
+.terminal-scrollbar-thumb {
+    position: absolute;
+    top: 0;
+    left: 1px;
+    width: 10px;
+    min-height: 30px;
+    background: rgba(255,255,255,0.35);
+    border-radius: 5px;
+    cursor: grab;
+    transition: background 0.15s;
+}
+
+.terminal-scrollbar-thumb:hover {
+    background: rgba(255,255,255,0.55);
+}
+
+.terminal-scrollbar-thumb:active {
+    cursor: grabbing;
+    background: rgba(255,255,255,0.7);
+}
+
 .tab-label:hover {
     cursor: text;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1900,6 +1900,21 @@
                 connectionData.proxy_jump = proxyJump;
             }
 
+            const useTmuxCheck = document.getElementById('useTmuxCheck');
+            if (useTmuxCheck && useTmuxCheck.checked) {
+                connectionData.use_tmux = true;
+                // Include tmux session name for reconnection to persistent sessions
+                if (SessionManager.pendingReconnectTmux) {
+                    connectionData.reconnect_tmux_name = SessionManager.pendingReconnectTmux;
+                    SessionManager.pendingReconnectTmux = null;
+                }
+                // Include display name for reconnecting persistent sessions
+                if (SessionManager.pendingDisplayName) {
+                    connectionData.display_name = SessionManager.pendingDisplayName;
+                    SessionManager.pendingDisplayName = null;
+                }
+            }
+
             const connectBtn = document.getElementById('connectBtn');
             const originalText = connectBtn.textContent;
             connectSeconds = 0;
@@ -1908,6 +1923,16 @@
                 connectSeconds++;
                 connectBtn.textContent = `Connecting... ${connectSeconds}s`;
             }, 1000);
+
+            // Clean up any persistent candidate tab for the same host/port/user
+            // Use removeSessionUI to avoid emitting ssh_disconnect which would
+            // delete the DB record and lose the session display name.
+            Object.keys(SessionManager.sessions).forEach(sid => {
+                const s = SessionManager.sessions[sid];
+                if (s && s.isPersistentCandidate && s.host === host && s.port === parseInt(port) && s.username === username) {
+                    SessionManager.removeSessionUI(sid);
+                }
+            });
 
             socket.emit('ssh_connect', connectionData);
             setConnectLoading(true);
@@ -2029,6 +2054,24 @@
         if (changePasswordBtn) {
             changePasswordBtn.addEventListener('click', () => {
                 window.location.href = APP_ROOT + '/change-password';
+            });
+        }
+
+        // Scrollback lines setting
+        const scrollbackInput = document.getElementById('scrollbackInput');
+        if (scrollbackInput) {
+            const savedScrollback = localStorage.getItem('terminalScrollback') || '150';
+            scrollbackInput.value = savedScrollback;
+            scrollbackInput.addEventListener('change', () => {
+                let val = parseInt(scrollbackInput.value, 10);
+                if (isNaN(val) || val < 50) val = 50;
+                if (val > 10000) val = 10000;
+                scrollbackInput.value = val;
+                localStorage.setItem('terminalScrollback', String(val));
+                // Update all existing terminals
+                Object.keys(TerminalManager.terminals).forEach(key => {
+                    TerminalManager.terminals[key].options.scrollback = val;
+                });
             });
         }
 

--- a/static/js/session-manager.js
+++ b/static/js/session-manager.js
@@ -11,6 +11,9 @@ const SessionManager = {
             window.socket.on('ssh_session_restored', (data) => {
                 this.restoreSession(data);
             });
+            window.socket.on('persistent_session_available', (data) => {
+                this.showPersistentSessionTab(data);
+            });
         }
         this.ensureTerminalGrid();
         this.setSplitLayout(1);
@@ -36,7 +39,8 @@ const SessionManager = {
             host: data.host,
             port: data.port,
             username: data.username,
-            via_jump: data.via_jump
+            via_jump: data.via_jump,
+            display_name: data.display_name
         };
 
         const restoredId = this.createSession(sessionData);
@@ -45,6 +49,13 @@ const SessionManager = {
         const emptyIndex = this.getFirstEmptyPaneIndex();
         const targetPane = emptyIndex !== -1 ? emptyIndex : this.activePaneIndex;
         this.assignSessionToPane(restoredId, targetPane);
+
+        // Write buffered output to the restored terminal
+        if (data.buffered_output) {
+            setTimeout(() => {
+                TerminalManager.writeOutput(sessionId, data.buffered_output);
+            }, 200);
+        }
 
         console.log(`[RESTORE] Session ${sessionId} fully restored - waiting for output`);
 
@@ -58,8 +69,63 @@ const SessionManager = {
 
     },
 
+    showPersistentSessionTab(data) {
+        const { session_id, host, port, username, key_id, tmux_session_name, display_name } = data;
+
+        if (this.sessions[session_id]) {
+            return;
+        }
+
+        const terminalId = `terminal-${session_id}`;
+        const terminalContainer = document.createElement('div');
+        terminalContainer.id = terminalId;
+        terminalContainer.className = 'terminal-wrapper unassigned';
+        document.getElementById('terminalsContainer').appendChild(terminalContainer);
+
+        document.getElementById('noSessions').classList.add('hidden');
+        const sessionBar = document.getElementById('sessionBar');
+        if (sessionBar) {
+            sessionBar.classList.remove('hidden');
+        }
+
+        this.sessions[session_id] = {
+            id: session_id,
+            host,
+            port,
+            username,
+            connected: false,
+            terminalId,
+            os: 'all',
+            displayName: display_name || null,
+            viaJump: null,
+            useTmux: true,
+            tmuxSessionName: tmux_session_name,
+            isPersistentCandidate: true,
+            keyId: key_id
+        };
+
+        // Save display name to localStorage by host:port:user key
+        if (display_name) {
+            try {
+                const stored = JSON.parse(localStorage.getItem('sessionDisplayNames') || '{}');
+                const hostKey = `${host}:${port}:${username}`;
+                stored[hostKey] = display_name;
+                localStorage.setItem('sessionDisplayNames', JSON.stringify(stored));
+            } catch (e) {}
+        }
+
+        this.createSessionTab(session_id, host, username);
+        this.updateSessionStatus(session_id, 'disconnected');
+
+        const emptyIndex = this.getFirstEmptyPaneIndex();
+        const targetPane = emptyIndex !== -1 ? emptyIndex : this.activePaneIndex;
+        this.assignSessionToPane(session_id, targetPane);
+
+        console.log(`[PERSISTENT] Showing persistent tmux session tab: ${host}:${port} (${session_id})`);
+    },
+
     createSession(sessionData) {
-        const { session_id, host, port, username } = sessionData;
+        const { session_id, host, port, username, display_name } = sessionData;
 
         const terminalId = `terminal-${session_id}`;
         const terminalContainer = document.createElement('div');
@@ -71,10 +137,16 @@ const SessionManager = {
         TerminalManager.attachTerminal(session_id, terminalId);
         TerminalManager.setupInputHandler(session_id, (data) => {
             if (window.socket) {
-                window.socket.emit('ssh_input', {
-                    session_id: session_id,
-                    data: data
-                });
+                // Filter out Device Attributes responses that xterm.js may echo back
+                data = data.replace(/\x1b\[[?>]?[0-9;]*c/g, '');
+                // Also filter bare DA patterns like "0;276;0c"
+                data = data.replace(/[0-9]+;[0-9;]*c/g, '');
+                if (data) {
+                    window.socket.emit('ssh_input', {
+                        session_id: session_id,
+                        data: data
+                    });
+                }
             }
         });
 
@@ -84,7 +156,14 @@ const SessionManager = {
             sessionBar.classList.remove('hidden');
         }
 
-        const storedName = this.getStoredDisplayName(session_id);
+        const fallbackKey = `${host}:${port}:${username}`;
+        const fallbackName = this.pendingDisplayNames ? this.pendingDisplayNames[fallbackKey] : null;
+        const storedName = display_name || this.pendingDisplayName || fallbackName || this.getStoredDisplayName(session_id, host, port, username);
+        console.log(`[CREATE] createSession: display_name="${display_name}", pendingDisplayName="${this.pendingDisplayName}", fallbackName="${fallbackName}", storedName="${storedName}"`);
+        this.pendingDisplayName = null;
+        if (this.pendingDisplayNames) {
+            delete this.pendingDisplayNames[fallbackKey];
+        }
         this.sessions[session_id] = {
             id: session_id,
             host,
@@ -94,7 +173,9 @@ const SessionManager = {
             terminalId,
             os: 'all',
             displayName: storedName || null,
-            viaJump: sessionData.via_jump || null
+            viaJump: sessionData.via_jump || null,
+            useTmux: sessionData.use_tmux || false,
+            tmuxSessionName: sessionData.tmux_session_name || null
         };
 
         this.createSessionTab(session_id, host, username);
@@ -138,6 +219,13 @@ const SessionManager = {
             jumpBadge.textContent = '🛰️';
             jumpBadge.title = 'via ' + sess.viaJump;
             tab.appendChild(jumpBadge);
+        }
+        if (sess && sess.useTmux) {
+            const tmuxBadge = document.createElement('span');
+            tmuxBadge.className = 'tab-tmux-badge';
+            tmuxBadge.textContent = '📌';
+            tmuxBadge.title = 'Persistent tmux session' + (sess.tmuxSessionName ? ': ' + sess.tmuxSessionName : '');
+            tab.appendChild(tmuxBadge);
         }
         tab.appendChild(tabEdit);
         tab.appendChild(tabClose);
@@ -196,6 +284,14 @@ const SessionManager = {
 
         if (window.socket) {
             window.socket.emit('ssh_disconnect', { session_id: sessionId });
+        }
+
+        this.removeSessionUI(sessionId);
+    },
+
+    removeSessionUI(sessionId) {
+        if (!this.sessions[sessionId]) {
+            return;
         }
 
         const terminalContainer = document.getElementById(this.sessions[sessionId].terminalId);
@@ -409,6 +505,8 @@ const SessionManager = {
     },
 
     saveSessionDisplayName(sessionId, displayName) {
+        const session = this.sessions[sessionId];
+        // Save to localStorage by session ID
         try {
             const stored = JSON.parse(localStorage.getItem('sessionDisplayNames') || '{}');
             if (displayName) {
@@ -416,16 +514,39 @@ const SessionManager = {
             } else {
                 delete stored[sessionId];
             }
+            // Also save by host:port:user key so it survives session ID changes
+            if (session) {
+                const hostKey = `${session.host}:${session.port}:${session.username}`;
+                if (displayName) {
+                    stored[hostKey] = displayName;
+                } else {
+                    delete stored[hostKey];
+                }
+            }
             localStorage.setItem('sessionDisplayNames', JSON.stringify(stored));
         } catch (e) {
             console.error('Failed to save session display name:', e);
         }
+        // Save to server DB
+        if (window.socket) {
+            window.socket.emit('save_session_name', {
+                session_id: sessionId,
+                display_name: displayName
+            });
+        }
     },
 
-    getStoredDisplayName(sessionId) {
+    getStoredDisplayName(sessionId, host, port, username) {
         try {
             const stored = JSON.parse(localStorage.getItem('sessionDisplayNames') || '{}');
-            return stored[sessionId] || null;
+            // Check by session ID first
+            if (stored[sessionId]) return stored[sessionId];
+            // Check by host:port:user key (persists across session ID changes)
+            if (host && port && username) {
+                const hostKey = `${host}:${port}:${username}`;
+                if (stored[hostKey]) return stored[hostKey];
+            }
+            return null;
         } catch (e) {
             return null;
         }
@@ -706,11 +827,14 @@ const SessionManager = {
         if (!overlay) {
             overlay = document.createElement('div');
             overlay.className = 'session-overlay';
+            const isPersistent = session.isPersistentCandidate;
+            const tmuxName = session.tmuxSessionName || '';
             overlay.innerHTML = `
                 <div class="session-overlay-card">
-                    <h3>Session disconnected</h3>
-                    <p>Reconnect to resume your work.</p>
-                    <button class="btn btn-primary" data-session-id="${sessionId}">Retry</button>
+                    <h3>${isPersistent ? 'Persistent session' : 'Session disconnected'}</h3>
+                    <p>${isPersistent ? 'tmux session running on remote host. Reconnect to resume.' : 'Reconnect to resume your work.'}</p>
+                    ${tmuxName ? `<p style="font-size:12px;opacity:0.7;">tmux: ${tmuxName}</p>` : ''}
+                    <button class="btn btn-primary" data-session-id="${sessionId}">${isPersistent ? 'Reconnect' : 'Retry'}</button>
                 </div>
             `;
             container.appendChild(overlay);
@@ -742,6 +866,26 @@ const SessionManager = {
         if (!session) {
             return;
         }
+
+        // For persistent tmux sessions with a key_id, reconnect directly
+        // without opening the connection modal.
+        if (session.isPersistentCandidate && session.keyId && session.useTmux) {
+            this.directReconnect(sessionId);
+            return;
+        }
+
+        // For persistent candidate sessions (password auth), save display name
+        // and remove the old tab before opening the modal.
+        if (session.isPersistentCandidate) {
+            this.pendingDisplayName = session.displayName;
+            this.pendingDisplayNames = this.pendingDisplayNames || {};
+            if (session.displayName) {
+                this.pendingDisplayNames[`${session.host}:${session.port}:${session.username}`] = session.displayName;
+            }
+            this.pendingReconnectTmux = session.useTmux ? session.tmuxSessionName : null;
+            this.removeSessionUI(sessionId);
+        }
+
         const hostInput = document.getElementById('hostInput');
         const portInput = document.getElementById('portInput');
         const userInput = document.getElementById('usernameInput');
@@ -754,6 +898,39 @@ const SessionManager = {
         if (userInput) {
             userInput.value = session.username;
         }
+
+        // If persistent session with key_id, auto-select the key
+        if (session.keyId) {
+            const keyRadio = document.querySelector('input[name="authType"][value="key"]');
+            if (keyRadio) {
+                keyRadio.checked = true;
+                keyRadio.dispatchEvent(new Event('change'));
+            }
+            setTimeout(() => {
+                const keySelect = document.getElementById('keySelect');
+                if (keySelect) {
+                    for (let opt of keySelect.options) {
+                        if (opt.value === session.keyId) {
+                            opt.selected = true;
+                            break;
+                        }
+                    }
+                }
+            }, 200);
+        }
+
+        // Pre-check tmux checkbox for persistent sessions
+        if (session.useTmux) {
+            const tmuxCheck = document.getElementById('useTmuxCheck');
+            if (tmuxCheck) {
+                tmuxCheck.checked = true;
+            }
+            // Store the tmux session name for reconnection
+            this.pendingReconnectTmux = session.tmuxSessionName || null;
+        } else {
+            this.pendingReconnectTmux = null;
+        }
+
         const modal = document.getElementById('connectionModal');
         if (window.ModalManager && modal) {
             window.ModalManager.open(modal);
@@ -761,6 +938,53 @@ const SessionManager = {
             modal.classList.add('show');
         }
     },
+
+    directReconnect(sessionId) {
+        const session = this.sessions[sessionId];
+        if (!session || !session.isPersistentCandidate) {
+            return;
+        }
+
+        const host = session.host;
+        const port = session.port;
+        const username = session.username;
+        const keyId = session.keyId;
+        const tmuxSessionName = session.tmuxSessionName;
+        const displayName = session.displayName;
+
+        console.log(`[RECONNECT] directReconnect: displayName="${displayName}", host=${host}, tmux=${tmuxSessionName}`);
+
+        // Store display name BEFORE removing UI so it survives the reconnect
+        this.pendingDisplayName = displayName;
+        // Also store by host:port:user as a fallback key
+        if (displayName) {
+            this.pendingDisplayNames = this.pendingDisplayNames || {};
+            this.pendingDisplayNames[`${host}:${port}:${username}`] = displayName;
+        }
+
+        // Remove the persistent candidate UI without notifying server
+        this.removeSessionUI(sessionId);
+
+        // Emit reconnect directly
+        if (window.socket) {
+            const connectionData = {
+                host: host,
+                port: parseInt(port),
+                username: username,
+                client_request_id: `reconnect_${Date.now().toString(36)}`,
+                key_id: keyId,
+                use_tmux: true,
+                reconnect_tmux_name: tmuxSessionName,
+                display_name: displayName
+            };
+            window.socket.emit('ssh_connect', connectionData);
+            window.showNotification(`Reconnecting to ${username}@${host}...`, 'info');
+        }
+    },
+
+    pendingDisplayName: null,
+
+    pendingReconnectTmux: null,
 
     getActiveSession() {
         return this.activeSessionId;

--- a/static/js/session-manager.js
+++ b/static/js/session-manager.js
@@ -137,10 +137,9 @@ const SessionManager = {
         TerminalManager.attachTerminal(session_id, terminalId);
         TerminalManager.setupInputHandler(session_id, (data) => {
             if (window.socket) {
-                // Filter out Device Attributes responses that xterm.js may echo back
+                // Filter out Device Attributes responses (ESC[c sequences only).
+                // Bare-pattern regexes were removed because they corrupt legitimate input.
                 data = data.replace(/\x1b\[[?>]?[0-9;]*c/g, '');
-                // Also filter bare DA patterns like "0;276;0c"
-                data = data.replace(/[0-9]+;[0-9;]*c/g, '');
                 if (data) {
                     window.socket.emit('ssh_input', {
                         session_id: session_id,
@@ -925,20 +924,37 @@ const SessionManager = {
             overlay = document.createElement('div');
             overlay.className = 'session-overlay';
             const isPersistent = session.isPersistentCandidate;
+
+            const card = document.createElement('div');
+            card.className = 'session-overlay-card';
+
+            const heading = document.createElement('h3');
+            heading.textContent = isPersistent ? 'Persistent session' : 'Session disconnected';
+            card.appendChild(heading);
+
+            const desc = document.createElement('p');
+            desc.textContent = isPersistent ? 'tmux session running on remote host. Reconnect to resume.' : 'Reconnect to resume your work.';
+            card.appendChild(desc);
+
             const tmuxName = session.tmuxSessionName || '';
-            overlay.innerHTML = `
-                <div class="session-overlay-card">
-                    <h3>${isPersistent ? 'Persistent session' : 'Session disconnected'}</h3>
-                    <p>${isPersistent ? 'tmux session running on remote host. Reconnect to resume.' : 'Reconnect to resume your work.'}</p>
-                    ${tmuxName ? `<p style="font-size:12px;opacity:0.7;">tmux: ${tmuxName}</p>` : ''}
-                    <button class="btn btn-primary" data-session-id="${sessionId}">${isPersistent ? 'Reconnect' : 'Retry'}</button>
-                </div>
-            `;
-            container.appendChild(overlay);
-            const button = overlay.querySelector('button');
+            if (tmuxName) {
+                const tmuxInfo = document.createElement('p');
+                tmuxInfo.style.cssText = 'font-size:12px;opacity:0.7;';
+                tmuxInfo.textContent = 'tmux: ' + tmuxName;
+                card.appendChild(tmuxInfo);
+            }
+
+            const button = document.createElement('button');
+            button.className = 'btn btn-primary';
+            button.dataset.sessionId = sessionId;
+            button.textContent = isPersistent ? 'Reconnect' : 'Retry';
             button.addEventListener('click', () => {
                 this.prefillConnectionForm(sessionId);
             });
+            card.appendChild(button);
+
+            overlay.appendChild(card);
+            container.appendChild(overlay);
         }
         overlay.classList.remove('hidden');
     },

--- a/static/js/session-manager.js
+++ b/static/js/session-manager.js
@@ -175,7 +175,8 @@ const SessionManager = {
             displayName: storedName || null,
             viaJump: sessionData.via_jump || null,
             useTmux: sessionData.use_tmux || false,
-            tmuxSessionName: sessionData.tmux_session_name || null
+            tmuxSessionName: sessionData.tmux_session_name || null,
+            keyId: sessionData.key_id || null
         };
 
         this.createSessionTab(session_id, host, username);
@@ -227,7 +228,14 @@ const SessionManager = {
             tmuxBadge.title = 'Persistent tmux session' + (sess.tmuxSessionName ? ': ' + sess.tmuxSessionName : '');
             tab.appendChild(tmuxBadge);
         }
+        const tabReconnect = document.createElement('span');
+        tabReconnect.className = 'tab-reconnect';
+        tabReconnect.innerHTML = '⟳';
+        tabReconnect.setAttribute('aria-label', 'Reconnect session');
+        tabReconnect.setAttribute('title', 'Reconnect');
+
         tab.appendChild(tabEdit);
+        tab.appendChild(tabReconnect);
         tab.appendChild(tabClose);
 
         tab.addEventListener('click', () => {
@@ -242,6 +250,11 @@ const SessionManager = {
         tabEdit.addEventListener('click', (e) => {
             e.stopPropagation();
             this.startRenameSession(sessionId, tabLabel);
+        });
+
+        tabReconnect.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.requestReconnect(sessionId);
         });
 
         tabClose.addEventListener('click', (e) => {
@@ -338,6 +351,90 @@ const SessionManager = {
         const label = this.getDisplayLabel(sessionId, session.username, session.host);
         if (confirm(`Close session "${label}"?`)) {
             this.closeSession(sessionId);
+        }
+    },
+
+    requestReconnect(sessionId) {
+        const session = this.sessions[sessionId];
+        if (!session) {
+            return;
+        }
+
+        const label = this.getDisplayLabel(sessionId, session.username, session.host);
+
+        // Persistent candidate (disconnected tmux session) — reconnect directly
+        if (session.isPersistentCandidate) {
+            this.directReconnect(sessionId);
+            return;
+        }
+
+        // Active session — disconnect first, then reconnect
+        if (session.connected) {
+            if (!confirm(`Reconnect session "${label}"?`)) {
+                return;
+            }
+
+            const host = session.host;
+            const port = session.port;
+            const username = session.username;
+            const displayName = session.displayName;
+            const useTmux = session.useTmux;
+            const tmuxSessionName = session.tmuxSessionName;
+            const keyId = session.keyId;
+
+            // Store display name for reconnect
+            this.pendingDisplayName = displayName;
+            this.pendingDisplayNames = this.pendingDisplayNames || {};
+            if (displayName) {
+                this.pendingDisplayNames[`${host}:${port}:${username}`] = displayName;
+            }
+
+            // Disconnect the current session (sends ssh_disconnect to server)
+            this.closeSession(sessionId);
+
+            // If we have a key_id, reconnect directly. Otherwise, open the
+            // pre-filled connection modal.
+            if (keyId) {
+                setTimeout(() => {
+                    if (window.socket) {
+                        const connectionData = {
+                            host: host,
+                            port: parseInt(port),
+                            username: username,
+                            client_request_id: `reconnect_${Date.now().toString(36)}`,
+                            key_id: keyId,
+                            use_tmux: useTmux,
+                            reconnect_tmux_name: useTmux ? tmuxSessionName : null,
+                            display_name: displayName
+                        };
+                        window.socket.emit('ssh_connect', connectionData);
+                        window.showNotification(`Reconnecting to ${label}...`, 'info');
+                    }
+                }, 500);
+            } else {
+                // No key_id — open pre-filled connection modal
+                setTimeout(() => {
+                    const hostInput = document.getElementById('hostInput');
+                    const portInput = document.getElementById('portInput');
+                    const userInput = document.getElementById('usernameInput');
+                    if (hostInput) hostInput.value = host;
+                    if (portInput) portInput.value = port;
+                    if (userInput) userInput.value = username;
+
+                    if (useTmux) {
+                        const tmuxCheck = document.getElementById('useTmuxCheck');
+                        if (tmuxCheck) tmuxCheck.checked = true;
+                        this.pendingReconnectTmux = tmuxSessionName || null;
+                    }
+
+                    const modal = document.getElementById('connectionModal');
+                    if (window.ModalManager && modal) {
+                        window.ModalManager.open(modal);
+                    } else if (modal) {
+                        modal.classList.add('show');
+                    }
+                }, 300);
+            }
         }
     },
 

--- a/static/js/terminal-manager.js
+++ b/static/js/terminal-manager.js
@@ -58,12 +58,13 @@ const TerminalManager = {
         const key = terminalKey || sessionId;
         const monoFont = this.getMonoFont();
         const theme = this.buildTheme();
+        const scrollbackLines = parseInt(localStorage.getItem('terminalScrollback') || '150', 10);
         const terminal = new Terminal({
             cursorBlink: true,
             fontSize: this.getResponsiveFontSize(),
             fontFamily: monoFont || 'monospace',
             theme: theme,
-            scrollback: 50000,
+            scrollback: scrollbackLines,
             scrollOnOutput: true,
             scrollOnUserInput: true,
             tabStopWidth: 4,
@@ -116,22 +117,20 @@ const TerminalManager = {
 
         terminal.open(container);
 
+        // Add custom scrollbar on the right side of the terminal
+        this.setupScrollbar(container, terminal, key);
+
         requestAnimationFrame(() => {
             requestAnimationFrame(() => {
                 this.fitTerminal(sessionId);
 
                 setTimeout(() => {
                     terminal.clear();
+                    // Discard any output buffered before the terminal was ready
+                    // to prevent stale output from previous sessions appearing
+                    this.pendingOutput[key] = [];
 
                     this.terminalReady[key] = true;
-
-                    if (this.pendingOutput[key] && this.pendingOutput[key].length > 0) {
-                        console.log(`Flushing ${this.pendingOutput[key].length} pending outputs for ${sessionId}`);
-                        this.pendingOutput[key].forEach(data => {
-                            this.writeToTerminalWithScroll(terminal, data);
-                        });
-                        this.pendingOutput[key] = [];
-                    }
                 }, 50);
             });
         });
@@ -157,6 +156,12 @@ const TerminalManager = {
         if (!terminal) {
             return;
         }
+
+        // Filter out Device Attributes responses that appear as visible text.
+        // Matches ESC[?...c, ESC[>...c, ESC[...c, and bare patterns like "0;276;0c"
+        data = data.replace(/\x1b\[[?>]?[0-9;]*c/g, '');
+        // Remove any remaining bare DA patterns (digits/semicolons ending with c)
+        data = data.replace(/[0-9]+;[0-9;]*c/g, '');
 
         if (this.terminalReady[terminalKey]) {
             this.writeToTerminalWithScroll(terminal, data);
@@ -293,6 +298,95 @@ const TerminalManager = {
         delete this.sessionTerminals[sessionId];
         delete this.transcripts[sessionId];
         delete this.transcriptSizes[sessionId];
+    },
+
+    setupScrollbar(container, terminal, terminalKey) {
+        // Create custom scrollbar overlay on the right side
+        const scrollbar = document.createElement('div');
+        scrollbar.className = 'terminal-scrollbar';
+        scrollbar.innerHTML = '<div class="terminal-scrollbar-thumb"></div>';
+        container.style.position = 'relative';
+        container.appendChild(scrollbar);
+
+        const thumb = scrollbar.querySelector('.terminal-scrollbar-thumb');
+        let isDragging = false;
+        let startY = 0;
+        let startScroll = 0;
+
+        const updateScrollbar = () => {
+            const buffer = terminal.buffer.active;
+            const totalLines = buffer.length;
+            const viewportHeight = terminal.rows;
+            const scrollPos = buffer.viewportY;
+            const maxScroll = totalLines - viewportHeight;
+
+            if (maxScroll <= 0) {
+                scrollbar.style.display = 'none';
+                return;
+            }
+            scrollbar.style.display = 'block';
+
+            const trackHeight = scrollbar.clientHeight;
+            const thumbHeight = Math.max(30, (viewportHeight / totalLines) * trackHeight);
+            const thumbTop = (scrollPos / maxScroll) * (trackHeight - thumbHeight);
+
+            thumb.style.height = `${thumbHeight}px`;
+            thumb.style.top = `${thumbTop}px`;
+        };
+
+        // Update scrollbar on terminal output and scroll
+        terminal.onScroll(() => updateScrollbar());
+        terminal.onResize(() => updateScrollbar());
+
+        // Also update periodically for output-driven changes
+        const intervalId = setInterval(() => {
+            if (!this.terminals[terminalKey]) {
+                clearInterval(intervalId);
+                return;
+            }
+            updateScrollbar();
+        }, 500);
+
+        // Drag to scroll
+        thumb.addEventListener('mousedown', (e) => {
+            isDragging = true;
+            startY = e.clientY;
+            startScroll = terminal.buffer.active.viewportY;
+            e.preventDefault();
+        });
+
+        document.addEventListener('mousemove', (e) => {
+            if (!isDragging) return;
+            const buffer = terminal.buffer.active;
+            const totalLines = buffer.length;
+            const maxScroll = totalLines - terminal.rows;
+            const trackHeight = scrollbar.clientHeight;
+            const thumbHeight = Math.max(30, (terminal.rows / totalLines) * trackHeight);
+            const deltaY = e.clientY - startY;
+            const scrollDelta = (deltaY / (trackHeight - thumbHeight)) * maxScroll;
+            const newScroll = Math.max(0, Math.min(maxScroll, Math.round(startScroll + scrollDelta)));
+            const currentScroll = buffer.viewportY;
+            terminal.scrollLines(newScroll - currentScroll);
+        });
+
+        document.addEventListener('mouseup', () => {
+            isDragging = false;
+        });
+
+        // Click on track to scroll
+        scrollbar.addEventListener('click', (e) => {
+            if (e.target === thumb) return;
+            const rect = scrollbar.getBoundingClientRect();
+            const clickY = e.clientY - rect.top;
+            const trackHeight = rect.height;
+            const buffer = terminal.buffer.active;
+            const maxScroll = buffer.length - terminal.rows;
+            const targetScroll = Math.round((clickY / trackHeight) * maxScroll);
+            const currentScroll = buffer.viewportY;
+            terminal.scrollLines(targetScroll - currentScroll);
+        });
+
+        updateScrollbar();
     },
 
     destroyTerminalKey(terminalKey, sessionId) {

--- a/static/js/terminal-manager.js
+++ b/static/js/terminal-manager.js
@@ -157,11 +157,10 @@ const TerminalManager = {
             return;
         }
 
-        // Filter out Device Attributes responses that appear as visible text.
-        // Matches ESC[?...c, ESC[>...c, ESC[...c, and bare patterns like "0;276;0c"
+        // Filter out Device Attributes responses (ESC[c sequences only).
+        // Bare-pattern regexes were removed because they corrupt legitimate
+        // output like "padding:0;color:red" or "cat file".
         data = data.replace(/\x1b\[[?>]?[0-9;]*c/g, '');
-        // Remove any remaining bare DA patterns (digits/semicolons ending with c)
-        data = data.replace(/[0-9]+;[0-9;]*c/g, '');
 
         if (this.terminalReady[terminalKey]) {
             this.writeToTerminalWithScroll(terminal, data);

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,6 +62,15 @@
                         </button>
                         <div class="lang-dropdown-header account-submenu" id="langDropdownHeader"></div>
 
+                        <div class="account-item" style="display:flex;align-items:center;gap:8px;padding:6px 12px;">
+                            <span class="account-item-icon" aria-hidden="true">📜</span>
+                            <span class="account-expander-label">Scrollback</span>
+                            <input type="number" id="scrollbackInput" min="50" max="10000" step="50"
+                                   style="width:70px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:4px;color:var(--text-primary);padding:2px 6px;font-size:12px;text-align:right;"
+                                   title="Terminal scrollback lines">
+                            <span style="font-size:11px;opacity:0.6;">lines</span>
+                        </div>
+
                         <div class="account-divider" role="separator"></div>
 
                         {% if current_user.is_admin %}<a id="adminPanelBtn" class="account-item account-action" href="{{ url_for('admin_page') }}"><span class="account-item-icon" aria-hidden="true">⚙️</span> <span data-i18n="admin.title">Admin</span></a>{% endif %}
@@ -261,6 +270,16 @@
                             <span data-i18n="connection.saveAsProfile">Save as profile</span>
                         </label>
                     </div>
+
+                    {% if tmux_enabled %}
+                    <div class="form-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="useTmuxCheck" {% if tmux_default %}checked{% endif %}>
+                            <span>Persistent session (tmux)</span>
+                        </label>
+                        <div class="field-hint">Keeps terminal alive on the remote host even when you close the browser or server restarts. Reattaches to existing tmux session automatically.</div>
+                    </div>
+                    {% endif %}
 
                     <div class="form-group hidden" id="profileNameGroup">
                         <label for="profileNameInput" data-i18n="connection.profileName">Profile Name</label>
@@ -701,16 +720,16 @@
     <script src="{{ url_for('static', filename='js/binary-transfer-client.js') }}"></script>
     <script src="{{ url_for('static', filename='js/drag-drop-manager.js') }}"></script>
 
-    <script src="{{ url_for('static', filename='js/terminal-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/session-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/broadcast-input.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/profile-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/jump-host-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/command-library.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/file-transfer.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/browser-filesystem.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/terminal-manager.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/session-manager.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/broadcast-input.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/profile-manager.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/jump-host-manager.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/command-library.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/file-transfer.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/browser-filesystem.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}?v=2"></script>
     <script>
         const flashedMessages = {{ get_flashed_messages(with_categories=true) | tojson }};
         flashedMessages.forEach(([category, message]) => {


### PR DESCRIPTION
…ring, DA filtering, display name persistence

## Persistent tmux sessions
- Configurable via TMUX_ENABLED, TMUX_DEFAULT, TMUX_SESSION_PREFIX env vars
- Each connection gets a unique tmux session name with UUID suffix
- Reconnections use tmux new-session -A to attach to existing session
- Session metadata (is_persistent, key_id, tmux_session_name) stored in DB
- Auto-cleanup of old disconnected sessions when reconnecting
- Direct reconnect for persistent sessions (SSH key auth)
- Persistent session tabs with tmux badge and reconnect overlay
- Display name persistence via save_session_name socket event

## Configurable scrollback + manual scrollbar
- Configurable scrollback lines (default 150, stored in localStorage)
- Custom scrollbar overlay with drag-to-scroll and click-to-scroll
- Scrollback input in account dropdown menu

## Terminal output buffering
- 512KB circular output buffer per SSH session
- Buffered output sent to client on session restore
- Replay last output on reconnect for seamless experience

## Device Attributes response filtering
- Filter DA responses (ESC[?...c, bare patterns like 0;276;0c) at 3 levels: server output, server input, client display
- Partial buffer handles split patterns across recv() boundaries
- Debug logging for control characters in SSH input

## Display name persistence
- Save display name to server DB via save_session_name socket event
- Return display_name in session restore events
- Save by host:port:user key in localStorage for cross-session-ID persistence
- Display name survives reconnects and new browser windows