### PR TITLE
Open SFTP by default on wide desktops

### DIFF
--- a/static/js/session-workspace-ui.js
+++ b/static/js/session-workspace-ui.js
@@ -151,10 +151,13 @@
             container: elements.filesMount,
         });
         const insightsController = insightsModule.createController({ socket, render: renderInsights });
+        const desktopQuery = root.matchMedia('(min-width: 851px)');
+        const wideDesktopQuery = root.matchMedia('(min-width: 1440px)');
         coordinator = workspaceModule.createCoordinator({
             filesPanel: filesController,
             insights: insightsController,
-            isDesktop: () => root.matchMedia('(min-width: 851px)').matches,
+            isDesktop: () => desktopQuery.matches,
+            isWideDesktop: () => wideDesktopQuery.matches,
             render(state) {
                 elements.toggle.disabled = !state.sftpEnabled;
                 elements.toggle.setAttribute('aria-pressed', String(state.sftpOpen));
@@ -170,6 +173,7 @@
                 layout: sessionManager.layout,
                 sessionId: activeId,
                 session: activeId ? sessionManager.getSession(activeId) : null,
+                sessionCount: sessionManager.getAllSessions().length,
             });
         }
 
@@ -179,7 +183,6 @@
             if (coordinator.getState().sftpOpen) coordinator.toggleSftp();
         });
 
-        const desktopQuery = root.matchMedia('(min-width: 851px)');
         function syncInsightsVisibility() {
             coordinator.setVisible(
                 documentRef.visibilityState !== 'hidden'
@@ -193,6 +196,7 @@
             syncInsightsVisibility();
             sync();
         });
+        wideDesktopQuery.addEventListener?.('change', sync);
         if (elements.notepadPanel && root.MutationObserver) {
             new MutationObserver(syncInsightsVisibility).observe(elements.notepadPanel, {
                 attributes: true,

--- a/static/js/session-workspace.js
+++ b/static/js/session-workspace.js
@@ -14,12 +14,14 @@
         const insights = options.insights || {};
         const render = options.render || (() => {});
         const isDesktop = options.isDesktop || (() => true);
+        const isWideDesktop = options.isWideDesktop || (() => false);
 
         let layout = 1;
         let sessionId = null;
         let session = null;
         let sftpOpen = false;
         let visible = true;
+        const manuallyDismissedSessions = new Set();
 
         function canOpenSftp() {
             return Boolean(
@@ -51,6 +53,11 @@
             filesPanel?.close?.();
         }
 
+        function openSftp() {
+            sftpOpen = true;
+            filesPanel?.open?.(sessionId, session);
+        }
+
         return {
             update(next) {
                 const previousSessionId = sessionId;
@@ -60,6 +67,9 @@
                     ? next.sessionId
                     : null;
                 session = next?.session || null;
+                const sessionCount = Number.isInteger(next?.sessionCount)
+                    ? next.sessionCount
+                    : 0;
                 const connected = Boolean(sessionId && session?.connected);
                 const sessionChanged = sessionId !== previousSessionId;
                 const connectionChanged = connected !== wasConnected;
@@ -75,6 +85,13 @@
                     closeSftp();
                 } else if (sftpOpen && sessionChanged) {
                     filesPanel?.follow?.(sessionId, session);
+                } else if (
+                    !sftpOpen
+                    && isWideDesktop()
+                    && sessionCount === 1
+                    && !manuallyDismissedSessions.has(sessionId)
+                ) {
+                    openSftp();
                 }
 
                 renderState();
@@ -82,6 +99,7 @@
 
             toggleSftp() {
                 if (sftpOpen) {
+                    if (sessionId) manuallyDismissedSessions.add(sessionId);
                     closeSftp();
                     renderState();
                     return false;
@@ -90,8 +108,8 @@
                     renderState();
                     return false;
                 }
-                sftpOpen = true;
-                filesPanel?.open?.(sessionId, session);
+                manuallyDismissedSessions.delete(sessionId);
+                openSftp();
                 renderState();
                 return true;
             },

--- a/templates/index.html
+++ b/templates/index.html
@@ -958,8 +958,8 @@
     <script src="{{ url_for('static', filename='js/binary-transfer-client.js') }}"></script>
     <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/session-files-panel.js') }}?v=1"></script>
-    <script src="{{ url_for('static', filename='js/session-workspace.js') }}?v=1"></script>
-    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=1"></script>
+    <script src="{{ url_for('static', filename='js/session-workspace.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/drag-drop-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/command-set-utils.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/profile-launcher-utils.js') }}?v=2"></script>

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -129,8 +129,7 @@ test('single-session workspace combines terminal, SFTP, live Linux stats, and no
 
     const toggle = page.locator('#sessionSftpToggleBtn');
     await expect(toggle).toBeEnabled();
-    await toggle.click();
-
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
     await expect(page.locator('#sessionMainSplit')).toHaveClass(/sftp-open/);
     await expect(page.locator('#sessionFilesPanel')).toBeVisible();
     await expect(page.locator('#fmLeftBadge')).toHaveText('ops@edge-01.example');
@@ -182,6 +181,12 @@ test('single-session workspace combines terminal, SFTP, live Linux stats, and no
     await page.locator('#notepadToggle').click();
     await page.waitForTimeout(4500);
     expect(await page.evaluate(() => window.__workspaceInsightSample)).toBe(samplesBeforeCollapse);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('#sessionFilesPanel')).toBeHidden();
+    await page.evaluate(() => SessionManager.notifyWorkspaceChange());
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
 
     await page.evaluate(() => SessionManager.setSplitLayout(2));
     await expect(page.locator('#sessionFilesPanel')).toBeHidden();

--- a/tests/js/session-workspace.test.js
+++ b/tests/js/session-workspace.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 
 const { createCoordinator } = require('../../static/js/session-workspace.js');
 
-function createHarness() {
+function createHarness(options = {}) {
     const calls = [];
     const filesPanel = {
         open(id, session) { calls.push(['files.open', id, session.host]); },
@@ -19,11 +19,74 @@ function createHarness() {
     const coordinator = createCoordinator({
         filesPanel,
         insights,
-        isDesktop: () => true,
+        isDesktop: options.isDesktop || (() => true),
+        isWideDesktop: options.isWideDesktop || (() => false),
         render: state => renders.push(state),
     });
     return { coordinator, calls, renders };
 }
+
+test('auto-opens embedded SFTP for the sole connected session on a wide desktop', () => {
+    const { coordinator, calls } = createHarness({ isWideDesktop: () => true });
+
+    coordinator.update({
+        layout: 1,
+        sessionId: 's1',
+        session: { host: 'alpha', connected: true },
+        sessionCount: 1,
+    });
+
+    assert.deepEqual(calls.slice(-2), [
+        ['insights.session', 's1', true],
+        ['files.open', 's1', 'alpha'],
+    ]);
+    assert.equal(coordinator.getState().sftpOpen, true);
+});
+
+test('does not auto-open below the wide-desktop breakpoint but keeps manual SFTP available', () => {
+    const { coordinator, calls } = createHarness({ isWideDesktop: () => false });
+    coordinator.update({
+        layout: 1,
+        sessionId: 's1',
+        session: { host: 'alpha', connected: true },
+        sessionCount: 1,
+    });
+
+    assert.equal(coordinator.getState().sftpOpen, false);
+    assert.equal(coordinator.toggleSftp(), true);
+    assert.deepEqual(calls.slice(-1), [['files.open', 's1', 'alpha']]);
+});
+
+test('does not auto-open when more than one SSH session exists', () => {
+    const { coordinator, calls } = createHarness({ isWideDesktop: () => true });
+    coordinator.update({
+        layout: 1,
+        sessionId: 's1',
+        session: { host: 'alpha', connected: true },
+        sessionCount: 2,
+    });
+
+    assert.equal(coordinator.getState().sftpOpen, false);
+    assert.equal(calls.some(call => call[0] === 'files.open'), false);
+});
+
+test('manual close suppresses automatic reopening for the same session', () => {
+    const { coordinator, calls } = createHarness({ isWideDesktop: () => true });
+    const update = {
+        layout: 1,
+        sessionId: 's1',
+        session: { host: 'alpha', connected: true },
+        sessionCount: 1,
+    };
+    coordinator.update(update);
+    assert.equal(coordinator.toggleSftp(), false);
+    calls.length = 0;
+
+    coordinator.update(update);
+
+    assert.equal(coordinator.getState().sftpOpen, false);
+    assert.deepEqual(calls, []);
+});
 
 test('opens embedded SFTP only for a connected session in layout 1', () => {
     const { coordinator, calls } = createHarness();


### PR DESCRIPTION
## Summary

- Automatically open the embedded SFTP panel when exactly one connected SSH session is active on wide desktops (1440 CSS pixels or more).
- Keep the existing manual SFTP control available on narrower desktop layouts without auto-opening it.
- Remember a manual close for the current session so subsequent workspace updates do not reopen the panel.
- Leave multi-session, tablet, and mobile behavior unchanged.

## Why

A single terminal leaves enough horizontal space for SFTP on large displays. The default should use that space while still respecting smaller screens and an explicit user close.

## Validation

- `node --test tests/js/*.test.js` - 114 passed
- `npx.cmd playwright test tests/e2e/session-workspace.spec.js --forbid-only` - 2 passed
- `git diff --check`