### PR TITLE
Fix account menu capture test

### DIFF
--- a/tests/e2e/product-captures.spec.js
+++ b/tests/e2e/product-captures.spec.js
@@ -887,7 +887,7 @@ test('captures a contained multi-session workspace and the current theme menu', 
     await captureDesktopStill(page, 'multi.png', testInfo);
 
     await page.locator('#accountBtnHeader').click();
-    await page.locator('#accountThemeBtn').click();
+    await page.locator('#accountSettingsBtn').click();
     await expect(page.locator('#settingsModal')).toHaveClass(/show/);
     await expect(page.locator('#settingsThemeSelect option')).toHaveCount(10);
     await expect(page.locator('#settingsThemeSelect')).toContainText('Glass Ops');


### PR DESCRIPTION
## Summary

- update the product capture test to open Settings through the current account-menu action

## Root cause

PR #82 intentionally removed `#accountThemeBtn`, but `product-captures.spec.js` still clicked that obsolete selector. The browser E2E job therefore timed out while all other checks passed.

## Validation

- `npx playwright test tests/e2e/product-captures.spec.js --grep "captures a contained multi-session workspace and the current theme menu" --forbid-only` - 1 passed
- `git diff --check`
