### PR TITLE
Chain command set steps with shell-safe execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,22 +249,27 @@ profiles or sets that must be changed first.
 
 After a new SSH connection succeeds, WebSSH resolves the latest referenced
 commands on the server, validates the combined text (maximum 4096 characters),
-and sends the steps to the remote interactive shell in their saved order. The
-commands run on the remote SSH host, never inside the WebSSH container.
-Reattaching to an existing persistent tmux session does not run them again.
+and sends the steps to the remote interactive shell in their saved order.
+Resolved command-set steps are joined with `&&`, so the next block starts only
+when the preceding block succeeds. Line breaks
+inside a free-text step remain unchanged; the exit status of that block's final
+command controls whether the next block starts. The commands run on the remote
+SSH host, never inside the WebSSH container. Reattaching to an existing
+persistent tmux session does not run them again.
 
 Existing profiles that still contain the former free-text startup commands keep
 working after an update. They show a legacy notice in the connection dialog and
 can be converted into a named set. Conversion creates the set first, then links
 the profile; the old text remains stored as a fallback but is ignored while the
-new set reference is valid.
+new set reference is valid. The profile's legacy startup commands retain their
+original multiline behavior until they are converted.
 
-Command output and errors appear normally in the terminal. WebSSH does not
-interpret a command's exit status or stop later lines because an earlier command
-failed; any different control flow still follows the behavior of the remote
-shell and the commands themselves. Treat command sets like any other remote
-administration automation: review their contents and grant WebSSH accounts only
-the SSH privileges they actually need.
+Command output and errors appear normally in the terminal. The remote shell
+evaluates the `&&` chain; WebSSH does not interpret exit statuses itself. Within
+a multiline free-text block, control flow continues to follow the authored text
+and the remote shell. Treat command sets like any other remote administration
+automation: review their contents and grant WebSSH accounts only the SSH
+privileges they actually need.
 
 No additional environment variable, Compose setting, frontend build step, or
 external service is required. Command sets are stored per user in the existing

--- a/app/command_set_manager.py
+++ b/app/command_set_manager.py
@@ -33,39 +33,34 @@ def _prefix_commands_with_sudo(value):
     return '\n'.join(lines)
 
 
-def _ends_with_unquoted_shell_comment(value):
+def _shell_comment_positions(value):
     in_single_quote = False
     in_double_quote = False
     escaped = False
     at_word_start = True
     comment_on_line = False
+    line_number = 0
+    column_number = 0
+    positions = {}
 
     for character in value:
         if comment_on_line:
             if character == '\n':
                 comment_on_line = False
                 at_word_start = True
-            continue
-
-        if escaped:
+        elif escaped:
             escaped = False
             if character != '\n':
                 at_word_start = False
-            continue
-
-        if in_single_quote:
+        elif in_single_quote:
             if character == "'":
                 in_single_quote = False
-            continue
-
-        if in_double_quote:
+        elif in_double_quote:
             if character == '"':
                 in_double_quote = False
             elif character == '\\':
                 escaped = True
-            continue
-
-        if character == '\\':
+        elif character == '\\':
             escaped = True
         elif character == "'":
             in_single_quote = True
@@ -79,14 +74,21 @@ def _ends_with_unquoted_shell_comment(value):
             at_word_start = True
         elif character == '#' and at_word_start:
             comment_on_line = True
+            positions[line_number] = column_number
         else:
             at_word_start = False
 
-    return comment_on_line
+        if character == '\n':
+            line_number += 1
+            column_number = 0
+        else:
+            column_number += 1
+
+    return positions
 
 
 def _prepare_step_for_chaining(value):
-    """Keep a step shell-safe when an ``&&`` separator follows it."""
+    """Trim boundary padding and make a comment-only step a shell no-op."""
     lines = value.split('\n')
     while lines and not lines[-1].strip():
         lines.pop()
@@ -94,14 +96,51 @@ def _prepare_step_for_chaining(value):
         return ':'
 
     trimmed = '\n'.join(lines)
-    if not _ends_with_unquoted_shell_comment(trimmed):
-        return trimmed
-
     has_command = any(
         line.strip() and not line.lstrip().startswith('#') for line in lines
     )
-    body = trimmed if has_command else f':\n{trimmed}'
-    return f'{{\n{body}\n}}'
+    return trimmed if has_command else f':\n{trimmed}'
+
+
+def _append_step_separator(value):
+    """Append a boundary without letting trailing comments consume it."""
+    lines = value.split('\n')
+    comment_positions = _shell_comment_positions(value)
+    last_line = len(lines) - 1
+    if last_line not in comment_positions:
+        return f'{value} && '
+
+    command_line = None
+    command_text = None
+    comment_text = None
+    for line_number in range(last_line, -1, -1):
+        comment_at = comment_positions.get(line_number)
+        before_comment = (
+            lines[line_number][:comment_at]
+            if comment_at is not None
+            else lines[line_number]
+        )
+        if before_comment.strip():
+            command_line = line_number
+            command_text = before_comment.rstrip()
+            comment_text = (
+                lines[line_number][comment_at:]
+                if comment_at is not None
+                else None
+            )
+            break
+
+    if command_line is None:
+        lines.insert(0, ': &&')
+    else:
+        if command_text.endswith(';'):
+            command_text = command_text[:-1].rstrip()
+        lines[command_line] = f'{command_text} &&'
+        if comment_text is not None:
+            lines[command_line] += f' {comment_text}'
+
+    joined = '\n'.join(lines)
+    return f'{joined}\n'
 
 
 def _command_sets_file(user_id):
@@ -356,9 +395,12 @@ def resolve_command_set(user_id, command_set_id):
         resolved_parts = [
             _prefix_commands_with_sudo(part) for part in resolved_parts
         ]
-    resolved = ' && '.join(
+    resolved_parts = [
         _prepare_step_for_chaining(part) for part in resolved_parts
-    )
+    ]
+    resolved = ''.join(
+        _append_step_separator(part) for part in resolved_parts[:-1]
+    ) + resolved_parts[-1]
     resolved, error = normalize_startup_commands(resolved)
     if error:
         return None, error

--- a/app/command_set_manager.py
+++ b/app/command_set_manager.py
@@ -139,10 +139,10 @@ def _normalize_steps(steps, commands):
 
         return None, None, f'Command set step {position} has an invalid type'
 
-    resolved, error = normalize_startup_commands('\n'.join(resolved_parts))
+    _validated, error = normalize_startup_commands('\n'.join(resolved_parts))
     if error:
         return None, None, error
-    return normalized_steps, resolved, None
+    return normalized_steps, resolved_parts, None
 
 
 def _validate_payload(user_id, payload, existing_sets):
@@ -171,7 +171,7 @@ def _validate_payload(user_id, payload, existing_sets):
     commands, error = _command_index(user_id)
     if error:
         return None, error
-    steps, _resolved, error = _normalize_steps(payload.get('steps'), commands)
+    steps, _resolved_parts, error = _normalize_steps(payload.get('steps'), commands)
     if error:
         return None, error
     return {
@@ -274,17 +274,22 @@ def resolve_command_set(user_id, command_set_id):
     commands, error = _command_index(user_id)
     if error:
         return None, error
-    _steps, resolved, error = _normalize_steps(command_set.get('steps'), commands)
+    _steps, resolved_parts, error = _normalize_steps(
+        command_set.get('steps'), commands
+    )
     if error:
         if 'step ' in error:
             return None, f"Command set '{command_set['name']}' {error.removeprefix('Command set ').lower()}"
         return None, error
     if command_set.get('use_sudo') is True:
-        resolved = _prefix_commands_with_sudo(resolved)
-        resolved, error = normalize_startup_commands(resolved)
-        if error:
-            return None, error
-    return resolved, error
+        resolved_parts = [
+            _prefix_commands_with_sudo(part) for part in resolved_parts
+        ]
+    resolved = ' && '.join(part.rstrip('\n') for part in resolved_parts)
+    resolved, error = normalize_startup_commands(resolved)
+    if error:
+        return None, error
+    return resolved, None
 
 
 def get_command_usage(user_id, command_id):

--- a/app/command_set_manager.py
+++ b/app/command_set_manager.py
@@ -43,6 +43,7 @@ def _shell_token_positions(value):
     column_number = 0
     comment_positions = {}
     semicolon_positions = set()
+    ampersand_positions = set()
 
     for character in value:
         if comment_on_line:
@@ -74,7 +75,10 @@ def _shell_token_positions(value):
         elif character == ';':
             semicolon_positions.add((line_number, column_number))
             at_word_start = True
-        elif character in '&|()<>':
+        elif character == '&':
+            ampersand_positions.add((line_number, column_number))
+            at_word_start = True
+        elif character in '|()<>':
             at_word_start = True
         elif character == '#' and at_word_start:
             comment_on_line = True
@@ -88,7 +92,16 @@ def _shell_token_positions(value):
         else:
             column_number += 1
 
-    return comment_positions, semicolon_positions
+    return comment_positions, semicolon_positions, ampersand_positions
+
+
+def _append_operator(command_text, line_number, semicolons, ampersands):
+    terminal_position = (line_number, len(command_text) - 1)
+    if terminal_position in semicolons:
+        return f'{command_text[:-1].rstrip()} &&'
+    if terminal_position in ampersands:
+        return f'{command_text} : &&'
+    return f'{command_text} &&'
 
 
 def _prepare_step_for_chaining(value):
@@ -109,10 +122,17 @@ def _prepare_step_for_chaining(value):
 def _append_step_separator(value):
     """Append a boundary without letting trailing comments consume it."""
     lines = value.split('\n')
-    comment_positions, semicolon_positions = _shell_token_positions(value)
+    comment_positions, semicolon_positions, ampersand_positions = (
+        _shell_token_positions(value)
+    )
     last_line = len(lines) - 1
     if last_line not in comment_positions:
-        return f'{value} && '
+        lines[last_line] = _append_operator(
+            lines[last_line], last_line,
+            semicolon_positions, ampersand_positions,
+        )
+        joined = '\n'.join(lines)
+        return f'{joined} '
 
     command_line = None
     command_text = None
@@ -137,10 +157,10 @@ def _append_step_separator(value):
     if command_line is None:
         lines.insert(0, ': &&')
     else:
-        semicolon_at = (command_line, len(command_text) - 1)
-        if command_text.endswith(';') and semicolon_at in semicolon_positions:
-            command_text = command_text[:-1].rstrip()
-        lines[command_line] = f'{command_text} &&'
+        lines[command_line] = _append_operator(
+            command_text, command_line,
+            semicolon_positions, ampersand_positions,
+        )
         if comment_text is not None:
             lines[command_line] += f' {comment_text}'
 

--- a/app/command_set_manager.py
+++ b/app/command_set_manager.py
@@ -33,6 +33,58 @@ def _prefix_commands_with_sudo(value):
     return '\n'.join(lines)
 
 
+def _ends_with_unquoted_shell_comment(value):
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    at_word_start = True
+    comment_on_line = False
+
+    for character in value:
+        if comment_on_line:
+            if character == '\n':
+                comment_on_line = False
+                at_word_start = True
+            continue
+
+        if escaped:
+            escaped = False
+            if character != '\n':
+                at_word_start = False
+            continue
+
+        if in_single_quote:
+            if character == "'":
+                in_single_quote = False
+            continue
+
+        if in_double_quote:
+            if character == '"':
+                in_double_quote = False
+            elif character == '\\':
+                escaped = True
+            continue
+
+        if character == '\\':
+            escaped = True
+        elif character == "'":
+            in_single_quote = True
+            at_word_start = False
+        elif character == '"':
+            in_double_quote = True
+            at_word_start = False
+        elif character == '\n' or character.isspace():
+            at_word_start = True
+        elif character in ';&|()<>':
+            at_word_start = True
+        elif character == '#' and at_word_start:
+            comment_on_line = True
+        else:
+            at_word_start = False
+
+    return comment_on_line
+
+
 def _prepare_step_for_chaining(value):
     """Keep a step shell-safe when an ``&&`` separator follows it."""
     lines = value.split('\n')
@@ -42,7 +94,7 @@ def _prepare_step_for_chaining(value):
         return ':'
 
     trimmed = '\n'.join(lines)
-    if not lines[-1].lstrip().startswith('#'):
+    if not _ends_with_unquoted_shell_comment(trimmed):
         return trimmed
 
     has_command = any(

--- a/app/command_set_manager.py
+++ b/app/command_set_manager.py
@@ -33,7 +33,7 @@ def _prefix_commands_with_sudo(value):
     return '\n'.join(lines)
 
 
-def _shell_comment_positions(value):
+def _shell_token_positions(value):
     in_single_quote = False
     in_double_quote = False
     escaped = False
@@ -41,7 +41,8 @@ def _shell_comment_positions(value):
     comment_on_line = False
     line_number = 0
     column_number = 0
-    positions = {}
+    comment_positions = {}
+    semicolon_positions = set()
 
     for character in value:
         if comment_on_line:
@@ -70,11 +71,14 @@ def _shell_comment_positions(value):
             at_word_start = False
         elif character == '\n' or character.isspace():
             at_word_start = True
-        elif character in ';&|()<>':
+        elif character == ';':
+            semicolon_positions.add((line_number, column_number))
+            at_word_start = True
+        elif character in '&|()<>':
             at_word_start = True
         elif character == '#' and at_word_start:
             comment_on_line = True
-            positions[line_number] = column_number
+            comment_positions[line_number] = column_number
         else:
             at_word_start = False
 
@@ -84,7 +88,7 @@ def _shell_comment_positions(value):
         else:
             column_number += 1
 
-    return positions
+    return comment_positions, semicolon_positions
 
 
 def _prepare_step_for_chaining(value):
@@ -105,7 +109,7 @@ def _prepare_step_for_chaining(value):
 def _append_step_separator(value):
     """Append a boundary without letting trailing comments consume it."""
     lines = value.split('\n')
-    comment_positions = _shell_comment_positions(value)
+    comment_positions, semicolon_positions = _shell_token_positions(value)
     last_line = len(lines) - 1
     if last_line not in comment_positions:
         return f'{value} && '
@@ -133,7 +137,8 @@ def _append_step_separator(value):
     if command_line is None:
         lines.insert(0, ': &&')
     else:
-        if command_text.endswith(';'):
+        semicolon_at = (command_line, len(command_text) - 1)
+        if command_text.endswith(';') and semicolon_at in semicolon_positions:
             command_text = command_text[:-1].rstrip()
         lines[command_line] = f'{command_text} &&'
         if comment_text is not None:

--- a/app/command_set_manager.py
+++ b/app/command_set_manager.py
@@ -33,6 +33,25 @@ def _prefix_commands_with_sudo(value):
     return '\n'.join(lines)
 
 
+def _prepare_step_for_chaining(value):
+    """Keep a step shell-safe when an ``&&`` separator follows it."""
+    lines = value.split('\n')
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if not lines:
+        return ':'
+
+    trimmed = '\n'.join(lines)
+    if not lines[-1].lstrip().startswith('#'):
+        return trimmed
+
+    has_command = any(
+        line.strip() and not line.lstrip().startswith('#') for line in lines
+    )
+    body = trimmed if has_command else f':\n{trimmed}'
+    return f'{{\n{body}\n}}'
+
+
 def _command_sets_file(user_id):
     from .models import User
 
@@ -285,7 +304,9 @@ def resolve_command_set(user_id, command_set_id):
         resolved_parts = [
             _prefix_commands_with_sudo(part) for part in resolved_parts
         ]
-    resolved = ' && '.join(part.rstrip('\n') for part in resolved_parts)
+    resolved = ' && '.join(
+        _prepare_step_for_chaining(part) for part in resolved_parts
+    )
     resolved, error = normalize_startup_commands(resolved)
     if error:
         return None, error

--- a/tests/test_command_set_manager.py
+++ b/tests/test_command_set_manager.py
@@ -414,6 +414,50 @@ def test_resolve_removes_only_unescaped_semicolon_before_comment(
 
 
 @pytest.mark.parametrize(
+    ('command', 'use_sudo', 'expected'),
+    [
+        ('echo ready;', False, 'echo ready && pwd'),
+        ('echo ready;', True, 'sudo echo ready && sudo pwd'),
+        ('sleep 0 &', False, 'sleep 0 & : && pwd'),
+        ('sleep 0 &', True, 'sudo sleep 0 & : && sudo pwd'),
+        (r'printf \&', False, r'printf \& && pwd'),
+        (r'printf \&', True, r'sudo printf \& && sudo pwd'),
+        ('sleep 0 & # note', False, 'sleep 0 & : && # note\npwd'),
+        ('sleep 0 & # note', True, 'sudo sleep 0 & : && # note\nsudo pwd'),
+        (r'printf \& # note', False, 'printf \\& && # note\npwd'),
+        (r'printf \& # note', True, 'sudo printf \\& && # note\nsudo pwd'),
+    ],
+)
+def test_resolve_handles_terminal_list_operators(
+    app, monkeypatch, command, use_sudo, expected
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Terminal operator {command} {use_sudo}',
+            'use_sudo': use_sudo,
+            'steps': [
+                {'type': 'inline', 'command': command},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
     ('use_sudo', 'expected'),
     [
         (False, 'echo first && : &&\n# note\npwd'),

--- a/tests/test_command_set_manager.py
+++ b/tests/test_command_set_manager.py
@@ -1,5 +1,7 @@
 """Tests for named post-connect command sets."""
 import json
+import shutil
+import subprocess
 
 import pytest
 
@@ -272,8 +274,8 @@ def test_resolve_trims_trailing_whitespace_at_step_boundaries(
 @pytest.mark.parametrize(
     ('use_sudo', 'expected'),
     [
-        (False, '{\necho ready\n# note\n} && pwd'),
-        (True, '{\nsudo echo ready\n# note\n} && sudo pwd'),
+        (False, 'echo ready &&\n# note\npwd'),
+        (True, 'sudo echo ready &&\n# note\nsudo pwd'),
     ],
 )
 def test_resolve_preserves_trailing_comment_without_hiding_next_step(
@@ -308,10 +310,10 @@ def test_resolve_preserves_trailing_comment_without_hiding_next_step(
 @pytest.mark.parametrize(
     ('command', 'use_sudo', 'expected'),
     [
-        ('echo ready # note', False, '{\necho ready # note\n} && pwd'),
-        ('echo ready; # note', False, '{\necho ready; # note\n} && pwd'),
-        ('echo ready # note', True, '{\nsudo echo ready # note\n} && sudo pwd'),
-        ('echo ready; # note', True, '{\nsudo echo ready; # note\n} && sudo pwd'),
+        ('echo ready # note', False, 'echo ready && # note\npwd'),
+        ('echo ready; # note', False, 'echo ready && # note\npwd'),
+        ('echo ready # note', True, 'sudo echo ready && # note\nsudo pwd'),
+        ('echo ready; # note', True, 'sudo echo ready && # note\nsudo pwd'),
     ],
 )
 def test_resolve_preserves_inline_comment_without_hiding_next_step(
@@ -378,8 +380,8 @@ def test_resolve_does_not_treat_literal_hash_as_shell_comment(
 @pytest.mark.parametrize(
     ('use_sudo', 'expected'),
     [
-        (False, 'echo first && {\n:\n# note\n} && pwd'),
-        (True, 'sudo echo first && {\n:\n# note\n} && sudo pwd'),
+        (False, 'echo first && : &&\n# note\npwd'),
+        (True, 'sudo echo first && : &&\n# note\nsudo pwd'),
     ],
 )
 def test_resolve_treats_comment_only_step_as_successful_noop(
@@ -410,6 +412,51 @@ def test_resolve_treats_comment_only_step_as_successful_noop(
 
     assert error is None
     assert resolved == expected
+
+
+def test_trailing_comment_boundary_preserves_errexit_semantics(app, monkeypatch):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': 'Preserve errexit',
+            'steps': [
+                {
+                    'type': 'inline',
+                    'command': 'set -e\nfalse\necho SHOULD_NOT_RUN\n# note',
+                },
+                {'type': 'inline', 'command': 'echo NEXT_SHOULD_NOT_RUN'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == (
+        'set -e\nfalse\necho SHOULD_NOT_RUN &&\n'
+        '# note\necho NEXT_SHOULD_NOT_RUN'
+    )
+
+    shell = shutil.which('sh')
+    if shell is None:
+        pytest.skip('POSIX shell is not available')
+    completed = subprocess.run(
+        [shell, '-c', resolved],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode != 0
+    assert 'SHOULD_NOT_RUN' not in completed.stdout
+    assert 'NEXT_SHOULD_NOT_RUN' not in completed.stdout
 
 
 def test_resolve_sudo_prefixes_commands_without_changing_non_commands(app, monkeypatch):

--- a/tests/test_command_set_manager.py
+++ b/tests/test_command_set_manager.py
@@ -306,6 +306,76 @@ def test_resolve_preserves_trailing_comment_without_hiding_next_step(
 
 
 @pytest.mark.parametrize(
+    ('command', 'use_sudo', 'expected'),
+    [
+        ('echo ready # note', False, '{\necho ready # note\n} && pwd'),
+        ('echo ready; # note', False, '{\necho ready; # note\n} && pwd'),
+        ('echo ready # note', True, '{\nsudo echo ready # note\n} && sudo pwd'),
+        ('echo ready; # note', True, '{\nsudo echo ready; # note\n} && sudo pwd'),
+    ],
+)
+def test_resolve_preserves_inline_comment_without_hiding_next_step(
+    app, monkeypatch, command, use_sudo, expected
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Inline comment {command} {use_sudo}',
+            'use_sudo': use_sudo,
+            'steps': [
+                {'type': 'inline', 'command': command},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
+    'command',
+    ["echo '#'", r'echo \#', 'echo value#suffix'],
+)
+def test_resolve_does_not_treat_literal_hash_as_shell_comment(
+    app, monkeypatch, command
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Literal hash {command}',
+            'steps': [
+                {'type': 'inline', 'command': command},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == f'{command} && pwd'
+
+
+@pytest.mark.parametrize(
     ('use_sudo', 'expected'),
     [
         (False, 'echo first && {\n:\n# note\n} && pwd'),

--- a/tests/test_command_set_manager.py
+++ b/tests/test_command_set_manager.py
@@ -378,6 +378,42 @@ def test_resolve_does_not_treat_literal_hash_as_shell_comment(
 
 
 @pytest.mark.parametrize(
+    ('command', 'expected'),
+    [
+        (r'printf \; # note', r'printf \; && # note' + '\npwd'),
+        (r'printf \\; # note', r'printf \\ && # note' + '\npwd'),
+        (r'printf \\\; # note', r'printf \\\; && # note' + '\npwd'),
+    ],
+)
+def test_resolve_removes_only_unescaped_semicolon_before_comment(
+    app, monkeypatch, command, expected
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Semicolon parity {command}',
+            'steps': [
+                {'type': 'inline', 'command': command},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
     ('use_sudo', 'expected'),
     [
         (False, 'echo first && : &&\n# note\npwd'),

--- a/tests/test_command_set_manager.py
+++ b/tests/test_command_set_manager.py
@@ -201,7 +201,36 @@ def test_resolve_preserves_order_and_parameter_semantics(app, monkeypatch):
         resolved, error = command_set_manager.resolve_command_set(user_id, created['id'])
 
     assert error is None
-    assert resolved == 'echo default\necho\necho custom\necho €\npwd\npwd'
+    assert resolved == (
+        'echo default && echo && echo custom && '
+        'echo €\npwd && pwd'
+    )
+
+
+def test_resolve_chains_steps_without_rewriting_internal_inline_lines(app, monkeypatch):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': 'Mixed blocks',
+            'steps': [
+                {'type': 'inline', 'command': 'cd /srv\necho ready\n'},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == 'cd /srv\necho ready && pwd'
 
 
 def test_resolve_sudo_prefixes_commands_without_changing_non_commands(app, monkeypatch):
@@ -238,7 +267,7 @@ def test_resolve_sudo_prefixes_commands_without_changing_non_commands(app, monke
 
     assert resolve_error is None
     assert resolved == (
-        'sudo echo default\n'
+        'sudo echo default && '
         '  sudo systemctl restart nginx\n'
         '\n'
         '# note\n'
@@ -263,6 +292,31 @@ def test_resolve_revalidates_length_after_sudo_prefix(app, monkeypatch):
             'name': 'Too long after prefix',
             'use_sudo': True,
             'steps': [{'type': 'inline', 'command': 'x' * 4092}],
+        })
+        assert error is None
+        resolved, resolve_error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert resolved is None
+    assert resolve_error == 'Startup commands must not exceed 4096 characters'
+
+
+def test_resolve_revalidates_length_after_step_separators(app, monkeypatch):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager, 'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': 'Too long after separators',
+            'steps': [
+                {'type': 'inline', 'command': 'x' * 2047},
+                {'type': 'inline', 'command': 'y' * 2047},
+            ],
         })
         assert error is None
         resolved, resolve_error = command_set_manager.resolve_command_set(

--- a/tests/test_command_set_manager.py
+++ b/tests/test_command_set_manager.py
@@ -233,6 +233,115 @@ def test_resolve_chains_steps_without_rewriting_internal_inline_lines(app, monke
     assert resolved == 'cd /srv\necho ready && pwd'
 
 
+@pytest.mark.parametrize(
+    ('use_sudo', 'expected'),
+    [
+        (False, 'echo ready && pwd'),
+        (True, 'sudo echo ready && sudo pwd'),
+    ],
+)
+def test_resolve_trims_trailing_whitespace_at_step_boundaries(
+    app, monkeypatch, use_sudo, expected
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Trailing whitespace {use_sudo}',
+            'use_sudo': use_sudo,
+            'steps': [
+                {'type': 'inline', 'command': 'echo ready\n   '},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
+    ('use_sudo', 'expected'),
+    [
+        (False, '{\necho ready\n# note\n} && pwd'),
+        (True, '{\nsudo echo ready\n# note\n} && sudo pwd'),
+    ],
+)
+def test_resolve_preserves_trailing_comment_without_hiding_next_step(
+    app, monkeypatch, use_sudo, expected
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Trailing comment {use_sudo}',
+            'use_sudo': use_sudo,
+            'steps': [
+                {'type': 'inline', 'command': 'echo ready\n# note'},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
+    ('use_sudo', 'expected'),
+    [
+        (False, 'echo first && {\n:\n# note\n} && pwd'),
+        (True, 'sudo echo first && {\n:\n# note\n} && sudo pwd'),
+    ],
+)
+def test_resolve_treats_comment_only_step_as_successful_noop(
+    app, monkeypatch, use_sudo, expected
+):
+    from app import command_manager, command_set_manager
+
+    monkeypatch.setattr(
+        command_manager,
+        'get_all_commands',
+        lambda user_id, os_filter=None: library_commands(),
+    )
+    user_id = create_user(app)
+    with app.app_context():
+        created, error = command_set_manager.upsert_command_set(user_id, {
+            'name': f'Comment only {use_sudo}',
+            'use_sudo': use_sudo,
+            'steps': [
+                {'type': 'inline', 'command': 'echo first'},
+                {'type': 'inline', 'command': '# note'},
+                {'type': 'library', 'command_id': 'cmd-pwd'},
+            ],
+        })
+        assert error is None
+        resolved, error = command_set_manager.resolve_command_set(
+            user_id, created['id']
+        )
+
+    assert error is None
+    assert resolved == expected
+
+
 def test_resolve_sudo_prefixes_commands_without_changing_non_commands(app, monkeypatch):
     from app import command_manager, command_set_manager
 

--- a/tests/test_command_set_socket_events.py
+++ b/tests/test_command_set_socket_events.py
@@ -257,7 +257,7 @@ def test_ssh_connect_resolves_command_set_and_ignores_legacy_text(app, monkeypat
             'startup_commands': 'echo must-not-run',
         })
 
-    assert calls[0]['startup_commands'] == 'sudo echo first\nsudo echo second'
+    assert calls[0]['startup_commands'] == 'sudo echo first && sudo echo second'
 
 
 def test_sudo_expansion_limit_stops_before_connection_validation(app, monkeypatch):

--- a/tests/test_command_set_ui.py
+++ b/tests/test_command_set_ui.py
@@ -189,5 +189,8 @@ def test_readme_documents_command_set_lifecycle_and_upgrade_behavior():
         'Existing command sets from an earlier version',
         'sets produced by legacy conversion',
         'does not store or answer a sudo password',
+        'joined with `&&`',
+        'inside a free-text step remain unchanged',
+        'legacy startup commands',
     ):
         assert phrase in readme


### PR DESCRIPTION
## What changed

- Resolve named command-set steps as separate blocks and join only their boundaries with `&&`.
- Apply the optional `sudo` prefix per block before chaining.
- Preserve line breaks and authored control flow inside free-text blocks.
- Keep trailing comments, whitespace, escaped separators, `set -e`, and terminal `;`/`&` shell-safe.
- Revalidate the final 4096-character limit after prefixes and separators are added.
- Document the resulting execution behavior and legacy-profile compatibility.

For example, the two library entries `apt update` and `apt upgrade -y` with sudo enabled now resolve to:

```sh
sudo apt update && sudo apt upgrade -y
```

## Why

Command-set blocks were previously delivered as separate terminal lines. In an interactive SSH shell this could leave later blocks unexecuted instead of treating the set as one ordered operation. The new boundary handling lets the remote shell start the next block only when the preceding block succeeds, without rewriting commands inside a free-text block.

Existing profiles with legacy multiline startup commands retain their previous behavior until they are converted to a named command set.

This implements the behavior discussed in [Discussion #48](https://github.com/bifrost0x/webssh/discussions/48).

## Validation

- `266 passed, 28 skipped` Python tests
- `5/5` Node tests
- JavaScript syntax checks for all frontend files
- POSIX shell syntax and execution checks covering comments, `set -e`, escaped separators, and terminal `;`/`&`
- `docker compose config --quiet`
- Independent final code review with no remaining findings