### PR TITLE
Stop sending input when restoring sessions

### DIFF
--- a/static/js/session-manager.js
+++ b/static/js/session-manager.js
@@ -58,15 +58,6 @@ const SessionManager = {
         }
 
         console.log(`[RESTORE] Session ${sessionId} fully restored - waiting for output`);
-
-        setTimeout(() => {
-            console.log(`[RESTORE] Sending keepalive newline to session ${sessionId}`);
-            window.socket.emit('ssh_input', {
-                session_id: sessionId,
-                data: '\n'
-            });
-        }, 500);
-
     },
 
     showPersistentSessionTab(data) {


### PR DESCRIPTION
## Summary

- remove the synthetic newline sent after restoring an active SSH session
- avoid adding an extra prompt on every browser reconnect
- prevent partially typed commands from being executed when a session is restored

The SSH transport already has its own keepalive, so session restoration should replay buffered output without injecting terminal input.

## Testing

- `node --check static/js/session-manager.js`
- restore-session regression harness confirms no `ssh_input` event is emitted
- `pytest`: 137 passed, 27 skipped
- Docker image build