### PR TITLE
test: isolate secret rotation CLI fixtures

### DIFF
--- a/tests/test_secret_rotation.py
+++ b/tests/test_secret_rotation.py
@@ -317,11 +317,14 @@ def test_rotate_secret_cli_generates_and_persists_new_secret(app, monkeypatch):
     import config
 
     data_dir = Path(config.DATA_DIR)
-    old_secret = 'unit-test-cli-rotation-key-material'
-    monkeypatch.setattr(config, 'SECRET_KEY', old_secret)
     (data_dir / 'secret_key').write_text(
-        old_secret + '\n',
+        'unit-test-cli-rotation-key-material\n',
         encoding='utf-8',
+    )
+    monkeypatch.setattr(
+        config,
+        'SECRET_KEY',
+        'unit-test-cli-rotation-key-material',
     )
 
     result = app.test_cli_runner().invoke(
@@ -333,7 +336,7 @@ def test_rotate_secret_cli_generates_and_persists_new_secret(app, monkeypatch):
         encoding='utf-8',
     ).rstrip('\n')
     assert new_secret
-    assert new_secret != old_secret
+    assert new_secret != 'unit-test-cli-rotation-key-material'
     assert 'restart' in result.output.lower()
     assert len(list(data_dir.parent.glob(
         f'{data_dir.name}-pre-rotation-*.zip'

--- a/tests/test_secret_rotation.py
+++ b/tests/test_secret_rotation.py
@@ -303,24 +303,22 @@ def test_rotate_secret_cli_requires_offline_ack(app):
     import config
 
     data_dir = Path(config.DATA_DIR)
-    (data_dir / 'secret_key').write_text(
-        config.SECRET_KEY + '\n',
-        encoding='utf-8',
-    )
-    before = (data_dir / 'secret_key').read_bytes()
+    secret_path = data_dir / 'secret_key'
+    assert not secret_path.exists()
 
     result = app.test_cli_runner().invoke(args=['rotate-secret-key'])
 
     assert result.exit_code != 0
     assert 'confirm-offline' in result.output
-    assert (data_dir / 'secret_key').read_bytes() == before
+    assert not secret_path.exists()
 
 
-def test_rotate_secret_cli_generates_and_persists_new_secret(app):
+def test_rotate_secret_cli_generates_and_persists_new_secret(app, monkeypatch):
     import config
 
     data_dir = Path(config.DATA_DIR)
-    old_secret = config.SECRET_KEY
+    old_secret = 'unit-test-cli-rotation-key-material'
+    monkeypatch.setattr(config, 'SECRET_KEY', old_secret)
     (data_dir / 'secret_key').write_text(
         old_secret + '\n',
         encoding='utf-8',


### PR DESCRIPTION
## What changed

- stop the offline-confirmation test from copying the runtime `SECRET_KEY` into a temporary file
- isolate the successful rotation CLI test with fixed test-only key material via `monkeypatch`

## Why

CodeQL alerts 6 and 7 traced `config.SECRET_KEY` into temporary files created by two tests. The production secret-rotation implementation was not involved in either sink, so the fix removes the unnecessary test coupling without changing production encryption, persistence, or permissions.

## Validation

- `pytest tests/test_secret_rotation.py -q`: 13 passed
- `pytest tests -q` on Python 3.14: 1243 passed, 33 skipped
- `git diff --check`