### PR TITLE
Add terminal copy and paste shortcuts

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1649,6 +1649,8 @@
             { keys: 'Ctrl+?', label: 'Show Shortcuts' },
             { keys: 'Ctrl+Shift+N', label: 'New Connection' },
             { keys: 'Ctrl+F', label: 'Search in Terminal' },
+            { keys: 'Ctrl/Cmd+C', label: 'Copy terminal selection' },
+            { keys: 'Ctrl/Cmd+V', label: 'Paste into terminal' },
             { keys: 'Ctrl+1-9', label: 'Switch to tab 1-9' },
             { keys: 'Ctrl+Tab', label: 'Next tab' },
             { keys: 'Ctrl+Shift+Tab', label: 'Previous tab' },

--- a/static/js/terminal-manager.js
+++ b/static/js/terminal-manager.js
@@ -13,6 +13,32 @@ const TerminalManager = {
         return getComputedStyle(document.body).getPropertyValue(name).trim() || fallback;
     },
 
+    isMacPlatform() {
+        const platform = navigator.userAgentData?.platform || navigator.platform || navigator.userAgent || '';
+        return /mac|iphone|ipad|ipod/i.test(platform);
+    },
+
+    shouldProcessClipboardKeyEvent(event, terminal, isMac) {
+        if (event.type !== 'keydown' || event.altKey || event.shiftKey) {
+            return true;
+        }
+
+        const key = (event.key || '').toLowerCase();
+        if (key !== 'c' && key !== 'v') {
+            return true;
+        }
+
+        if (isMac) {
+            return !(event.metaKey && !event.ctrlKey);
+        }
+
+        if (!event.ctrlKey || event.metaKey) {
+            return true;
+        }
+
+        return key === 'c' ? !terminal.hasSelection() : false;
+    },
+
     buildTheme() {
         return {
             background: this.getCssVar('--term-background', '#1c2128'),
@@ -70,6 +96,11 @@ const TerminalManager = {
             tabStopWidth: 4,
             allowProposedApi: true
         });
+
+        const isMac = this.isMacPlatform();
+        terminal.attachCustomKeyEventHandler(event => (
+            this.shouldProcessClipboardKeyEvent(event, terminal, isMac)
+        ));
 
         const fitAddon = new FitAddon.FitAddon();
         terminal.loadAddon(fitAddon);

--- a/templates/index.html
+++ b/templates/index.html
@@ -720,7 +720,7 @@
     <script src="{{ url_for('static', filename='js/binary-transfer-client.js') }}"></script>
     <script src="{{ url_for('static', filename='js/drag-drop-manager.js') }}"></script>
 
-    <script src="{{ url_for('static', filename='js/terminal-manager.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/terminal-manager.js') }}?v=3"></script>
     <script src="{{ url_for('static', filename='js/session-manager.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/broadcast-input.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/profile-manager.js') }}?v=2"></script>


### PR DESCRIPTION
## Summary

- add platform-aware copy and paste handling to each xterm instance
- preserve `Ctrl+C` as the SSH interrupt when no text is selected
- keep paste on xterm's native path, including newline normalization and bracketed paste
- document the shortcuts and refresh the terminal-manager asset version

## Why

This implements the request from [Discussion #40](https://github.com/bifrost0x/webssh/discussions/40) without changing the backend, Socket.IO input path, or dependencies.

## Validation

- `node --check static/js/terminal-manager.js`
- `node --check static/js/app.js`
- `pytest tests -q`: 137 passed, 27 skipped
- browser verification for selection copy, `Ctrl+C` interrupt, multiline paste, and bracketed paste
- local Docker image build and healthy container startup