### PR TITLE
Harden SSH session lifecycle and cleanup

### DIFF
--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -376,6 +376,13 @@ def handle_ssh_connect(data, current_user=None):
         if error:
             emit_error(error)
         else:
+            created_session = ssh_manager.get_session(session_id)
+            if not created_session:
+                log_error("SSH session disappeared after creation", session_id=session_id)
+                emit_error("Connection failed")
+                return
+            created_tmux_name = created_session.get('tmux_session_name') if use_tmux else None
+
             display_name = data.get('display_name') if use_tmux else None
             if display_name:
                 display_name = display_name.strip()[:128] or None
@@ -403,7 +410,7 @@ def handle_ssh_connect(data, current_user=None):
                     is_persistent=use_tmux,
                     key_id=key_id if use_tmux else None,
                     auth_type=auth_type,
-                    tmux_session_name=ssh_manager.get_session(session_id).get('tmux_session_name') if use_tmux else None,
+                    tmux_session_name=created_tmux_name,
                     display_name=display_name if use_tmux else None
                 )
                 db.session.add(ssh_session)
@@ -423,7 +430,7 @@ def handle_ssh_connect(data, current_user=None):
                 'use_tmux': use_tmux,
                 'key_id': key_id if use_tmux else None,
                 'auth_type': auth_type,
-                'tmux_session_name': ssh_manager.get_session(session_id).get('tmux_session_name') if use_tmux else None,
+                'tmux_session_name': created_tmux_name,
                 'display_name': display_name
             })
             log_ssh_connection(current_user.username, host, port, True, request.remote_addr)

--- a/app/ssh_manager.py
+++ b/app/ssh_manager.py
@@ -4,7 +4,7 @@ import shlex
 import time
 import uuid
 import socket
-from threading import Lock, Thread
+from threading import Lock, Thread, Timer
 import config
 from pathlib import Path
 from .audit_logger import log_info, log_warning, log_error, log_debug
@@ -13,6 +13,7 @@ from .ssh_key_loader import load_private_key as _load_private_key
 sessions = {}
 sessions_lock = Lock()
 _pending_connections = 0
+TMUX_KILL_TIMEOUT = 2.0
 
 
 class TailscaleSSHAuthStrategy(AuthStrategy):
@@ -467,9 +468,6 @@ def close_session(session_id, kill_tmux=False):
                candidate. Pass True only from explicit user disconnect.
     """
     try:
-        from .sftp_handler import close_sftp_cache
-        close_sftp_cache(session_id)
-
         with sessions_lock:
             session = sessions.pop(session_id, None)
             if session is None:
@@ -479,19 +477,31 @@ def close_session(session_id, kill_tmux=False):
         # All network I/O happens after removing the session from the shared
         # registry, so a slow or half-open SSH transport cannot block unrelated
         # session operations behind sessions_lock.
+        try:
+            from .sftp_handler import close_sftp_cache
+            close_sftp_cache(session_id)
+        except Exception as e:
+            log_debug(f"Error closing SFTP cache", session_id=session_id, error=str(e))
+
         if kill_tmux and session.get('use_tmux') and session.get('tmux_session_name') and session['client']:
             kill_channel = None
             try:
                 transport = session['client'].get_transport()
                 if transport and transport.is_active():
-                    kill_channel = transport.open_session(timeout=2.0)
-                    kill_channel.settimeout(2.0)
+                    kill_channel = transport.open_session(timeout=TMUX_KILL_TIMEOUT)
+                    kill_channel.settimeout(TMUX_KILL_TIMEOUT)
                     command = 'tmux kill-session -t ' + shlex.quote(session['tmux_session_name'])
-                    kill_channel.exec_command(command)
+                    timeout_guard = Timer(TMUX_KILL_TIMEOUT, kill_channel.close)
+                    timeout_guard.daemon = True
+                    timeout_guard.start()
                     try:
-                        kill_channel.recv(1)
-                    except Exception:
-                        pass
+                        kill_channel.exec_command(command)
+                        try:
+                            kill_channel.recv(1)
+                        except Exception:
+                            pass
+                    finally:
+                        timeout_guard.cancel()
             except Exception as e:
                 log_debug(f"Error killing tmux session", session_id=session_id, error=str(e))
             finally:

--- a/app/ssh_manager.py
+++ b/app/ssh_manager.py
@@ -1,5 +1,6 @@
 import paramiko
 from paramiko.auth_strategy import AuthStrategy, NoneAuth
+import shlex
 import time
 import uuid
 import socket
@@ -11,6 +12,7 @@ from .ssh_key_loader import load_private_key as _load_private_key
 
 sessions = {}
 sessions_lock = Lock()
+_pending_connections = 0
 
 
 class TailscaleSSHAuthStrategy(AuthStrategy):
@@ -71,12 +73,17 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
         proxy_jump_*: Optional jump host (bastion) connection parameters
         auth_type: Target authentication method (password, key, or tailscale)
     """
+    global _pending_connections
+
     bastion_client = None
     connection_stored = False
+    slot_reserved = False
     try:
         with sessions_lock:
-            if len(sessions) >= config.MAX_SESSIONS:
+            if len(sessions) + _pending_connections >= config.MAX_SESSIONS:
                 return None, "Maximum number of sessions reached"
+            _pending_connections += 1
+            slot_reserved = True
 
         # Optional ProxyJump: connect to the bastion first, then tunnel to the target.
         sock = None
@@ -219,26 +226,39 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
 
         time.sleep(0.1)
 
+        capacity_reached = False
         with sessions_lock:
-            sessions[session_id] = {
-                'client': client,
-                'channel': channel,
-                'host': host,
-                'port': port,
-                'username': username,
-                'user_id': user_id,
-                'connected': True,
-                'last_activity': time.time(),
-                'bastion_client': bastion_client,
-                'proxy_jump_host': proxy_jump_host,
-                'auth_type': auth_type,
-                'use_tmux': use_tmux,
-                'tmux_session_name': tmux_session_name,
-                'output_buffer': [],
-                'output_buffer_size': 0,
-                'output_buffer_max': 512000  # 512KB max buffer
-            }
-            connection_stored = True
+            _pending_connections -= 1
+            slot_reserved = False
+            if len(sessions) >= config.MAX_SESSIONS:
+                capacity_reached = True
+            else:
+                sessions[session_id] = {
+                    'client': client,
+                    'channel': channel,
+                    'host': host,
+                    'port': port,
+                    'username': username,
+                    'user_id': user_id,
+                    'connected': True,
+                    'last_activity': time.time(),
+                    'bastion_client': bastion_client,
+                    'proxy_jump_host': proxy_jump_host,
+                    'auth_type': auth_type,
+                    'use_tmux': use_tmux,
+                    'tmux_session_name': tmux_session_name,
+                    'output_buffer': [],
+                    'output_buffer_size': 0,
+                    'output_buffer_max': 512000  # 512KB max buffer
+                }
+                connection_stored = True
+
+        if capacity_reached:
+            try:
+                client.close()
+            except Exception:
+                pass
+            return None, "Maximum number of sessions reached"
 
         if socketio_instance and app:
             thread = Thread(
@@ -266,6 +286,10 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
         log_error("SSH connection unexpected error", host=f"{host}:{port}", error=str(e))
         return None, "Connection failed"
     finally:
+        if slot_reserved:
+            with sessions_lock:
+                _pending_connections -= 1
+
         # Avoid leaking the bastion connection if the target connect failed.
         if bastion_client is not None and not connection_stored:
             try:
@@ -447,49 +471,53 @@ def close_session(session_id, kill_tmux=False):
         close_sftp_cache(session_id)
 
         with sessions_lock:
-            if session_id not in sessions:
+            session = sessions.pop(session_id, None)
+            if session is None:
                 return False
-
-            session = sessions[session_id]
             session['connected'] = False
 
-            # Kill tmux session on remote host only on explicit disconnect.
-            # Idle timeout and server restart leave tmux running so the
-            # session survives and appears as a reconnect candidate.
-            if kill_tmux and session.get('use_tmux') and session.get('tmux_session_name') and session['client']:
-                try:
-                    transport = session['client'].get_transport()
-                    if transport and transport.is_active():
-                        kill_channel = transport.open_session()
-                        kill_channel.exec_command(f'tmux kill-session -t {session["tmux_session_name"]}')
-                        kill_channel.settimeout(2.0)
-                        try:
-                            kill_channel.recv(1)
-                        except Exception:
-                            pass
+        # All network I/O happens after removing the session from the shared
+        # registry, so a slow or half-open SSH transport cannot block unrelated
+        # session operations behind sessions_lock.
+        if kill_tmux and session.get('use_tmux') and session.get('tmux_session_name') and session['client']:
+            kill_channel = None
+            try:
+                transport = session['client'].get_transport()
+                if transport and transport.is_active():
+                    kill_channel = transport.open_session(timeout=2.0)
+                    kill_channel.settimeout(2.0)
+                    command = 'tmux kill-session -t ' + shlex.quote(session['tmux_session_name'])
+                    kill_channel.exec_command(command)
+                    try:
+                        kill_channel.recv(1)
+                    except Exception:
+                        pass
+            except Exception as e:
+                log_debug(f"Error killing tmux session", session_id=session_id, error=str(e))
+            finally:
+                if kill_channel is not None:
+                    try:
                         kill_channel.close()
-                except Exception as e:
-                    log_debug(f"Error killing tmux session", session_id=session_id, error=str(e))
+                    except Exception:
+                        pass
 
-            if session['channel']:
-                try:
-                    session['channel'].close()
-                except Exception as e:
-                    log_debug(f"Error closing channel", session_id=session_id, error=str(e))
+        if session['channel']:
+            try:
+                session['channel'].close()
+            except Exception as e:
+                log_debug(f"Error closing channel", session_id=session_id, error=str(e))
 
-            if session['client']:
-                try:
-                    session['client'].close()
-                except Exception as e:
-                    log_debug(f"Error closing SSH client", session_id=session_id, error=str(e))
+        if session['client']:
+            try:
+                session['client'].close()
+            except Exception as e:
+                log_debug(f"Error closing SSH client", session_id=session_id, error=str(e))
 
-            if session.get('bastion_client'):
-                try:
-                    session['bastion_client'].close()
-                except Exception as e:
-                    log_debug(f"Error closing jump host client", session_id=session_id, error=str(e))
-
-            del sessions[session_id]
+        if session.get('bastion_client'):
+            try:
+                session['bastion_client'].close()
+            except Exception as e:
+                log_debug(f"Error closing jump host client", session_id=session_id, error=str(e))
 
         return True
     except Exception as e:

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -46,6 +46,12 @@ class FakeTransport:
         self.open_timeout = timeout
         return self.kill_channel
 
+    def _send_user_message(self, _message):
+        pass
+
+    def get_exception(self):
+        return None
+
 
 class FakeSSHClient:
     def __init__(self, connect_started=None, connect_release=None,
@@ -209,6 +215,38 @@ def test_close_session_does_not_hold_registry_lock_during_io(monkeypatch):
     assert result == [True]
 
 
+def test_close_session_removes_registry_entry_before_sftp_cleanup(monkeypatch):
+    cleanup_started = threading.Event()
+    cleanup_release = threading.Event()
+    client = FakeSSHClient()
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions['session-1'] = _session(client)
+
+    def blocking_sftp_cleanup(_session_id):
+        cleanup_started.set()
+        assert cleanup_release.wait(2)
+
+    monkeypatch.setattr(
+        'app.sftp_handler.close_sftp_cache', blocking_sftp_cleanup)
+    result = []
+    close_thread = threading.Thread(
+        target=lambda: result.append(ssh_manager.close_session('session-1')),
+        daemon=True,
+    )
+    close_thread.start()
+    assert cleanup_started.wait(2)
+
+    try:
+        with ssh_manager.sessions_lock:
+            assert 'session-1' not in ssh_manager.sessions
+    finally:
+        cleanup_release.set()
+        close_thread.join(2)
+
+    assert not close_thread.is_alive()
+    assert result == [True]
+
+
 def test_close_session_quotes_tmux_target_and_sets_timeout_first(monkeypatch):
     kill_channel = FakeChannel()
     transport = FakeTransport(kill_channel)
@@ -256,3 +294,52 @@ def test_close_session_closes_everything_when_tmux_exec_fails(monkeypatch):
     assert client.closed is True
     assert bastion_client.closed is True
     assert 'session-1' not in ssh_manager.sessions
+
+
+def test_close_session_bounds_paramiko_tmux_exec_handshake(monkeypatch):
+    transport = FakeTransport()
+    kill_channel = ssh_manager.paramiko.Channel(1)
+    kill_channel.active = True
+    kill_channel.remote_chanid = 1
+    kill_channel.transport = transport
+    transport.kill_channel = kill_channel
+
+    client = FakeSSHClient(transport=transport)
+    interactive_channel = FakeChannel()
+    bastion_client = FakeSSHClient()
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions['session-1'] = _session(
+            client,
+            channel=interactive_channel,
+            use_tmux=True,
+            tmux_session_name='tmux-session',
+            bastion_client=bastion_client,
+        )
+
+    monkeypatch.setattr(
+        'app.sftp_handler.close_sftp_cache', lambda _session_id: None)
+    monkeypatch.setattr(
+        ssh_manager, 'TMUX_KILL_TIMEOUT', 0.05, raising=False)
+
+    finished = threading.Event()
+    result = []
+
+    def close():
+        result.append(ssh_manager.close_session('session-1', kill_tmux=True))
+        finished.set()
+
+    close_thread = threading.Thread(target=close, daemon=True)
+    close_thread.start()
+    completed_within_deadline = finished.wait(0.5)
+
+    if not completed_within_deadline:
+        kill_channel.close()
+    close_thread.join(2)
+
+    assert completed_within_deadline, 'tmux exec handshake exceeded its deadline'
+    assert not close_thread.is_alive()
+    assert result == [True]
+    assert transport.open_timeout == 0.05
+    assert interactive_channel.closed is True
+    assert client.closed is True
+    assert bastion_client.closed is True

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,258 @@
+import threading
+
+import pytest
+
+from app import ssh_manager
+
+
+class FakeChannel:
+    def __init__(self, exec_error=None):
+        self.exec_error = exec_error
+        self.closed = False
+        self.command = None
+        self.timeout = None
+        self.events = []
+
+    def settimeout(self, timeout):
+        self.timeout = timeout
+        self.events.append(('settimeout', timeout))
+
+    def exec_command(self, command):
+        self.command = command
+        self.events.append(('exec_command', command))
+        if self.exec_error:
+            raise self.exec_error
+
+    def recv(self, _size):
+        return b''
+
+    def close(self):
+        self.closed = True
+
+
+class FakeTransport:
+    def __init__(self, kill_channel=None):
+        self.keepalive = None
+        self.kill_channel = kill_channel
+        self.open_timeout = None
+
+    def set_keepalive(self, seconds):
+        self.keepalive = seconds
+
+    def is_active(self):
+        return True
+
+    def open_session(self, timeout=None):
+        self.open_timeout = timeout
+        return self.kill_channel
+
+
+class FakeSSHClient:
+    def __init__(self, connect_started=None, connect_release=None,
+                 close_started=None, close_release=None, transport=None):
+        self.connect_started = connect_started
+        self.connect_release = connect_release
+        self.close_started = close_started
+        self.close_release = close_release
+        self.transport = transport or FakeTransport()
+        self.channel = FakeChannel()
+        self.closed = False
+
+    def load_host_keys(self, _path):
+        pass
+
+    def set_missing_host_key_policy(self, _policy):
+        pass
+
+    def connect(self, **_kwargs):
+        if self.connect_started:
+            self.connect_started.set()
+        if self.connect_release:
+            assert self.connect_release.wait(2)
+
+    def get_transport(self):
+        return self.transport
+
+    def invoke_shell(self, **_kwargs):
+        return self.channel
+
+    def close(self):
+        self.closed = True
+        if self.close_started:
+            self.close_started.set()
+        if self.close_release:
+            assert self.close_release.wait(2)
+
+
+@pytest.fixture(autouse=True)
+def clean_session_state():
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions.clear()
+        ssh_manager._pending_connections = 0
+    yield
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions.clear()
+        ssh_manager._pending_connections = 0
+
+
+def _connect(**overrides):
+    kwargs = {
+        'host': 'target.example',
+        'port': 22,
+        'username': 'alice',
+        'password': 'secret',
+        'user_id': 7,
+    }
+    kwargs.update(overrides)
+    return ssh_manager.create_ssh_connection(**kwargs)
+
+
+def _session(client, channel=None, **overrides):
+    session = {
+        'client': client,
+        'channel': channel or client.channel,
+        'connected': True,
+        'use_tmux': False,
+        'tmux_session_name': None,
+        'bastion_client': None,
+    }
+    session.update(overrides)
+    return session
+
+
+def test_pending_connection_reserves_capacity(monkeypatch):
+    connect_started = threading.Event()
+    connect_release = threading.Event()
+    first_client = FakeSSHClient(connect_started, connect_release)
+    created_clients = []
+
+    def client_factory():
+        client = first_client if not created_clients else FakeSSHClient()
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(ssh_manager.config, 'MAX_SESSIONS', 1)
+    monkeypatch.setattr(ssh_manager.paramiko, 'SSHClient', client_factory)
+    monkeypatch.setattr(ssh_manager.time, 'sleep', lambda _seconds: None)
+
+    first_result = []
+    first_thread = threading.Thread(
+        target=lambda: first_result.append(_connect()), daemon=True)
+    first_thread.start()
+    assert connect_started.wait(2)
+
+    second_session_id, second_error = _connect()
+
+    assert second_session_id is None
+    assert second_error == 'Maximum number of sessions reached'
+    assert len(created_clients) == 1
+    with ssh_manager.sessions_lock:
+        assert ssh_manager._pending_connections == 1
+        assert ssh_manager.sessions == {}
+
+    connect_release.set()
+    first_thread.join(2)
+    assert not first_thread.is_alive()
+    assert first_result[0][1] is None
+    assert first_result[0][0] in ssh_manager.sessions
+    with ssh_manager.sessions_lock:
+        assert ssh_manager._pending_connections == 0
+
+
+def test_failed_connection_releases_reserved_capacity(monkeypatch):
+    client = FakeSSHClient()
+
+    def fail_connect(**_kwargs):
+        raise ssh_manager.paramiko.SSHException('boom')
+
+    client.connect = fail_connect
+    monkeypatch.setattr(ssh_manager.config, 'MAX_SESSIONS', 1)
+    monkeypatch.setattr(ssh_manager.paramiko, 'SSHClient', lambda: client)
+
+    session_id, error = _connect()
+
+    assert session_id is None
+    assert error == 'SSH connection failed'
+    with ssh_manager.sessions_lock:
+        assert ssh_manager._pending_connections == 0
+
+
+def test_close_session_does_not_hold_registry_lock_during_io(monkeypatch):
+    close_started = threading.Event()
+    close_release = threading.Event()
+    client = FakeSSHClient(
+        close_started=close_started, close_release=close_release)
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions['session-1'] = _session(client)
+
+    monkeypatch.setattr(
+        'app.sftp_handler.close_sftp_cache', lambda _session_id: None)
+    result = []
+    close_thread = threading.Thread(
+        target=lambda: result.append(ssh_manager.close_session('session-1')),
+        daemon=True,
+    )
+    close_thread.start()
+    assert close_started.wait(2)
+
+    acquired = ssh_manager.sessions_lock.acquire(timeout=0.5)
+    try:
+        assert acquired is True
+        assert 'session-1' not in ssh_manager.sessions
+    finally:
+        if acquired:
+            ssh_manager.sessions_lock.release()
+
+    close_release.set()
+    close_thread.join(2)
+    assert not close_thread.is_alive()
+    assert result == [True]
+
+
+def test_close_session_quotes_tmux_target_and_sets_timeout_first(monkeypatch):
+    kill_channel = FakeChannel()
+    transport = FakeTransport(kill_channel)
+    client = FakeSSHClient(transport=transport)
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions['session-1'] = _session(
+            client,
+            use_tmux=True,
+            tmux_session_name='name; touch /tmp/marker',
+        )
+
+    monkeypatch.setattr(
+        'app.sftp_handler.close_sftp_cache', lambda _session_id: None)
+
+    assert ssh_manager.close_session('session-1', kill_tmux=True) is True
+    assert transport.open_timeout == 2.0
+    assert kill_channel.command == (
+        "tmux kill-session -t 'name; touch /tmp/marker'")
+    assert kill_channel.events[0] == ('settimeout', 2.0)
+    assert kill_channel.events[1][0] == 'exec_command'
+    assert kill_channel.closed is True
+
+
+def test_close_session_closes_everything_when_tmux_exec_fails(monkeypatch):
+    kill_channel = FakeChannel(exec_error=RuntimeError('boom'))
+    transport = FakeTransport(kill_channel)
+    client = FakeSSHClient(transport=transport)
+    interactive_channel = FakeChannel()
+    bastion_client = FakeSSHClient()
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions['session-1'] = _session(
+            client,
+            channel=interactive_channel,
+            use_tmux=True,
+            tmux_session_name='tmux-session',
+            bastion_client=bastion_client,
+        )
+
+    monkeypatch.setattr(
+        'app.sftp_handler.close_sftp_cache', lambda _session_id: None)
+
+    assert ssh_manager.close_session('session-1', kill_tmux=True) is True
+    assert kill_channel.closed is True
+    assert interactive_channel.closed is True
+    assert client.closed is True
+    assert bastion_client.closed is True
+    assert 'session-1' not in ssh_manager.sessions

--- a/tests/test_socket_session_lifecycle.py
+++ b/tests/test_socket_session_lifecycle.py
@@ -1,0 +1,101 @@
+import importlib
+import os
+import tempfile
+import time
+
+import pytest
+
+from app import socketio, ssh_manager
+from app.auth import register_user
+
+
+@pytest.fixture(scope='module')
+def app():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        os.environ['DATA_DIR'] = tmpdir
+        import config
+        importlib.reload(config)
+        config.RATELIMIT_ENABLED = False
+
+        from app import create_app
+        from app.models import db
+
+        test_app = create_app()
+        # Re-register handlers on the Socket.IO server created for this app.
+        from app import socket_events
+        importlib.reload(socket_events)
+        test_app.config['TESTING'] = True
+        test_app.config['WTF_CSRF_ENABLED'] = False
+        with test_app.app_context():
+            db.create_all()
+        yield test_app
+        with test_app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+
+
+def _authenticated_socket(app):
+    username = 'session_race_user'
+    password = 'socket-password-123'
+    with app.app_context():
+        user, error = register_user(username, password)
+        assert error is None
+        user_id = user.id
+
+    http_client = app.test_client()
+    response = http_client.post('/login', data={
+        'username': username,
+        'password': password,
+    })
+    assert response.status_code == 302
+
+    socket_client = socketio.test_client(
+        app, flask_test_client=http_client)
+    assert socket_client.is_connected()
+    socket_client.get_received()
+    return socket_client, user_id
+
+
+def _collect_until(socket_client, event_name, timeout=5):
+    deadline = time.monotonic() + timeout
+    events = []
+    while time.monotonic() < deadline:
+        events.extend(socket_client.get_received())
+        if any(event['name'] == event_name for event in events):
+            break
+        time.sleep(0.02)
+    return events
+
+
+def test_connect_fails_closed_if_created_session_disappears(app, monkeypatch):
+    from app.models import SSHSession
+
+    socket_client, _user_id = _authenticated_socket(app)
+    monkeypatch.setattr(
+        ssh_manager,
+        'create_ssh_connection',
+        lambda **_kwargs: ('vanished-session', None),
+    )
+    monkeypatch.setattr(ssh_manager, 'get_session', lambda _session_id: None)
+
+    try:
+        socket_client.emit('ssh_connect', {
+            'host': 'example.com',
+            'port': 22,
+            'username': 'alice',
+            'password': 'secret',
+            'use_tmux': True,
+            'client_request_id': 'race-request',
+        })
+        events = _collect_until(socket_client, 'ssh_error')
+
+        errors = [event for event in events if event['name'] == 'ssh_error']
+        assert errors
+        assert errors[0]['args'][0]['error'] == 'Connection failed'
+        assert not any(event['name'] == 'ssh_connected' for event in events)
+        with app.app_context():
+            assert SSHSession.query.filter_by(
+                session_id='vanished-session').first() is None
+    finally:
+        if socket_client.is_connected():
+            socket_client.disconnect()


### PR DESCRIPTION
This fixes four pre-existing issues in the SSH session layer. Each is independent; they are grouped here because they all touch the session lifecycle.

## 1. `MAX_SESSIONS` TOCTOU race
Capacity was checked and the session inserted under two *separate* acquisitions of `sessions_lock`, with a blocking network connect in between. Concurrent connects could all pass the check and then all insert, exceeding the cap.

Fixed by reserving a slot with a `_pending_connections` counter (guarded by `sessions_lock`) before connecting, and converting the reservation into a stored session atomically at the end. Every early return / exception path releases the reservation exactly once in `finally`.

## 2. `close_session` held `sessions_lock` across network I/O
The tmux-kill `exec_command`/`recv`, `channel.close()`, `client.close()` and `bastion.close()` all ran while holding `sessions_lock`. A single half-open TCP connection could block every other session operation.

Fixed by popping the session under the lock, then performing all I/O outside it.

## 3. `close_session` leaked the tmux-kill channel + unquoted shell interpolation
- The kill channel was not closed if `exec_command` raised (no `finally`).
- `f'tmux kill-session -t {name}'` interpolated the session name straight into the shell command.
- `settimeout()` was called *after* `exec_command`, so the first `recv` could block.

Fixed by closing the channel in `finally`, quoting the name with `shlex.quote`, and setting the timeout before `exec_command` (also passing `timeout=2.0` to `open_session`).

## 4. `handle_ssh_connect` dereferenced `get_session()` without a None check
`ssh_manager.get_session(session_id).get('tmux_session_name')` could raise `AttributeError` if the session disappeared right after creation. Fixed by fetching the session once, failing closed (emit error + return) if it is missing, and reusing the value for both the DB record and the `ssh_connected` payload.

## Tests
Adds `tests/test_session_lifecycle.py` and `tests/test_socket_session_lifecycle.py` covering all four fixes (capacity reservation/release, lock/IO split, shell-metachar quoting, timeout ordering, channel cleanup on exec failure, and fail-closed connect). Full suite passes.
