### PR TITLE
fix: preserve key usability after mutations

### DIFF
--- a/static/js/profile-manager.js
+++ b/static/js/profile-manager.js
@@ -137,7 +137,9 @@ const ProfileManager = {
         if (!summary || !summary.id) return;
         const exists = this.keys.some(key => key.id === summary.id);
         this.setKeys(exists
-            ? this.keys.map(key => key.id === summary.id ? summary : key)
+            ? this.keys.map(key => key.id === summary.id
+                ? {...key, ...summary}
+                : key)
             : [...this.keys, summary]);
     },
 

--- a/tests/js/profile-manager.test.js
+++ b/tests/js/profile-manager.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadProfileManager() {
+    const source = fs.readFileSync(path.join(
+        __dirname,
+        '../../static/js/profile-manager.js',
+    ), 'utf8');
+    const context = { window: {} };
+
+    vm.createContext(context);
+    vm.runInContext(source, context);
+
+    const manager = context.window.ProfileManager;
+    manager.setKeys = function setKeys(keys) {
+        this.keys = keys;
+    };
+    return manager;
+}
+
+test('partial key mutation replies preserve transient usability', () => {
+    const manager = loadProfileManager();
+    manager.keys = [{
+        id: 'key-1',
+        name: 'Original name',
+        type: 'Ed25519',
+        usable: true,
+    }];
+
+    manager.upsertKeySummary({
+        id: 'key-1',
+        name: 'Renamed key',
+        type: 'Ed25519',
+    });
+
+    assert.equal(manager.keys[0].name, 'Renamed key');
+    assert.equal(manager.keys[0].usable, true);
+});


### PR DESCRIPTION
## Summary

- preserve transient key usability when partial upload or rename acknowledgements update an existing key summary
- add a focused regression test for the mutation acknowledgement sequence

## Root cause

Mutation acknowledgements contain stored key metadata but not the transient `usable` field. Replacing the complete key summary with that partial payload made saved key profiles temporarily fall back to review mode.

## Validation

- `npm.cmd run test:js` - 69 passed
- `node --check static/js/profile-manager.js`
- `git diff --check origin/main...HEAD`

Follow-up to #69.