### PR TITLE
Make dependency lock checks line-ending independent

### DIFF
--- a/scripts/lock_requirements.ps1
+++ b/scripts/lock_requirements.ps1
@@ -37,15 +37,15 @@ function New-LockFile {
     return $temporaryLock
 }
 
-function Test-ByteEqual {
+function Test-TextEqual {
     param(
         [Parameter(Mandatory)] [string]$Expected,
         [Parameter(Mandatory)] [string]$Actual
     )
 
-    [byte[]]$expectedBytes = [System.IO.File]::ReadAllBytes($Expected)
-    [byte[]]$actualBytes = [System.IO.File]::ReadAllBytes($Actual)
-    return [System.Linq.Enumerable]::SequenceEqual($expectedBytes, $actualBytes)
+    $expectedText = [System.IO.File]::ReadAllText($Expected).Replace("`r`n", "`n")
+    $actualText = [System.IO.File]::ReadAllText($Actual).Replace("`r`n", "`n")
+    return $expectedText -ceq $actualText
 }
 
 try {
@@ -57,7 +57,7 @@ try {
     foreach ($lock in @($runtimeLock, $testLock, $graphLock)) {
         $committedLock = Join-Path $projectRoot (Split-Path $lock -Leaf)
         if ($Check) {
-            if (-not (Test-ByteEqual -Expected $committedLock -Actual $lock)) {
+            if (-not (Test-TextEqual -Expected $committedLock -Actual $lock)) {
                 throw "$committedLock is out of date. Run pwsh -File scripts/lock_requirements.ps1 and commit the result."
             }
         }

--- a/tests/test_dependency_policy.py
+++ b/tests/test_dependency_policy.py
@@ -168,6 +168,14 @@ def test_lock_generator_reuses_committed_pins_unless_upgrade_is_explicit():
     assert 'if ($Upgrade) { @("--upgrade") } else { @() }' in script
 
 
+def test_lock_generator_compares_text_independent_of_checkout_line_endings():
+    script = Path("scripts/lock_requirements.ps1").read_text(encoding="utf-8")
+
+    assert "function Test-TextEqual" in script
+    assert '.Replace("`r`n", "`n")' in script
+    assert "Test-ByteEqual" not in script
+
+
 @pytest.mark.parametrize("path", ["requirements.txt", "requirements-test.txt"])
 def test_runtime_locks_exclude_vulnerable_cryptography_versions(path):
     """CVE-2026-69247 affects cryptography 44 through 49."""


### PR DESCRIPTION
## What changed

- compare generated Python locks as normalized UTF-8 text instead of raw bytes
- keep every dependency, marker, and hash difference strict while treating CRLF and LF as equivalent
- add a regression policy test for cross-platform checkout line endings

## Root cause

Git may check out text files with CRLF on Windows, while uv emits LF. The previous byte comparison therefore reported identical locks as stale on a fresh Windows checkout.

## Validation

- dependency lock check passed with uv 0.10.9
- 30 dependency policy tests passed
- git diff --check passed