### PR TITLE
Add active session diagnostics overlay

### DIFF
--- a/app/session_insights.py
+++ b/app/session_insights.py
@@ -18,6 +18,8 @@ _collector_locks_guard = Lock()
 
 
 LINUX_STATS_COMMAND = r"""LC_ALL=C
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+export LC_ALL PATH
 awk 'NR == 1 { $1=""; sub(/^ /, ""); print "cpu=" $0; exit }' /proc/stat
 awk '
   /^MemTotal:/ { print "mem_total_kib=" $2 }
@@ -113,7 +115,7 @@ if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
 fi
 
 if command -v docker >/dev/null 2>&1; then
-  docker_version=$(docker version --format '{{.Server.Version}}' 2>&1)
+  docker_version=$(DOCKER_CLIENT_TIMEOUT=1 docker version --format '{{.Server.Version}}' 2>&1)
   docker_status=$?
   if [ "$docker_status" -eq 0 ] && [ -n "$docker_version" ]; then
     printf 'docker_version=%s\n' "$docker_version"

--- a/app/session_insights.py
+++ b/app/session_insights.py
@@ -1,5 +1,7 @@
-"""Bounded, agentless Linux statistics for an active SSH session."""
+"""Bounded, agentless Linux diagnostics for an active SSH session."""
 
+import math
+import re
 import socket
 import time
 from threading import Lock
@@ -40,6 +42,117 @@ printf 'os_name=%s\n' "$os_name"
 """
 
 
+LINUX_DIAGNOSTICS_COMMAND = LINUX_STATS_COMMAND + r"""
+awk '
+  /^SwapTotal:/ { print "swap_total_kib=" $2 }
+  /^SwapFree:/ { print "swap_free_kib=" $2 }
+' /proc/meminfo
+awk '{
+  print "load_1=" $1
+  print "load_5=" $2
+  print "load_15=" $3
+}' /proc/loadavg
+awk '/^cpu[0-9]+ / { count++ } END {
+  if (count > 0) print "cpu_count=" count
+}' /proc/stat
+awk -F '[: ]+' 'NR > 2 {
+  if ($2 != "lo") {
+    received += $3
+    transmitted += $11
+  }
+} END {
+  print "network_received_bytes=" received + 0
+  print "network_transmitted_bytes=" transmitted + 0
+}' /proc/net/dev
+
+process_probe=$(ps -p $$ -o pid= 2>&1)
+process_status=$?
+if [ "$process_status" -eq 0 ]; then
+  ps -e -o stat= 2>/dev/null | awk '
+    { total++ }
+    substr($1, 1, 1) == "Z" { zombies++ }
+    END {
+      print "process_total=" total + 0
+      print "process_zombies=" zombies + 0
+    }'
+  ps -e -o pid=,user=,comm=,pcpu=,pmem= --sort=-pcpu 2>/dev/null \
+    | awk 'NR <= 5 {
+        printf "process_cpu=%s|%s|%s|%s|%s\n", $1, $2, $3, $4, $5
+      }'
+  ps -e -o pid=,user=,comm=,pcpu=,pmem= --sort=-pmem 2>/dev/null \
+    | awk 'NR <= 5 {
+        printf "process_memory=%s|%s|%s|%s|%s\n", $1, $2, $3, $4, $5
+      }'
+elif printf '%s' "$process_probe" | grep -Eqi \
+    'permission denied|access denied|not authorized|authorization denied'; then
+  printf 'permission_denied=processes\n'
+fi
+
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  systemd_state=$(systemctl show --property=SystemState --value 2>&1)
+  systemd_state_status=$?
+  systemd_units=$(systemctl list-units --type=service --all --no-legend --no-pager 2>&1)
+  systemd_units_status=$?
+  if [ "$systemd_state_status" -eq 0 ] && [ "$systemd_units_status" -eq 0 ]; then
+    printf 'systemd_state=%s\n' "$systemd_state"
+    printf '%s\n' "$systemd_units" | awk '
+      $3 == "active" { running++ }
+      $3 == "failed" { failed++ }
+      END {
+        print "systemd_running=" running + 0
+        print "systemd_failed=" failed + 0
+      }'
+    printf '%s\n' "$systemd_units" | awk '$3 == "failed" && count < 5 {
+      print "systemd_failed_unit=" $1
+      count++
+    }'
+  elif printf '%s\n%s' "$systemd_state" "$systemd_units" | grep -Eqi \
+      'permission denied|access denied|not authorized|authorization denied|authentication is required'; then
+    printf 'permission_denied=systemd\n'
+  fi
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  docker_version=$(docker version --format '{{.Server.Version}}' 2>&1)
+  docker_status=$?
+  if [ "$docker_status" -eq 0 ] && [ -n "$docker_version" ]; then
+    printf 'docker_version=%s\n' "$docker_version"
+    docker ps -q 2>/dev/null | awk 'NF { count++ } END {
+      print "docker_running=" count + 0
+    }'
+    docker ps -aq 2>/dev/null | awk 'NF { count++ } END {
+      print "docker_total=" count + 0
+    }'
+    docker ps --format '{{.Names}}|{{.Status}}' 2>/dev/null | head -n 5 \
+      | sed 's/^/docker_container=/'
+  elif printf '%s' "$docker_version" | grep -Eqi \
+      'permission denied|access denied|not authorized|authorization denied|got permission denied'; then
+    printf 'permission_denied=docker\n'
+  fi
+fi
+"""
+
+
+_SINGLE_KEYS = {
+    'cpu', 'mem_total_kib', 'mem_available_kib',
+    'disk_total_kib', 'disk_used_kib', 'disk_available_kib',
+    'disk_percent', 'uptime_seconds', 'os_name',
+    'load_1', 'load_5', 'load_15', 'cpu_count',
+    'swap_total_kib', 'swap_free_kib',
+    'network_received_bytes', 'network_transmitted_bytes',
+    'process_total', 'process_zombies',
+    'systemd_state', 'systemd_running', 'systemd_failed',
+    'docker_version', 'docker_running', 'docker_total',
+}
+_MULTI_KEYS = {
+    'process_cpu', 'process_memory', 'systemd_failed_unit',
+    'docker_container', 'permission_denied',
+}
+_PERMISSION_SCOPES = ('processes', 'systemd', 'docker')
+_UNIT_NAME = re.compile(r'^[A-Za-z0-9@_.:-]{1,200}$')
+_CONTAINER_NAME = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$')
+
+
 def _non_negative_int(values, key):
     try:
         value = int(values[key])
@@ -50,6 +163,60 @@ def _non_negative_int(values, key):
     return value
 
 
+def _optional_int(values, key, *, maximum=None):
+    try:
+        value = int(values[key])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if value < 0 or (maximum is not None and value > maximum):
+        return None
+    return value
+
+
+def _optional_float(values, key, *, maximum=1_000_000):
+    try:
+        value = float(values[key])
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(value) or value < 0 or value > maximum:
+        return None
+    return value
+
+
+def _safe_text(value, *, maximum):
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > maximum:
+        return None
+    if any(ord(character) < 32 or ord(character) == 127 for character in normalized):
+        return None
+    return normalized
+
+
+def _parse_process_rows(rows):
+    parsed = []
+    for row in rows[:5]:
+        parts = row.split('|')
+        if len(parts) != 5:
+            continue
+        pid = _optional_int({'pid': parts[0]}, 'pid', maximum=2_147_483_647)
+        user = _safe_text(parts[1], maximum=64)
+        command = _safe_text(parts[2], maximum=128)
+        cpu_percent = _optional_float({'value': parts[3]}, 'value', maximum=100_000)
+        memory_percent = _optional_float({'value': parts[4]}, 'value', maximum=100)
+        if None in (pid, user, command, cpu_percent, memory_percent) or pid == 0:
+            continue
+        parsed.append({
+            'pid': pid,
+            'user': user,
+            'command': command,
+            'cpu_percent': cpu_percent,
+            'memory_percent': memory_percent,
+        })
+    return parsed
+
+
 def parse_linux_stats(text, *, max_bytes=DEFAULT_MAX_BYTES):
     """Parse the fixed collector output into a small, safe payload."""
     if not isinstance(text, str):
@@ -58,16 +225,15 @@ def parse_linux_stats(text, *, max_bytes=DEFAULT_MAX_BYTES):
         raise ValueError('stats payload too large')
 
     values = {}
+    repeated = {key: [] for key in _MULTI_KEYS}
     for raw_line in text.splitlines():
         key, separator, value = raw_line.partition('=')
         if not separator:
             continue
-        if key in {
-            'cpu', 'mem_total_kib', 'mem_available_kib',
-            'disk_total_kib', 'disk_used_kib', 'disk_available_kib',
-            'disk_percent', 'uptime_seconds', 'os_name',
-        }:
+        if key in _SINGLE_KEYS:
             values[key] = value.strip()
+        elif key in _MULTI_KEYS and len(repeated[key]) < 16:
+            repeated[key].append(value.strip())
 
     try:
         cpu = [int(part) for part in values['cpu'].split()]
@@ -104,7 +270,7 @@ def parse_linux_stats(text, *, max_bytes=DEFAULT_MAX_BYTES):
     if not os_name or len(os_name) > 200:
         raise ValueError('invalid os name')
 
-    return {
+    result = {
         'cpu': cpu,
         'memory': {
             'total_kib': mem_total,
@@ -120,6 +286,110 @@ def parse_linux_stats(text, *, max_bytes=DEFAULT_MAX_BYTES):
         'uptime_seconds': uptime_seconds,
         'os_name': os_name,
     }
+
+    load_values = (
+        _optional_float(values, 'load_1'),
+        _optional_float(values, 'load_5'),
+        _optional_float(values, 'load_15'),
+    )
+    cpu_count = _optional_int(values, 'cpu_count', maximum=1_000_000)
+    if all(value is not None for value in load_values) and cpu_count:
+        result['load'] = {
+            'one': load_values[0],
+            'five': load_values[1],
+            'fifteen': load_values[2],
+            'cpu_count': cpu_count,
+        }
+
+    swap_total = _optional_int(values, 'swap_total_kib', maximum=2 ** 63 - 1)
+    swap_free = _optional_int(values, 'swap_free_kib', maximum=2 ** 63 - 1)
+    if swap_total is not None and swap_free is not None and swap_free <= swap_total:
+        result['swap'] = {
+            'total_kib': swap_total,
+            'available_kib': swap_free,
+            'used_kib': swap_total - swap_free,
+        }
+
+    received = _optional_int(
+        values, 'network_received_bytes', maximum=2 ** 64 - 1
+    )
+    transmitted = _optional_int(
+        values, 'network_transmitted_bytes', maximum=2 ** 64 - 1
+    )
+    if received is not None and transmitted is not None:
+        result['network'] = {
+            'received_bytes': received,
+            'transmitted_bytes': transmitted,
+        }
+
+    process_total = _optional_int(values, 'process_total', maximum=10_000_000)
+    process_zombies = _optional_int(values, 'process_zombies', maximum=10_000_000)
+    top_cpu = _parse_process_rows(repeated['process_cpu'])
+    top_memory = _parse_process_rows(repeated['process_memory'])
+    if (
+        process_total is not None
+        and process_zombies is not None
+        and process_zombies <= process_total
+        and (top_cpu or top_memory)
+    ):
+        result['processes'] = {
+            'total': process_total,
+            'zombies': process_zombies,
+            'top_cpu': top_cpu,
+            'top_memory': top_memory,
+        }
+
+    systemd_state = _safe_text(values.get('systemd_state'), maximum=32)
+    systemd_running = _optional_int(values, 'systemd_running', maximum=10_000_000)
+    systemd_failed = _optional_int(values, 'systemd_failed', maximum=10_000_000)
+    failed_units = [
+        unit for unit in repeated['systemd_failed_unit'][:5]
+        if _UNIT_NAME.fullmatch(unit)
+    ]
+    if (
+        systemd_state is not None
+        and re.fullmatch(r'[a-z-]+', systemd_state)
+        and systemd_running is not None
+        and systemd_failed is not None
+        and (systemd_failed == 0 or failed_units)
+    ):
+        result['systemd'] = {
+            'state': systemd_state,
+            'running': systemd_running,
+            'failed': systemd_failed,
+            'failed_units': failed_units,
+        }
+
+    docker_version = _safe_text(values.get('docker_version'), maximum=64)
+    docker_running = _optional_int(values, 'docker_running', maximum=10_000_000)
+    docker_total = _optional_int(values, 'docker_total', maximum=10_000_000)
+    containers = []
+    for row in repeated['docker_container'][:5]:
+        name, separator, status = row.partition('|')
+        status = _safe_text(status, maximum=160)
+        if separator and _CONTAINER_NAME.fullmatch(name) and status is not None:
+            containers.append({'name': name, 'status': status})
+    if (
+        docker_version is not None
+        and docker_running is not None
+        and docker_total is not None
+        and docker_running <= docker_total
+    ):
+        result['docker'] = {
+            'version': docker_version,
+            'running': docker_running,
+            'total': docker_total,
+            'containers': containers,
+        }
+
+    permissions = []
+    for scope in repeated['permission_denied']:
+        if scope in _PERMISSION_SCOPES and scope not in permissions:
+            permissions.append(scope)
+    if permissions:
+        result['permission_denied'] = permissions
+
+    return result
 
 
 def _acquire_session_lock(session_id):
@@ -154,7 +424,8 @@ def _release_session_lock(session_id, collector_lock):
 
 
 def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
-                        max_bytes=DEFAULT_MAX_BYTES):
+                        max_bytes=DEFAULT_MAX_BYTES,
+                        include_diagnostics=False):
     """Collect one Linux sample without touching the interactive PTY."""
     if not isinstance(session_id, str) or not session_id:
         return None, 'unavailable'
@@ -175,9 +446,14 @@ def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
         if not transport or not transport.is_active():
             return None, 'unavailable'
 
+        command = (
+            LINUX_DIAGNOSTICS_COMMAND
+            if include_diagnostics is True
+            else LINUX_STATS_COMMAND
+        )
         channel = ssh_manager._open_exec_channel(
             transport,
-            LINUX_STATS_COMMAND,
+            command,
             timeout=timeout,
         )
         deadline = time.monotonic() + timeout

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -1491,7 +1491,11 @@ def handle_request_session_insights(data, current_user=None):
         return
 
     try:
-        stats, error = session_insights.collect_linux_stats(session_id)
+        include_diagnostics = data.get('include_diagnostics') is True
+        stats, error = session_insights.collect_linux_stats(
+            session_id,
+            include_diagnostics=include_diagnostics,
+        )
     except Exception as exc:
         log_warning(
             'Session insights collection failed',

--- a/static/css/session-workspace.css
+++ b/static/css/session-workspace.css
@@ -320,9 +320,355 @@
     font-size: 9px;
 }
 
+.session-diagnostics-toggle {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    margin-top: 12px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 7px;
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.session-diagnostics-toggle:hover:not(:disabled),
+.session-diagnostics-toggle[aria-expanded="true"] {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}
+
+.session-diagnostics-toggle:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.session-diagnostics-toggle .material-icons {
+    font-size: 17px;
+}
+
+body.session-diagnostics-open {
+    overflow: hidden;
+}
+
+.session-diagnostics-overlay {
+    position: fixed;
+    z-index: 16000;
+    inset: 0;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.session-diagnostics-overlay.hidden,
+.session-diagnostics-overlay [hidden] {
+    display: none !important;
+}
+
+.session-diagnostics-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(4, 8, 14, 0.72);
+    backdrop-filter: blur(3px);
+}
+
+.session-diagnostics-drawer {
+    position: relative;
+    display: flex;
+    width: min(1120px, calc(100vw - 72px));
+    height: 100%;
+    flex-direction: column;
+    border-left: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    box-shadow: -20px 0 55px rgba(0, 0, 0, 0.32);
+    animation: session-diagnostics-enter 0.2s ease-out;
+}
+
+@keyframes session-diagnostics-enter {
+    from { transform: translateX(28px); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+.session-diagnostics-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 22px 26px 18px;
+    border-bottom: 1px solid var(--border-color);
+    background: linear-gradient(145deg, var(--bg-secondary), var(--bg-tertiary));
+}
+
+.session-diagnostics-header h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 22px;
+}
+
+.session-diagnostics-hostline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px 12px;
+    margin-top: 7px;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.session-diagnostics-hostline span:first-child {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-weight: 600;
+}
+
+.session-diagnostics-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.session-diagnostics-close {
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--border-color);
+    border-radius: 7px;
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 24px;
+    line-height: 1;
+}
+
+.session-diagnostics-close:hover {
+    color: var(--text-primary);
+}
+
+.session-diagnostics-content {
+    flex: 1;
+    min-height: 0;
+    padding: 22px 26px 30px;
+    overflow-y: auto;
+}
+
+.session-diagnostics-permissions {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 18px;
+    padding: 12px 14px;
+    border: 1px solid color-mix(in srgb, var(--warning-color, #d29922) 45%, var(--border-color));
+    border-radius: 9px;
+    background: color-mix(in srgb, var(--warning-color, #d29922) 8%, var(--bg-secondary));
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+.session-diagnostics-permissions .material-icons {
+    color: var(--warning-color, #d29922);
+    font-size: 20px;
+}
+
+.session-diagnostics-permissions strong {
+    display: block;
+    margin-bottom: 3px;
+    color: var(--text-primary);
+}
+
+.session-diagnostics-permissions ul,
+.session-diagnostics-failures,
+.session-diagnostics-containers {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.session-diagnostics-permissions li + li {
+    margin-top: 3px;
+}
+
+.session-diagnostics-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.session-diagnostics-metric {
+    display: flex;
+    min-height: 102px;
+    flex-direction: column;
+    justify-content: center;
+    padding: 14px 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+}
+
+.session-diagnostics-metric > span {
+    margin-bottom: 9px;
+    color: var(--text-muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.session-diagnostics-metric strong {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 20px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.session-diagnostics-metric small {
+    margin-top: 5px;
+    overflow: hidden;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.session-diagnostics-section {
+    margin-top: 16px;
+    padding: 17px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+}
+
+.session-diagnostics-section-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 14px;
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+.session-diagnostics-section-heading > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.session-diagnostics-section-heading .material-icons {
+    color: var(--accent-primary);
+    font-size: 19px;
+}
+
+.session-diagnostics-section h3,
+.session-diagnostics-section h4 {
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.session-diagnostics-section h3 {
+    font-size: 14px;
+}
+
+.session-diagnostics-section h4 {
+    margin-bottom: 8px;
+    font-size: 11px;
+}
+
+.session-process-grids,
+.session-diagnostics-services {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.session-process-panel {
+    min-width: 0;
+    overflow-x: auto;
+}
+
+.session-process-panel table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 10px;
+}
+
+.session-process-panel th,
+.session-process-panel td {
+    padding: 7px 8px;
+    border-bottom: 1px solid var(--border-color);
+    text-align: left;
+    white-space: nowrap;
+}
+
+.session-process-panel th {
+    color: var(--text-muted);
+    font-size: 9px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.session-process-panel td {
+    max-width: 150px;
+    overflow: hidden;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    text-overflow: ellipsis;
+}
+
+.session-process-panel td:first-child {
+    color: var(--text-primary);
+}
+
+.session-diagnostics-failures {
+    margin-top: 12px;
+}
+
+.session-diagnostics-failures li {
+    padding: 7px 9px;
+    border-left: 3px solid var(--danger-color, #f85149);
+    background: color-mix(in srgb, var(--danger-color, #f85149) 7%, transparent);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+}
+
+.session-diagnostics-failures li + li {
+    margin-top: 5px;
+}
+
+.session-diagnostics-containers li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 0;
+    border-top: 1px solid var(--border-color);
+    font-size: 10px;
+}
+
+.session-diagnostics-containers strong {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    text-overflow: ellipsis;
+}
+
+.session-diagnostics-containers span {
+    flex: 0 0 auto;
+    color: var(--text-muted);
+}
+
 @media (max-width: 1100px) {
     .session-main-split.sftp-open {
         grid-template-columns: minmax(0, 1fr) 360px;
+    }
+
+    .session-diagnostics-metrics {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 
@@ -339,5 +685,22 @@
 
     .session-insights-card {
         display: none;
+    }
+
+    .session-diagnostics-drawer {
+        width: 100%;
+        border-left: 0;
+    }
+
+    .session-diagnostics-header,
+    .session-diagnostics-content {
+        padding-right: 18px;
+        padding-left: 18px;
+    }
+
+    .session-diagnostics-metrics,
+    .session-process-grids,
+    .session-diagnostics-services {
+        grid-template-columns: minmax(0, 1fr);
     }
 }

--- a/static/js/session-diagnostics.js
+++ b/static/js/session-diagnostics.js
@@ -1,0 +1,448 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+    if (root && root.document) {
+        root.SessionDiagnosticsModule = api;
+    }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const STATUS_LABELS = {
+        ready: 'Live',
+        loading: 'Sampling',
+        stale: 'Stale',
+        unavailable: 'Unavailable',
+        disconnected: 'Offline',
+    };
+    const PERMISSION_NOTICES = {
+        docker: 'Docker is installed, but this SSH user cannot access the Docker daemon.',
+        processes: 'Process details are restricted for this SSH user.',
+        systemd: 'systemd service details are restricted for this SSH user.',
+    };
+
+    function finiteNumber(value) {
+        const number = Number(value);
+        return Number.isFinite(number) && number >= 0 ? number : null;
+    }
+
+    function formatKib(value) {
+        const kib = finiteNumber(value);
+        if (kib === null) return null;
+        const mib = kib / 1024;
+        if (mib < 1024) return `${mib.toFixed(1)} MB`;
+        return `${(mib / 1024).toFixed(1)} GB`;
+    }
+
+    function formatRate(value) {
+        const bytes = finiteNumber(value);
+        if (bytes === null) return null;
+        if (bytes < 1024) return `${Math.round(bytes)} B/s`;
+        const kib = bytes / 1024;
+        if (kib < 1024) return `${kib.toFixed(1)} KB/s`;
+        const mib = kib / 1024;
+        if (mib < 1024) return `${mib.toFixed(1)} MB/s`;
+        return `${(mib / 1024).toFixed(1)} GB/s`;
+    }
+
+    function formatUptime(seconds) {
+        const total = finiteNumber(seconds);
+        if (total === null) return null;
+        const days = Math.floor(total / 86400);
+        const hours = Math.floor((total % 86400) / 3600);
+        const minutes = Math.floor((total % 3600) / 60);
+        if (days > 0) return `${days}d ${hours}h`;
+        return `${hours}h ${minutes}m`;
+    }
+
+    function formatPercent(value) {
+        const number = finiteNumber(value);
+        return number === null ? null : `${number.toFixed(1)}%`;
+    }
+
+    function boundedProcesses(rows) {
+        if (!Array.isArray(rows)) return [];
+        return rows.slice(0, 5).map(row => ({
+            pid: String(row.pid),
+            user: String(row.user),
+            command: String(row.command),
+            cpu: formatPercent(row.cpu_percent),
+            memory: formatPercent(row.memory_percent),
+        })).filter(row => row.cpu !== null && row.memory !== null);
+    }
+
+    function buildViewModel(state = {}, session = null) {
+        const stats = state.stats || null;
+        const available = Boolean(state.sessionId && stats);
+        const host = session
+            ? `${session.username}@${session.host}`
+            : 'No active session';
+        const model = {
+            available,
+            host,
+            status: STATUS_LABELS[state.status] || 'Offline',
+            statusClass: state.status || 'disconnected',
+            os: stats?.os_name || null,
+            summary: {
+                cpu: finiteNumber(state.cpuPercent) === null
+                    ? null
+                    : `${Math.round(Number(state.cpuPercent))}%`,
+                memoryUsed: formatKib(stats?.memory?.used_kib),
+                memoryTotal: formatKib(stats?.memory?.total_kib),
+                diskUsed: formatKib(stats?.disk?.used_kib),
+                diskTotal: formatKib(stats?.disk?.total_kib),
+                uptime: formatUptime(stats?.uptime_seconds),
+            },
+            sections: {
+                load: null,
+                swap: null,
+                network: null,
+                processes: null,
+                systemd: null,
+                docker: null,
+            },
+            permissionNotices: [],
+        };
+        if (!available) return model;
+
+        const load = stats.load;
+        if (
+            finiteNumber(load?.one) !== null
+            && finiteNumber(load?.five) !== null
+            && finiteNumber(load?.fifteen) !== null
+            && finiteNumber(load?.cpu_count) > 0
+        ) {
+            model.sections.load = {
+                one: Number(load.one).toFixed(2),
+                five: Number(load.five).toFixed(2),
+                fifteen: Number(load.fifteen).toFixed(2),
+                cpuCount: Number(load.cpu_count),
+            };
+        }
+
+        const swap = stats.swap;
+        if (finiteNumber(swap?.total_kib) > 0) {
+            model.sections.swap = {
+                used: formatKib(swap.used_kib),
+                total: formatKib(swap.total_kib),
+            };
+        }
+
+        const rates = state.networkRates;
+        const received = formatRate(rates?.received_bps);
+        const transmitted = formatRate(rates?.transmitted_bps);
+        if (stats.network && received !== null && transmitted !== null) {
+            model.sections.network = { received, transmitted };
+        }
+
+        const processes = stats.processes;
+        const topCpu = boundedProcesses(processes?.top_cpu);
+        const topMemory = boundedProcesses(processes?.top_memory);
+        if (processes && (topCpu.length || topMemory.length)) {
+            model.sections.processes = {
+                total: Number(processes.total),
+                zombies: Number(processes.zombies),
+                topCpu,
+                topMemory,
+            };
+        }
+
+        if (stats.systemd) {
+            model.sections.systemd = {
+                state: String(stats.systemd.state),
+                running: Number(stats.systemd.running),
+                failed: Number(stats.systemd.failed),
+                failedUnits: Array.isArray(stats.systemd.failed_units)
+                    ? stats.systemd.failed_units.slice(0, 5).map(String)
+                    : [],
+            };
+        }
+
+        if (stats.docker) {
+            model.sections.docker = {
+                version: String(stats.docker.version),
+                running: Number(stats.docker.running),
+                total: Number(stats.docker.total),
+                containers: Array.isArray(stats.docker.containers)
+                    ? stats.docker.containers.slice(0, 5).map(container => ({
+                        name: String(container.name),
+                        status: String(container.status),
+                    }))
+                    : [],
+            };
+        }
+
+        const seenPermissions = new Set();
+        (Array.isArray(stats.permission_denied) ? stats.permission_denied : [])
+            .forEach(scope => {
+                if (PERMISSION_NOTICES[scope] && !seenPermissions.has(scope)) {
+                    seenPermissions.add(scope);
+                    model.permissionNotices.push(PERMISSION_NOTICES[scope]);
+                }
+            });
+        return model;
+    }
+
+    function createController(options) {
+        const documentRef = options.document;
+        const onOpenChange = options.onOpenChange || (() => {});
+        const byId = id => documentRef.getElementById(id);
+        const elements = {
+            trigger: byId('sessionDiagnosticsToggle'),
+            overlay: byId('sessionDiagnosticsOverlay'),
+            backdrop: byId('sessionDiagnosticsBackdrop'),
+            close: byId('sessionDiagnosticsClose'),
+            host: byId('sessionDiagnosticsHost'),
+            os: byId('sessionDiagnosticsOs'),
+            state: byId('sessionDiagnosticsState'),
+            permissions: byId('sessionDiagnosticsPermissions'),
+            permissionList: byId('sessionDiagnosticsPermissionList'),
+            cpuMetric: byId('sessionDiagnosticsCpuMetric'),
+            cpuValue: byId('sessionDiagnosticsCpuValue'),
+            memoryMetric: byId('sessionDiagnosticsMemoryMetric'),
+            memoryValue: byId('sessionDiagnosticsMemoryValue'),
+            memoryDetail: byId('sessionDiagnosticsMemoryDetail'),
+            diskMetric: byId('sessionDiagnosticsDiskMetric'),
+            diskValue: byId('sessionDiagnosticsDiskValue'),
+            diskDetail: byId('sessionDiagnosticsDiskDetail'),
+            uptimeMetric: byId('sessionDiagnosticsUptimeMetric'),
+            uptimeValue: byId('sessionDiagnosticsUptimeValue'),
+            loadMetric: byId('sessionDiagnosticsLoadMetric'),
+            loadValue: byId('sessionDiagnosticsLoadValue'),
+            loadDetail: byId('sessionDiagnosticsLoadDetail'),
+            swapMetric: byId('sessionDiagnosticsSwapMetric'),
+            swapValue: byId('sessionDiagnosticsSwapValue'),
+            swapDetail: byId('sessionDiagnosticsSwapDetail'),
+            networkMetric: byId('sessionDiagnosticsNetworkMetric'),
+            networkValue: byId('sessionDiagnosticsNetworkValue'),
+            networkDetail: byId('sessionDiagnosticsNetworkDetail'),
+            processMetric: byId('sessionDiagnosticsProcessMetric'),
+            processValue: byId('sessionDiagnosticsProcessValue'),
+            processDetail: byId('sessionDiagnosticsProcessDetail'),
+            processesSection: byId('sessionDiagnosticsProcessesSection'),
+            cpuProcessesPanel: byId('sessionDiagnosticsCpuProcessesPanel'),
+            memoryProcessesPanel: byId('sessionDiagnosticsMemoryProcessesPanel'),
+            cpuProcesses: byId('sessionDiagnosticsCpuProcesses'),
+            memoryProcesses: byId('sessionDiagnosticsMemoryProcesses'),
+            systemdSection: byId('sessionDiagnosticsSystemdSection'),
+            systemdState: byId('sessionDiagnosticsSystemdState'),
+            systemdCounts: byId('sessionDiagnosticsSystemdCounts'),
+            systemdFailures: byId('sessionDiagnosticsSystemdFailures'),
+            dockerSection: byId('sessionDiagnosticsDockerSection'),
+            dockerVersion: byId('sessionDiagnosticsDockerVersion'),
+            dockerCounts: byId('sessionDiagnosticsDockerCounts'),
+            dockerContainers: byId('sessionDiagnosticsDockerContainers'),
+        };
+        if (!elements.trigger || !elements.overlay || !elements.close) return null;
+
+        let open = false;
+        let activeSessionId = null;
+        let previousFocus = null;
+
+        function setOpen(nextOpen, restoreFocus = true) {
+            const normalized = Boolean(nextOpen && !elements.trigger.disabled);
+            if (open === normalized) return;
+            open = normalized;
+            elements.overlay.classList.toggle('hidden', !open);
+            elements.overlay.setAttribute('aria-hidden', String(!open));
+            elements.trigger.setAttribute('aria-expanded', String(open));
+            documentRef.body?.classList.toggle('session-diagnostics-open', open);
+            if (open) {
+                previousFocus = documentRef.activeElement;
+                elements.close.focus();
+            } else if (restoreFocus) {
+                const focusTarget = previousFocus && documentRef.contains(previousFocus)
+                    ? previousFocus
+                    : elements.trigger;
+                focusTarget?.focus?.();
+            }
+            onOpenChange(open);
+        }
+
+        function setMetric(wrapper, valueElement, value, detailElement, detail) {
+            const visible = value !== null && value !== undefined;
+            wrapper.hidden = !visible;
+            if (!visible) return;
+            valueElement.textContent = value;
+            if (detailElement) detailElement.textContent = detail || '';
+        }
+
+        function replaceList(container, values, formatter) {
+            container.replaceChildren();
+            values.forEach(value => {
+                const item = documentRef.createElement('li');
+                formatter(item, value);
+                container.appendChild(item);
+            });
+        }
+
+        function replaceProcesses(container, rows, key) {
+            container.replaceChildren();
+            rows.forEach(row => {
+                const tr = documentRef.createElement('tr');
+                [row.command, row.user, row.pid, row[key]].forEach(value => {
+                    const cell = documentRef.createElement('td');
+                    cell.textContent = value;
+                    tr.appendChild(cell);
+                });
+                container.appendChild(tr);
+            });
+        }
+
+        function render(state, session) {
+            const nextSessionId = state?.sessionId || null;
+            if (activeSessionId && activeSessionId !== nextSessionId && open) {
+                setOpen(false, false);
+            }
+            activeSessionId = nextSessionId;
+            const model = buildViewModel(state, session);
+            elements.trigger.disabled = !model.available;
+            if (!model.available && open) setOpen(false, false);
+            elements.host.textContent = model.host;
+            elements.os.textContent = model.os || '';
+            elements.os.hidden = !model.os;
+            elements.state.textContent = model.status;
+            elements.state.className = `session-insights-state ${model.statusClass}`;
+
+            setMetric(elements.cpuMetric, elements.cpuValue, model.summary.cpu);
+            setMetric(
+                elements.memoryMetric,
+                elements.memoryValue,
+                model.summary.memoryUsed,
+                elements.memoryDetail,
+                model.summary.memoryTotal ? `of ${model.summary.memoryTotal}` : '',
+            );
+            setMetric(
+                elements.diskMetric,
+                elements.diskValue,
+                model.summary.diskUsed,
+                elements.diskDetail,
+                model.summary.diskTotal ? `of ${model.summary.diskTotal} on /` : '',
+            );
+            setMetric(
+                elements.uptimeMetric,
+                elements.uptimeValue,
+                model.summary.uptime,
+            );
+
+            const load = model.sections.load;
+            setMetric(
+                elements.loadMetric,
+                elements.loadValue,
+                load?.one,
+                elements.loadDetail,
+                load ? `${load.five} / ${load.fifteen} - ${load.cpuCount} CPUs` : '',
+            );
+            const swap = model.sections.swap;
+            setMetric(
+                elements.swapMetric,
+                elements.swapValue,
+                swap?.used,
+                elements.swapDetail,
+                swap ? `of ${swap.total}` : '',
+            );
+            const network = model.sections.network;
+            setMetric(
+                elements.networkMetric,
+                elements.networkValue,
+                network?.received,
+                elements.networkDetail,
+                network ? `${network.transmitted} sent` : '',
+            );
+            const processes = model.sections.processes;
+            setMetric(
+                elements.processMetric,
+                elements.processValue,
+                processes ? String(processes.total) : null,
+                elements.processDetail,
+                processes ? `${processes.zombies} zombie` : '',
+            );
+
+            elements.permissions.hidden = model.permissionNotices.length === 0;
+            replaceList(elements.permissionList, model.permissionNotices, (item, notice) => {
+                item.textContent = notice;
+            });
+
+            elements.processesSection.hidden = !processes;
+            if (processes) {
+                elements.cpuProcessesPanel.hidden = processes.topCpu.length === 0;
+                elements.memoryProcessesPanel.hidden = processes.topMemory.length === 0;
+                replaceProcesses(elements.cpuProcesses, processes.topCpu, 'cpu');
+                replaceProcesses(elements.memoryProcesses, processes.topMemory, 'memory');
+            }
+
+            const systemd = model.sections.systemd;
+            elements.systemdSection.hidden = !systemd;
+            if (systemd) {
+                elements.systemdState.textContent = systemd.state;
+                elements.systemdCounts.textContent = `${systemd.running} active - ${systemd.failed} failed`;
+                elements.systemdFailures.hidden = systemd.failedUnits.length === 0;
+                replaceList(elements.systemdFailures, systemd.failedUnits, (item, unit) => {
+                    item.textContent = unit;
+                });
+            }
+
+            const docker = model.sections.docker;
+            elements.dockerSection.hidden = !docker;
+            if (docker) {
+                elements.dockerVersion.textContent = `Docker ${docker.version}`;
+                elements.dockerCounts.textContent = `${docker.running} running - ${docker.total} total`;
+                elements.dockerContainers.hidden = docker.containers.length === 0;
+                replaceList(elements.dockerContainers, docker.containers, (item, container) => {
+                    const name = documentRef.createElement('strong');
+                    const status = documentRef.createElement('span');
+                    name.textContent = container.name;
+                    status.textContent = container.status;
+                    item.append(name, status);
+                });
+            }
+        }
+
+        function handleKeydown(event) {
+            if (!open) return;
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setOpen(false);
+                return;
+            }
+            if (event.key === 'Tab') {
+                event.preventDefault();
+                elements.close.focus();
+            }
+        }
+
+        function handleTrigger() {
+            setOpen(!open);
+        }
+
+        function handleClose() {
+            setOpen(false);
+        }
+
+        elements.trigger.addEventListener('click', handleTrigger);
+        elements.close.addEventListener('click', handleClose);
+        elements.backdrop?.addEventListener('click', handleClose);
+        documentRef.addEventListener('keydown', handleKeydown);
+        elements.trigger.disabled = true;
+
+        return {
+            render,
+            isOpen: () => open,
+            close: () => setOpen(false),
+            destroy() {
+                setOpen(false, false);
+                elements.trigger.removeEventListener('click', handleTrigger);
+                elements.close.removeEventListener('click', handleClose);
+                elements.backdrop?.removeEventListener('click', handleClose);
+                documentRef.removeEventListener('keydown', handleKeydown);
+            },
+        };
+    }
+
+    return {
+        buildViewModel,
+        createController,
+        formatRate,
+    };
+}));

--- a/static/js/session-insights.js
+++ b/static/js/session-insights.js
@@ -249,7 +249,10 @@
                 const normalized = Boolean(nextVisible);
                 if (diagnosticsVisible === normalized) return;
                 diagnosticsVisible = normalized;
-                if (diagnosticsVisible) requestSample();
+                if (diagnosticsVisible) {
+                    previousNetworkBySession.delete(sessionId);
+                    requestSample();
+                }
             },
 
             destroy() {

--- a/static/js/session-insights.js
+++ b/static/js/session-insights.js
@@ -48,6 +48,33 @@
         return 'normal';
     }
 
+    function calculateNetworkRates(previous, current) {
+        if (!previous || !current) return null;
+        const elapsedSeconds = (
+            Number(current.sampled_at) - Number(previous.sampled_at)
+        ) / 1000;
+        const receivedDelta = (
+            Number(current.received_bytes) - Number(previous.received_bytes)
+        );
+        const transmittedDelta = (
+            Number(current.transmitted_bytes) - Number(previous.transmitted_bytes)
+        );
+        if (
+            !Number.isFinite(elapsedSeconds)
+            || !Number.isFinite(receivedDelta)
+            || !Number.isFinite(transmittedDelta)
+            || elapsedSeconds <= 0
+            || receivedDelta < 0
+            || transmittedDelta < 0
+        ) {
+            return null;
+        }
+        return {
+            received_bps: Math.round(receivedDelta / elapsedSeconds),
+            transmitted_bps: Math.round(transmittedDelta / elapsedSeconds),
+        };
+    }
+
     function createController(options) {
         const socket = options.socket;
         const render = options.render || (() => {});
@@ -55,10 +82,12 @@
         const clearIntervalFn = options.clearIntervalFn || clearInterval;
         const setTimeoutFn = options.setTimeoutFn || setTimeout;
         const clearTimeoutFn = options.clearTimeoutFn || clearTimeout;
+        const nowFn = options.nowFn || Date.now;
 
         let sessionId = null;
         let connected = false;
         let visible = true;
+        let diagnosticsVisible = false;
         let intervalId = null;
         let responseTimeoutId = null;
         let pendingRequest = null;
@@ -67,6 +96,7 @@
         let lastGood = null;
         const previousCpuBySession = new Map();
         const historyBySession = new Map();
+        const previousNetworkBySession = new Map();
 
         function currentState(status, extra = {}) {
             return {
@@ -103,11 +133,17 @@
             if (!visible || !connected || !sessionId || pendingRequest) return;
             requestCounter += 1;
             const requestId = `insights-${requestCounter}`;
-            pendingRequest = { sessionId, requestId };
-            socket.emit('request_session_insights', {
+            pendingRequest = {
+                sessionId,
+                requestId,
+                includeDiagnostics: diagnosticsVisible,
+            };
+            const payload = {
                 session_id: sessionId,
                 request_id: requestId,
-            });
+            };
+            if (diagnosticsVisible) payload.include_diagnostics = true;
+            socket.emit('request_session_insights', payload);
             responseTimeoutId = setTimeoutFn(() => {
                 if (!pendingRequest || pendingRequest.requestId !== requestId) return;
                 pendingRequest = null;
@@ -132,6 +168,7 @@
                 return;
             }
 
+            const responseRequest = pendingRequest;
             pendingRequest = null;
             clearResponseTimeout();
             if (!payload.success || !payload.stats) {
@@ -150,12 +187,36 @@
             while (history.length > HISTORY_LIMIT) history.shift();
             historyBySession.set(sessionId, history);
 
+            let networkRates = null;
+            if (stats.network) {
+                const networkSample = {
+                    received_bytes: Number(stats.network.received_bytes),
+                    transmitted_bytes: Number(stats.network.transmitted_bytes),
+                    sampled_at: Number(nowFn()),
+                };
+                networkRates = calculateNetworkRates(
+                    previousNetworkBySession.get(sessionId) || null,
+                    networkSample,
+                );
+                if (
+                    Number.isFinite(networkSample.received_bytes)
+                    && Number.isFinite(networkSample.transmitted_bytes)
+                    && Number.isFinite(networkSample.sampled_at)
+                ) {
+                    previousNetworkBySession.set(sessionId, networkSample);
+                }
+            }
+
             lastGood = {
                 stats,
                 cpuPercent,
                 cpuHistory: history.slice(),
+                networkRates,
             };
             render(currentState('ready', { ...lastGood }));
+            if (diagnosticsVisible && !responseRequest.includeDiagnostics) {
+                requestSample();
+            }
         }
 
         socket.on('session_insights', handleResponse);
@@ -184,6 +245,13 @@
                 }
             },
 
+            setDiagnosticsVisible(nextVisible) {
+                const normalized = Boolean(nextVisible);
+                if (diagnosticsVisible === normalized) return;
+                diagnosticsVisible = normalized;
+                if (diagnosticsVisible) requestSample();
+            },
+
             destroy() {
                 clearPolling();
                 socket.off?.('session_insights', handleResponse);
@@ -197,6 +265,7 @@
         calculateCpuPercent,
         formatKib,
         severityForPercent,
+        calculateNetworkRates,
         createController,
     };
 }));

--- a/static/js/session-workspace-ui.js
+++ b/static/js/session-workspace-ui.js
@@ -197,10 +197,12 @@
         function syncInsightsVisibility() {
             coordinator.setVisible(
                 documentRef.visibilityState !== 'hidden'
-                && desktopQuery.matches
                 && (
-                    !elements.notepadPanel?.classList.contains('collapsed')
-                    || diagnosticsController?.isOpen()
+                    diagnosticsController?.isOpen()
+                    || (
+                        desktopQuery.matches
+                        && !elements.notepadPanel?.classList.contains('collapsed')
+                    )
                 )
             );
         }

--- a/static/js/session-workspace-ui.js
+++ b/static/js/session-workspace-ui.js
@@ -62,10 +62,11 @@
         const terminalManager = options.terminalManager;
         const documentRef = options.document || document;
         const insightsModule = root.SessionInsightsModule;
+        const diagnosticsModule = root.SessionDiagnosticsModule;
         const filesModule = root.SessionFilesPanelModule;
         const workspaceModule = root.SessionWorkspaceModule;
         const fileManager = root.getSFTPFileManager?.();
-        if (!socket || !sessionManager || !insightsModule || !filesModule || !workspaceModule || !fileManager) {
+        if (!socket || !sessionManager || !insightsModule || !diagnosticsModule || !filesModule || !workspaceModule || !fileManager) {
             return null;
         }
 
@@ -93,6 +94,8 @@
 
         let filesController = null;
         let coordinator = null;
+        let insightsController = null;
+        let diagnosticsController = null;
 
         function setResource(element, bar, value) {
             const severity = insightsModule.severityForPercent(value);
@@ -112,6 +115,7 @@
             };
             elements.insightsState.textContent = labels[state.status] || 'Offline';
             elements.insightsState.className = `session-insights-state ${state.status || ''}`;
+            diagnosticsController?.render(state, active);
             if (!state.stats) {
                 if (state.status === 'disconnected' || state.status === 'unavailable') {
                     elements.cpuValue.textContent = '--';
@@ -150,7 +154,14 @@
             manager: fileManager,
             container: elements.filesMount,
         });
-        const insightsController = insightsModule.createController({ socket, render: renderInsights });
+        diagnosticsController = diagnosticsModule.createController({
+            document: documentRef,
+            onOpenChange(open) {
+                insightsController?.setDiagnosticsVisible(open);
+                syncInsightsVisibility();
+            },
+        });
+        insightsController = insightsModule.createController({ socket, render: renderInsights });
         const desktopQuery = root.matchMedia('(min-width: 851px)');
         const wideDesktopQuery = root.matchMedia('(min-width: 1440px)');
         coordinator = workspaceModule.createCoordinator({
@@ -187,7 +198,10 @@
             coordinator.setVisible(
                 documentRef.visibilityState !== 'hidden'
                 && desktopQuery.matches
-                && !elements.notepadPanel?.classList.contains('collapsed')
+                && (
+                    !elements.notepadPanel?.classList.contains('collapsed')
+                    || diagnosticsController?.isOpen()
+                )
             );
         }
         root.addEventListener('session-workspace-change', sync);

--- a/templates/index.html
+++ b/templates/index.html
@@ -1087,11 +1087,11 @@
     <script src="{{ url_for('static', filename='js/i18n.js') }}?v=6"></script>
 
     <script src="{{ url_for('static', filename='js/binary-transfer-client.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=3"></script>
     <script src="{{ url_for('static', filename='js/session-diagnostics.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/session-files-panel.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/session-workspace.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=3"></script>
+    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=4"></script>
     <script src="{{ url_for('static', filename='js/drag-drop-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/command-set-utils.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/command-palette-utils.js') }}?v=1"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -222,7 +222,7 @@
     <div class="session-diagnostics-overlay hidden" id="sessionDiagnosticsOverlay" aria-hidden="true">
         <div class="session-diagnostics-backdrop" id="sessionDiagnosticsBackdrop"></div>
         <section class="session-diagnostics-drawer" role="dialog" aria-modal="true" aria-labelledby="sessionDiagnosticsTitle">
-            <header class="session-diagnostics-header">
+            <div class="session-diagnostics-header">
                 <div>
                     <div class="session-panel-eyebrow">Active session</div>
                     <h2 id="sessionDiagnosticsTitle">Server diagnostics</h2>
@@ -235,7 +235,7 @@
                     <span class="session-insights-state disconnected" id="sessionDiagnosticsState">Offline</span>
                     <button class="session-diagnostics-close" id="sessionDiagnosticsClose" type="button" aria-label="Close server diagnostics" title="Close server diagnostics">&times;</button>
                 </div>
-            </header>
+            </div>
 
             <div class="session-diagnostics-content">
                 <aside class="session-diagnostics-permissions" id="sessionDiagnosticsPermissions" aria-live="polite" hidden>

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
 
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=8">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=2">
 </head>
 <body data-theme="{{ theme|default('glass') }}" data-confirm-session-close="{{ 'true' if confirm_session_close else 'false' }}">
 
@@ -200,6 +200,10 @@
                         <span id="sessionOsValue">Linux only</span>
                         <span id="sessionUptimeValue">Refreshes every 4s</span>
                     </div>
+                    <button class="session-diagnostics-toggle" id="sessionDiagnosticsToggle" type="button" aria-expanded="false" aria-controls="sessionDiagnosticsOverlay" disabled>
+                        <span class="material-icons" aria-hidden="true">monitor_heart</span>
+                        <span>Open diagnostics</span>
+                    </button>
                 </section>
                 <div class="notepad-section">
                 <div class="notepad-header">
@@ -214,6 +218,127 @@
             </aside>
         </div>
     </main>
+
+    <div class="session-diagnostics-overlay hidden" id="sessionDiagnosticsOverlay" aria-hidden="true">
+        <div class="session-diagnostics-backdrop" id="sessionDiagnosticsBackdrop"></div>
+        <section class="session-diagnostics-drawer" role="dialog" aria-modal="true" aria-labelledby="sessionDiagnosticsTitle">
+            <header class="session-diagnostics-header">
+                <div>
+                    <div class="session-panel-eyebrow">Active session</div>
+                    <h2 id="sessionDiagnosticsTitle">Server diagnostics</h2>
+                    <div class="session-diagnostics-hostline">
+                        <span id="sessionDiagnosticsHost">No active session</span>
+                        <span id="sessionDiagnosticsOs" hidden></span>
+                    </div>
+                </div>
+                <div class="session-diagnostics-header-actions">
+                    <span class="session-insights-state disconnected" id="sessionDiagnosticsState">Offline</span>
+                    <button class="session-diagnostics-close" id="sessionDiagnosticsClose" type="button" aria-label="Close server diagnostics" title="Close server diagnostics">&times;</button>
+                </div>
+            </header>
+
+            <div class="session-diagnostics-content">
+                <aside class="session-diagnostics-permissions" id="sessionDiagnosticsPermissions" aria-live="polite" hidden>
+                    <span class="material-icons" aria-hidden="true">lock</span>
+                    <div>
+                        <strong>Limited by permissions</strong>
+                        <ul id="sessionDiagnosticsPermissionList"></ul>
+                    </div>
+                </aside>
+
+                <div class="session-diagnostics-metrics">
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsCpuMetric" hidden>
+                        <span>CPU now</span>
+                        <strong id="sessionDiagnosticsCpuValue"></strong>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsLoadMetric" hidden>
+                        <span>Load 1m</span>
+                        <strong id="sessionDiagnosticsLoadValue"></strong>
+                        <small id="sessionDiagnosticsLoadDetail"></small>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsMemoryMetric" hidden>
+                        <span>Memory</span>
+                        <strong id="sessionDiagnosticsMemoryValue"></strong>
+                        <small id="sessionDiagnosticsMemoryDetail"></small>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsSwapMetric" hidden>
+                        <span>Swap</span>
+                        <strong id="sessionDiagnosticsSwapValue"></strong>
+                        <small id="sessionDiagnosticsSwapDetail"></small>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsDiskMetric" hidden>
+                        <span>Root disk</span>
+                        <strong id="sessionDiagnosticsDiskValue"></strong>
+                        <small id="sessionDiagnosticsDiskDetail"></small>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsNetworkMetric" hidden>
+                        <span>Network received</span>
+                        <strong id="sessionDiagnosticsNetworkValue"></strong>
+                        <small id="sessionDiagnosticsNetworkDetail"></small>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsProcessMetric" hidden>
+                        <span>Processes</span>
+                        <strong id="sessionDiagnosticsProcessValue"></strong>
+                        <small id="sessionDiagnosticsProcessDetail"></small>
+                    </article>
+                    <article class="session-diagnostics-metric" id="sessionDiagnosticsUptimeMetric" hidden>
+                        <span>Uptime</span>
+                        <strong id="sessionDiagnosticsUptimeValue"></strong>
+                    </article>
+                </div>
+
+                <section class="session-diagnostics-section" id="sessionDiagnosticsProcessesSection" hidden>
+                    <div class="session-diagnostics-section-heading">
+                        <div>
+                            <span class="material-icons" aria-hidden="true">memory</span>
+                            <h3>What is using this server?</h3>
+                        </div>
+                        <span>Top 5 per view</span>
+                    </div>
+                    <div class="session-process-grids">
+                        <div class="session-process-panel" id="sessionDiagnosticsCpuProcessesPanel">
+                            <h4>Top CPU</h4>
+                            <table>
+                                <thead><tr><th>Command</th><th>User</th><th>PID</th><th>CPU</th></tr></thead>
+                                <tbody id="sessionDiagnosticsCpuProcesses"></tbody>
+                            </table>
+                        </div>
+                        <div class="session-process-panel" id="sessionDiagnosticsMemoryProcessesPanel">
+                            <h4>Top memory</h4>
+                            <table>
+                                <thead><tr><th>Command</th><th>User</th><th>PID</th><th>RAM</th></tr></thead>
+                                <tbody id="sessionDiagnosticsMemoryProcesses"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+
+                <div class="session-diagnostics-services">
+                    <section class="session-diagnostics-section" id="sessionDiagnosticsSystemdSection" hidden>
+                        <div class="session-diagnostics-section-heading">
+                            <div>
+                                <span class="material-icons" aria-hidden="true">settings_suggest</span>
+                                <h3>systemd</h3>
+                            </div>
+                            <span id="sessionDiagnosticsSystemdState"></span>
+                        </div>
+                        <strong id="sessionDiagnosticsSystemdCounts"></strong>
+                        <ul class="session-diagnostics-failures" id="sessionDiagnosticsSystemdFailures" hidden></ul>
+                    </section>
+                    <section class="session-diagnostics-section" id="sessionDiagnosticsDockerSection" hidden>
+                        <div class="session-diagnostics-section-heading">
+                            <div>
+                                <span class="material-icons" aria-hidden="true">view_in_ar</span>
+                                <h3 id="sessionDiagnosticsDockerVersion">Docker</h3>
+                            </div>
+                            <span id="sessionDiagnosticsDockerCounts"></span>
+                        </div>
+                        <ul class="session-diagnostics-containers" id="sessionDiagnosticsDockerContainers" hidden></ul>
+                    </section>
+                </div>
+            </div>
+        </section>
+    </div>
 
     <div class="modal modal-wide" id="connectionModal" role="dialog" aria-modal="true" aria-labelledby="connectionModalTitle" aria-hidden="true">
         <div class="modal-content">
@@ -962,10 +1087,11 @@
     <script src="{{ url_for('static', filename='js/i18n.js') }}?v=6"></script>
 
     <script src="{{ url_for('static', filename='js/binary-transfer-client.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=1"></script>
+    <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/session-diagnostics.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/session-files-panel.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/session-workspace.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=3"></script>
     <script src="{{ url_for('static', filename='js/drag-drop-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/command-set-utils.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/command-palette-utils.js') }}?v=1"></script>

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -49,26 +49,75 @@ async function seedLinuxSession(page) {
                         [260, 0, 180, 1060],
                         [400, 0, 260, 1120],
                     ];
+                    const stats = {
+                        cpu: cpuSamples[Math.min(insightSample - 1, cpuSamples.length - 1)],
+                        memory: {
+                            total_kib: 16 * 1024 * 1024,
+                            available_kib: 6 * 1024 * 1024,
+                            used_kib: 10 * 1024 * 1024,
+                        },
+                        disk: {
+                            total_kib: 100 * 1024 * 1024,
+                            available_kib: 39 * 1024 * 1024,
+                            used_kib: 61 * 1024 * 1024,
+                            percent: 61,
+                        },
+                        uptime_seconds: 93784,
+                        os_name: 'Ubuntu 24.04.2 LTS',
+                    };
+                    if (payload.include_diagnostics === true) {
+                        window.__workspaceExpandedRequests = (
+                            window.__workspaceExpandedRequests || 0
+                        ) + 1;
+                        Object.assign(stats, {
+                            load: { one: 1.25, five: 0.75, fifteen: 0.5, cpu_count: 8 },
+                            swap: {
+                                total_kib: 2 * 1024 * 1024,
+                                available_kib: 1536 * 1024,
+                                used_kib: 512 * 1024,
+                            },
+                            network: {
+                                received_bytes: 1000000 + insightSample * 8192,
+                                transmitted_bytes: 500000 + insightSample * 4096,
+                            },
+                            processes: {
+                                total: 215,
+                                zombies: 1,
+                                top_cpu: [
+                                    { pid: 812, user: 'postgres', command: 'postgres', cpu_percent: 32.5, memory_percent: 4.1 },
+                                    { pid: 924, user: 'deploy', command: 'python3', cpu_percent: 18, memory_percent: 2.5 },
+                                ],
+                                top_memory: [
+                                    { pid: 177, user: 'redis', command: 'redis-server', cpu_percent: 3.5, memory_percent: 12.4 },
+                                ],
+                            },
+                            systemd: {
+                                state: 'degraded',
+                                running: 41,
+                                failed: 1,
+                                failed_units: ['backup.service'],
+                            },
+                        });
+                        const diagnosticsMode = window.__workspaceDiagnosticsMode || 'full';
+                        if (diagnosticsMode === 'full') {
+                            stats.docker = {
+                                version: '27.5.1',
+                                running: 2,
+                                total: 3,
+                                containers: [
+                                    { name: 'webssh', status: 'Up 3 hours (healthy)' },
+                                    { name: 'redis', status: 'Up 3 hours' },
+                                ],
+                            };
+                        } else if (diagnosticsMode === 'permission') {
+                            stats.permission_denied = ['docker'];
+                        }
+                    }
                     deliver('session_insights', {
                         success: true,
                         session_id: payload.session_id,
                         request_id: payload.request_id,
-                        stats: {
-                            cpu: cpuSamples[Math.min(insightSample - 1, cpuSamples.length - 1)],
-                            memory: {
-                                total_kib: 16 * 1024 * 1024,
-                                available_kib: 6 * 1024 * 1024,
-                                used_kib: 10 * 1024 * 1024,
-                            },
-                            disk: {
-                                total_kib: 100 * 1024 * 1024,
-                                available_kib: 39 * 1024 * 1024,
-                                used_kib: 61 * 1024 * 1024,
-                                percent: 61,
-                            },
-                            uptime_seconds: 93784,
-                            os_name: 'Ubuntu 24.04.2 LTS',
-                        },
+                        stats,
                     });
                     return window.socket;
                 }
@@ -206,5 +255,57 @@ test('mobile workspace does not poll hidden Linux telemetry', async ({ page }) =
 
     expect(await page.evaluate(() => window.__workspaceInsightSample || 0)).toBe(0);
     await expect(page.locator('#sessionInsightsCard')).toBeHidden();
+    await assertNoExternalRequests(page);
+});
+
+test('diagnostics overlay requests and renders optional details only while open', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page);
+    await expect(page.locator('#sessionInsightsState')).toHaveText('Live');
+    await page.waitForTimeout(500);
+
+    expect(await page.evaluate(() => window.__workspaceExpandedRequests || 0)).toBe(0);
+    const toggle = page.locator('#sessionDiagnosticsToggle');
+    await expect(toggle).toBeEnabled();
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('#sessionDiagnosticsOverlay')).toBeVisible();
+    await expect(page.locator('#sessionDiagnosticsProcessesSection')).toBeVisible();
+    await expect(page.locator('#sessionDiagnosticsCpuProcesses')).toContainText('postgres');
+    await expect(page.locator('#sessionDiagnosticsMemoryProcesses')).toContainText('redis-server');
+    await expect(page.locator('#sessionDiagnosticsSystemdSection')).toBeVisible();
+    await expect(page.locator('#sessionDiagnosticsSystemdCounts')).toHaveText('41 active - 1 failed');
+    await expect(page.locator('#sessionDiagnosticsSystemdFailures')).toContainText('backup.service');
+    await expect(page.locator('#sessionDiagnosticsDockerSection')).toBeVisible();
+    await expect(page.locator('#sessionDiagnosticsDockerContainers')).toContainText('webssh');
+    await expect(page.locator('#sessionDiagnosticsNetworkMetric')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('#sessionDiagnosticsNetworkValue')).toContainText('KB/s');
+
+    const beforePermission = await page.evaluate(() => window.__workspaceExpandedRequests);
+    await page.evaluate(() => { window.__workspaceDiagnosticsMode = 'permission'; });
+    await expect.poll(() => page.evaluate(() => window.__workspaceExpandedRequests), {
+        timeout: 6000,
+    }).toBeGreaterThan(beforePermission);
+    await expect(page.locator('#sessionDiagnosticsPermissions')).toBeVisible();
+    await expect(page.locator('#sessionDiagnosticsPermissionList')).toContainText(
+        'cannot access the Docker daemon',
+    );
+    await expect(page.locator('#sessionDiagnosticsDockerSection')).toBeHidden();
+
+    const beforeGenericOmission = await page.evaluate(() => window.__workspaceExpandedRequests);
+    await page.evaluate(() => { window.__workspaceDiagnosticsMode = 'generic'; });
+    await expect.poll(() => page.evaluate(() => window.__workspaceExpandedRequests), {
+        timeout: 6000,
+    }).toBeGreaterThan(beforeGenericOmission);
+    await expect(page.locator('#sessionDiagnosticsPermissions')).toBeHidden();
+    await expect(page.locator('#sessionDiagnosticsDockerSection')).toBeHidden();
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#sessionDiagnosticsOverlay')).toBeHidden();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    const expandedAfterClose = await page.evaluate(() => window.__workspaceExpandedRequests);
+    await page.waitForTimeout(4500);
+    expect(await page.evaluate(() => window.__workspaceExpandedRequests)).toBe(expandedAfterClose);
     await assertNoExternalRequests(page);
 });

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -310,3 +310,23 @@ test('diagnostics overlay requests and renders optional details only while open'
     expect(await page.evaluate(() => window.__workspaceExpandedRequests)).toBe(expandedAfterClose);
     await assertNoExternalRequests(page);
 });
+
+test('open diagnostics keep polling across the mobile breakpoint', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page);
+    await expect(page.locator('#sessionDiagnosticsToggle')).toBeEnabled();
+    await page.locator('#sessionDiagnosticsToggle').click();
+    await expect(page.locator('#sessionDiagnosticsOverlay')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__workspaceExpandedRequests || 0), {
+        timeout: 6000,
+    }).toBeGreaterThan(0);
+
+    const beforeResize = await page.evaluate(() => window.__workspaceExpandedRequests);
+    await page.setViewportSize({ width: 800, height: 900 });
+    await expect(page.locator('#sessionDiagnosticsOverlay')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__workspaceExpandedRequests), {
+        timeout: 6000,
+    }).toBeGreaterThan(beforeResize);
+    await expect(page.locator('#sessionDiagnosticsState')).toHaveText('Live');
+    await assertNoExternalRequests(page);
+});

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -261,6 +261,7 @@ test('mobile workspace does not poll hidden Linux telemetry', async ({ page }) =
 test('diagnostics overlay requests and renders optional details only while open', async ({ page }) => {
     await login(page);
     await seedLinuxSession(page);
+    await expect(page.locator('header')).toHaveCount(1);
     await expect(page.locator('#sessionInsightsState')).toHaveText('Live');
     await page.waitForTimeout(500);
 

--- a/tests/js/session-diagnostics.test.js
+++ b/tests/js/session-diagnostics.test.js
@@ -1,0 +1,115 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const diagnostics = require('../../static/js/session-diagnostics.js');
+
+
+function coreState(extraStats = {}) {
+    return {
+        status: 'ready',
+        sessionId: 'session-a',
+        cpuPercent: 42,
+        networkRates: null,
+        stats: {
+            cpu: [10, 0, 5, 85],
+            memory: { total_kib: 1000, available_kib: 400, used_kib: 600 },
+            disk: { total_kib: 2000, available_kib: 1500, used_kib: 500, percent: 25 },
+            uptime_seconds: 3600,
+            os_name: 'Debian GNU/Linux 13',
+            ...extraStats,
+        },
+    };
+}
+
+
+test('omits unsupported optional sections instead of creating empty cards', () => {
+    const model = diagnostics.buildViewModel(
+        coreState(),
+        { username: 'ops', host: 'edge-01.example' },
+    );
+
+    assert.equal(model.available, true);
+    assert.equal(model.host, 'ops@edge-01.example');
+    assert.equal(model.sections.load, null);
+    assert.equal(model.sections.swap, null);
+    assert.equal(model.sections.network, null);
+    assert.equal(model.sections.processes, null);
+    assert.equal(model.sections.systemd, null);
+    assert.equal(model.sections.docker, null);
+    assert.deepEqual(model.permissionNotices, []);
+});
+
+
+test('builds bounded display data for supported diagnostics', () => {
+    const processRows = Array.from({ length: 8 }, (_, index) => ({
+        pid: 100 + index,
+        user: 'ops',
+        command: `worker-${index}`,
+        cpu_percent: 30 - index,
+        memory_percent: 5 + index,
+    }));
+    const state = coreState({
+        load: { one: 1.25, five: 0.75, fifteen: 0.5, cpu_count: 8 },
+        swap: { total_kib: 2048, available_kib: 1024, used_kib: 1024 },
+        network: { received_bytes: 5000, transmitted_bytes: 2500 },
+        processes: {
+            total: 215,
+            zombies: 2,
+            top_cpu: processRows,
+            top_memory: processRows.slice().reverse(),
+        },
+        systemd: {
+            state: 'degraded',
+            running: 41,
+            failed: 1,
+            failed_units: ['backup.service'],
+        },
+        docker: {
+            version: '27.5.1',
+            running: 3,
+            total: 5,
+            containers: [
+                { name: 'webssh', status: 'Up 3 hours (healthy)' },
+                { name: 'redis', status: 'Up 3 hours' },
+            ],
+        },
+    });
+    state.networkRates = { received_bps: 2048, transmitted_bps: 1024 };
+
+    const model = diagnostics.buildViewModel(state, { username: 'ops', host: 'edge' });
+
+    assert.equal(model.sections.load.one, '1.25');
+    assert.equal(model.sections.swap.used, '1.0 MB');
+    assert.equal(model.sections.network.received, '2.0 KB/s');
+    assert.equal(model.sections.network.transmitted, '1.0 KB/s');
+    assert.equal(model.sections.processes.topCpu.length, 5);
+    assert.equal(model.sections.processes.topMemory.length, 5);
+    assert.equal(model.sections.systemd.failedUnits[0], 'backup.service');
+    assert.equal(model.sections.docker.containers[0].name, 'webssh');
+});
+
+
+test('surfaces only permission failures with scoped user-facing notices', () => {
+    const model = diagnostics.buildViewModel(coreState({
+        permission_denied: ['docker', 'processes', 'unknown', 'docker'],
+    }), null);
+
+    assert.deepEqual(model.permissionNotices, [
+        'Docker is installed, but this SSH user cannot access the Docker daemon.',
+        'Process details are restricted for this SSH user.',
+    ]);
+    assert.equal(model.sections.docker, null);
+    assert.equal(model.sections.processes, null);
+});
+
+
+test('returns an unavailable model without telemetry or a connected session', () => {
+    const model = diagnostics.buildViewModel(
+        { status: 'disconnected', sessionId: null },
+        null,
+    );
+
+    assert.equal(model.available, false);
+    assert.equal(model.host, 'No active session');
+    assert.deepEqual(model.permissionNotices, []);
+});

--- a/tests/js/session-insights.test.js
+++ b/tests/js/session-insights.test.js
@@ -4,7 +4,7 @@ const test = require('node:test');
 const insights = require('../../static/js/session-insights.js');
 
 
-function fakeRuntime() {
+function fakeRuntime(options = {}) {
     const emitted = [];
     const handlers = new Map();
     const intervals = new Map();
@@ -42,6 +42,7 @@ function fakeRuntime() {
         clearTimeoutFn(id) {
             timeouts.delete(id);
         },
+        nowFn: options.nowFn,
     });
 
     return { controller, emitted, handlers, intervals, timeouts, renders };
@@ -80,6 +81,7 @@ test('requests immediately and repeats on an exact four second interval', () => 
     assert.equal(runtime.emitted.length, 1);
     assert.equal(runtime.emitted[0].event, 'request_session_insights');
     assert.equal(runtime.emitted[0].payload.session_id, 'session-a');
+    assert.equal('include_diagnostics' in runtime.emitted[0].payload, false);
     assert.equal(runtime.intervals.size, 1);
     assert.equal([...runtime.intervals.values()][0].delay, 4000);
     assert.equal([...runtime.timeouts.values()][0].delay, 3500);
@@ -100,6 +102,90 @@ test('requests immediately and repeats on an exact four second interval', () => 
 
     [...runtime.intervals.values()][0].callback();
     assert.equal(runtime.emitted.length, 2);
+});
+
+
+test('requests expanded diagnostics only while the overlay is visible', () => {
+    const runtime = fakeRuntime();
+    runtime.controller.setSession('session-a', true);
+    const firstRequest = runtime.emitted[0].payload;
+
+    runtime.handlers.get('session_insights')({
+        success: true,
+        session_id: 'session-a',
+        request_id: firstRequest.request_id,
+        stats: {
+            cpu: [100, 0, 50, 850],
+            memory: { total_kib: 1000, available_kib: 400, used_kib: 600 },
+            disk: { total_kib: 2000, available_kib: 1500, used_kib: 500, percent: 25 },
+            uptime_seconds: 3600,
+            os_name: 'Linux',
+        },
+    });
+
+    runtime.controller.setDiagnosticsVisible(true);
+    assert.equal(runtime.emitted.at(-1).payload.include_diagnostics, true);
+
+    const expandedRequest = runtime.emitted.at(-1).payload;
+    runtime.handlers.get('session_insights')({
+        success: true,
+        session_id: 'session-a',
+        request_id: expandedRequest.request_id,
+        stats: {
+            cpu: [110, 0, 55, 900],
+            memory: { total_kib: 1000, available_kib: 400, used_kib: 600 },
+            disk: { total_kib: 2000, available_kib: 1500, used_kib: 500, percent: 25 },
+            uptime_seconds: 3604,
+            os_name: 'Linux',
+        },
+    });
+    runtime.controller.setDiagnosticsVisible(false);
+    [...runtime.intervals.values()][0].callback();
+
+    assert.equal('include_diagnostics' in runtime.emitted.at(-1).payload, false);
+});
+
+
+test('derives network throughput and discards counter resets', () => {
+    let now = 1000;
+    const runtime = fakeRuntime({ nowFn: () => now });
+    runtime.controller.setSession('session-a', true);
+
+    function respond(receivedBytes, transmittedBytes) {
+        const request = runtime.emitted.at(-1).payload;
+        runtime.handlers.get('session_insights')({
+            success: true,
+            session_id: 'session-a',
+            request_id: request.request_id,
+            stats: {
+                cpu: [100 + now, 0, 50, 850 + now],
+                memory: { total_kib: 1000, available_kib: 400, used_kib: 600 },
+                disk: { total_kib: 2000, available_kib: 1500, used_kib: 500, percent: 25 },
+                uptime_seconds: 3600,
+                os_name: 'Linux',
+                network: {
+                    received_bytes: receivedBytes,
+                    transmitted_bytes: transmittedBytes,
+                },
+            },
+        });
+    }
+
+    respond(10000, 5000);
+    assert.equal(runtime.renders.at(-1).networkRates, null);
+
+    now = 3000;
+    [...runtime.intervals.values()][0].callback();
+    respond(14000, 7000);
+    assert.deepEqual(runtime.renders.at(-1).networkRates, {
+        received_bps: 2000,
+        transmitted_bps: 1000,
+    });
+
+    now = 5000;
+    [...runtime.intervals.values()][0].callback();
+    respond(100, 50);
+    assert.equal(runtime.renders.at(-1).networkRates, null);
 });
 
 

--- a/tests/js/session-insights.test.js
+++ b/tests/js/session-insights.test.js
@@ -189,6 +189,42 @@ test('derives network throughput and discards counter resets', () => {
 });
 
 
+test('starts a fresh network baseline whenever diagnostics is reopened', () => {
+    let now = 1000;
+    const runtime = fakeRuntime({ nowFn: () => now });
+    runtime.controller.setSession('session-a', true);
+    runtime.controller.setDiagnosticsVisible(true);
+
+    function respond(stats) {
+        const request = runtime.emitted.at(-1).payload;
+        runtime.handlers.get('session_insights')({
+            success: true,
+            session_id: 'session-a',
+            request_id: request.request_id,
+            stats: {
+                cpu: [100, 0, 50, 850],
+                memory: { total_kib: 1000, available_kib: 400, used_kib: 600 },
+                disk: { total_kib: 2000, available_kib: 1500, used_kib: 500, percent: 25 },
+                uptime_seconds: 3600,
+                os_name: 'Linux',
+                ...stats,
+            },
+        });
+    }
+
+    respond({});
+    respond({ network: { received_bytes: 10000, transmitted_bytes: 5000 } });
+    assert.equal(runtime.renders.at(-1).networkRates, null);
+
+    runtime.controller.setDiagnosticsVisible(false);
+    now = 61000;
+    runtime.controller.setDiagnosticsVisible(true);
+    respond({ network: { received_bytes: 70000, transmitted_bytes: 35000 } });
+
+    assert.equal(runtime.renders.at(-1).networkRates, null);
+});
+
+
 test('never overlaps a pending request and ignores late responses', () => {
     const runtime = fakeRuntime();
     runtime.controller.setSession('session-a', true);

--- a/tests/test_session_insights.py
+++ b/tests/test_session_insights.py
@@ -18,6 +18,32 @@ os_name=Ubuntu 24.04.2 LTS
 """
 
 
+DIAGNOSTICS_PAYLOAD = VALID_PAYLOAD + """\
+load_1=1.25
+load_5=0.75
+load_15=0.50
+cpu_count=8
+swap_total_kib=2097152
+swap_free_kib=1572864
+network_received_bytes=123456789
+network_transmitted_bytes=98765432
+process_total=215
+process_zombies=2
+process_cpu=812|postgres|postgres|32.5|4.1
+process_cpu=924|deploy|python3|18.0|2.5
+process_memory=177|redis|redis-server|3.5|12.4
+systemd_state=degraded
+systemd_running=41
+systemd_failed=1
+systemd_failed_unit=backup.service
+docker_version=27.5.1
+docker_running=3
+docker_total=5
+docker_container=webssh|Up 3 hours (healthy)
+docker_container=redis|Up 3 hours
+"""
+
+
 def test_parse_linux_stats_returns_normalized_numeric_values():
     result = session_insights.parse_linux_stats(VALID_PAYLOAD)
 
@@ -69,6 +95,101 @@ def test_parse_linux_stats_ignores_unknown_keys_without_exposing_them():
     )
 
     assert 'remote_secret' not in result
+
+
+def test_parse_linux_stats_normalizes_optional_diagnostics():
+    result = session_insights.parse_linux_stats(DIAGNOSTICS_PAYLOAD)
+
+    assert result['load'] == {
+        'one': 1.25,
+        'five': 0.75,
+        'fifteen': 0.5,
+        'cpu_count': 8,
+    }
+    assert result['swap'] == {
+        'total_kib': 2097152,
+        'available_kib': 1572864,
+        'used_kib': 524288,
+    }
+    assert result['network'] == {
+        'received_bytes': 123456789,
+        'transmitted_bytes': 98765432,
+    }
+    assert result['processes'] == {
+        'total': 215,
+        'zombies': 2,
+        'top_cpu': [
+            {
+                'pid': 812,
+                'user': 'postgres',
+                'command': 'postgres',
+                'cpu_percent': 32.5,
+                'memory_percent': 4.1,
+            },
+            {
+                'pid': 924,
+                'user': 'deploy',
+                'command': 'python3',
+                'cpu_percent': 18.0,
+                'memory_percent': 2.5,
+            },
+        ],
+        'top_memory': [
+            {
+                'pid': 177,
+                'user': 'redis',
+                'command': 'redis-server',
+                'cpu_percent': 3.5,
+                'memory_percent': 12.4,
+            },
+        ],
+    }
+    assert result['systemd'] == {
+        'state': 'degraded',
+        'running': 41,
+        'failed': 1,
+        'failed_units': ['backup.service'],
+    }
+    assert result['docker'] == {
+        'version': '27.5.1',
+        'running': 3,
+        'total': 5,
+        'containers': [
+            {'name': 'webssh', 'status': 'Up 3 hours (healthy)'},
+            {'name': 'redis', 'status': 'Up 3 hours'},
+        ],
+    }
+    assert 'permission_denied' not in result
+
+
+def test_parse_linux_stats_omits_malformed_optional_sections_but_keeps_core():
+    result = session_insights.parse_linux_stats(
+        VALID_PAYLOAD
+        + 'load_1=-1\nload_5=0.2\nload_15=0.1\ncpu_count=0\n'
+        + 'swap_total_kib=100\nswap_free_kib=200\n'
+        + 'process_total=-1\nprocess_zombies=0\n'
+        + 'process_cpu=not-a-row\n'
+        + 'systemd_state=running\nsystemd_running=2\nsystemd_failed=1\n'
+        + 'systemd_failed_unit=../../secret\n'
+        + 'docker_version=27\ndocker_running=5\ndocker_total=2\n'
+        + 'docker_container=invalid name|Up\n'
+    )
+
+    assert result['os_name'] == 'Ubuntu 24.04.2 LTS'
+    for key in ('load', 'swap', 'processes', 'systemd', 'docker'):
+        assert key not in result
+
+
+def test_parse_linux_stats_exposes_only_deduplicated_known_permission_scopes():
+    result = session_insights.parse_linux_stats(
+        VALID_PAYLOAD
+        + 'permission_denied=docker\n'
+        + 'permission_denied=systemd\n'
+        + 'permission_denied=docker\n'
+        + 'permission_denied=unknown\n'
+    )
+
+    assert result['permission_denied'] == ['docker', 'systemd']
 
 
 class FakeChannel:
@@ -150,6 +271,38 @@ def test_collect_linux_stats_uses_separate_fixed_exec_channel(monkeypatch):
     assert observed == {
         'transport': transport,
         'command': session_insights.LINUX_STATS_COMMAND,
+        'timeout': 0.2,
+    }
+    assert channel.closed is True
+
+
+def test_collect_linux_stats_uses_expanded_fixed_command_only_when_requested(
+        monkeypatch):
+    transport = install_session(monkeypatch)
+    channel = FakeChannel(payload=DIAGNOSTICS_PAYLOAD.encode())
+    observed = {}
+
+    def open_channel(actual_transport, command, *, timeout):
+        observed.update(
+            transport=actual_transport,
+            command=command,
+            timeout=timeout,
+        )
+        return channel
+
+    monkeypatch.setattr(
+        session_insights.ssh_manager, '_open_exec_channel', open_channel
+    )
+
+    stats, error = session_insights.collect_linux_stats(
+        'owned-session', timeout=0.2, include_diagnostics=True
+    )
+
+    assert error is None
+    assert stats['docker']['running'] == 3
+    assert observed == {
+        'transport': transport,
+        'command': session_insights.LINUX_DIAGNOSTICS_COMMAND,
         'timeout': 0.2,
     }
     assert channel.closed is True

--- a/tests/test_session_insights.py
+++ b/tests/test_session_insights.py
@@ -192,6 +192,19 @@ def test_parse_linux_stats_exposes_only_deduplicated_known_permission_scopes():
     assert result['permission_denied'] == ['docker', 'systemd']
 
 
+def test_remote_diagnostics_use_a_fixed_safe_environment_without_elevation():
+    assert session_insights.LINUX_STATS_COMMAND.startswith(
+        'LC_ALL=C\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin\nexport LC_ALL PATH\n'
+    )
+    assert 'DOCKER_CLIENT_TIMEOUT=1 docker version' in (
+        session_insights.LINUX_DIAGNOSTICS_COMMAND
+    )
+    for forbidden in ('sudo ', 'su ', 'doas ', 'curl ', 'wget ', ' /proc/*/environ'):
+        assert forbidden not in session_insights.LINUX_DIAGNOSTICS_COMMAND
+    assert 'comm=' in session_insights.LINUX_DIAGNOSTICS_COMMAND
+    assert 'args=' not in session_insights.LINUX_DIAGNOSTICS_COMMAND
+
+
 class FakeChannel:
     def __init__(self, payload=VALID_PAYLOAD.encode(), *, status=0,
                  recv_error=None):

--- a/tests/test_session_insights_socket.py
+++ b/tests/test_session_insights_socket.py
@@ -25,8 +25,8 @@ def invoke(monkeypatch, payload, *, owned=True, collector_result=None,
         lambda user_id, endpoint, limit: rate_limited,
     )
 
-    def collect(session_id):
-        collector_calls.append(session_id)
+    def collect(session_id, *, include_diagnostics=False):
+        collector_calls.append((session_id, include_diagnostics))
         return collector_result or ({'cpu': [1, 2, 3, 4]}, None)
 
     monkeypatch.setattr(
@@ -66,7 +66,7 @@ def test_session_insights_socket_returns_owned_sample_and_request_identity(
         collector_result=(stats, None),
     )
 
-    assert calls == ['owned-session']
+    assert calls == [('owned-session', False)]
     assert emitted == [('session_insights', {
         'success': True,
         'session_id': 'owned-session',
@@ -140,10 +140,35 @@ def test_session_insights_socket_returns_generic_collector_failure(monkeypatch):
         collector_result=(None, 'unavailable'),
     )
 
-    assert calls == ['owned-session']
+    assert calls == [('owned-session', False)]
     assert emitted == [('session_insights', {
         'success': False,
         'session_id': 'owned-session',
         'request_id': 'sample-3',
         'error': 'Session insights unavailable',
     })]
+
+
+@pytest.mark.parametrize(
+    ('requested_value', 'expected'),
+    [
+        (True, True),
+        (False, False),
+        ('true', False),
+        (1, False),
+        (None, False),
+    ],
+)
+def test_session_insights_socket_only_accepts_literal_diagnostics_flag(
+        monkeypatch, requested_value, expected):
+    emitted, calls = invoke(
+        monkeypatch,
+        {
+            'session_id': 'owned-session',
+            'request_id': 'sample-diagnostics',
+            'include_diagnostics': requested_value,
+        },
+    )
+
+    assert calls == [('owned-session', expected)]
+    assert emitted[0][1]['success'] is True


### PR DESCRIPTION
## Summary

- keep the existing compact active-session overview and add an accessible diagnostics drawer
- show live CPU, load, memory, swap, root disk, network throughput, process pressure, systemd health, and Docker status
- detect optional capabilities and hide unsupported or generically failed sections
- show concise permission notices only when the SSH user is explicitly denied access
- request expanded diagnostics only while the drawer is open

## Security

- preserves the existing authenticated socket handler, per-user rate limit, and session ownership check before collection
- uses fixed, input-free read-only commands on a separate bounded SSH exec channel
- keeps the 2 second execution timeout and 16 KiB response limit
- fixes the remote locale and system PATH, and limits Docker client discovery to one second
- never invokes privilege escalation or reads process arguments or environments
- allowlists and bounds every optional field and list before returning it to the browser
- renders remote values with textContent and never returns raw remote stderr

Docker access is not expanded: the dashboard only reports container metadata when the connected SSH user already has Docker daemon access.

## Validation

- `1399 passed, 33 skipped` with the full Python test suite
- `127 passed` with the complete JavaScript unit suite
- `3 passed` for the session workspace Playwright suite
- `git diff --check`
- code graph refreshed with `graphify update .`
