### PR TITLE
Fix active session command launcher initialization

### DIFF
--- a/static/js/session-command-launcher.js
+++ b/static/js/session-command-launcher.js
@@ -13,6 +13,24 @@
         return /[\r\n]/.test(value);
     }
 
+    function getSessionManager() {
+        return typeof SessionManager !== 'undefined'
+            ? SessionManager
+            : root.SessionManager;
+    }
+
+    function getCommandLibrary() {
+        return typeof CommandLibrary !== 'undefined'
+            ? CommandLibrary
+            : root.CommandLibrary;
+    }
+
+    function getTerminalManager() {
+        return typeof TerminalManager !== 'undefined'
+            ? TerminalManager
+            : root.TerminalManager;
+    }
+
     function commandEntry(command) {
         const base = typeof command?.command === 'string' ? command.command : '';
         const parameters = typeof command?.parameters === 'string' ? command.parameters : '';
@@ -127,15 +145,15 @@
             if (!document || this.initialized) return;
             this.initialized = true;
             this.controller = createSessionCommandController({
-                getSession: sessionId => root.SessionManager?.getSession(sessionId),
-                getCommands: () => root.CommandLibrary?.commands || [],
+                getSession: sessionId => getSessionManager()?.getSession(sessionId),
+                getCommands: () => getCommandLibrary()?.commands || [],
                 getCommandSets: () => root.CommandSetManager?.commandSets || [],
                 emitInput: (sessionId, data) => root.socket?.emit('ssh_input', {
                     session_id: sessionId,
                     data,
                 }),
                 close: () => this.close(),
-                focusSession: sessionId => root.TerminalManager?.terminals?.[sessionId]?.focus(),
+                focusSession: sessionId => getTerminalManager()?.terminals?.[sessionId]?.focus(),
                 notify: (message, type) => root.showNotification?.(message, type),
                 insertedMessage: label => this.t(
                     'sessionCommands.inserted',
@@ -171,7 +189,7 @@
             this.close(false);
             document.querySelectorAll('.session-command-launcher').forEach(node => node.remove());
 
-            const sessionManager = root.SessionManager;
+            const sessionManager = getSessionManager();
             const paneIndex = sessionManager?.getActivePaneIndex?.();
             const sessionId = sessionManager?.paneAssignments?.[paneIndex];
             const session = sessionId ? sessionManager.getSession(sessionId) : null;
@@ -213,7 +231,7 @@
         },
 
         open(sessionId, container, trigger) {
-            const session = root.SessionManager?.getSession(sessionId);
+            const session = getSessionManager()?.getSession(sessionId);
             if (!session?.connected) return;
             this.sessionId = sessionId;
             this.searchQuery = '';
@@ -245,7 +263,7 @@
             if (!this.popup || !this.sessionId) return;
             const document = root.document;
             const popup = this.popup;
-            const session = root.SessionManager?.getSession(this.sessionId);
+            const session = getSessionManager()?.getSession(this.sessionId);
             if (!session?.connected) {
                 this.close(false);
                 return;

--- a/templates/index.html
+++ b/templates/index.html
@@ -1175,7 +1175,7 @@
     <script src="{{ url_for('static', filename='js/command-library.js') }}?v=3"></script>
     <script src="{{ url_for('static', filename='js/command-set-manager.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/connection-command-manager.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/session-command-launcher.js') }}?v=1"></script>
+    <script src="{{ url_for('static', filename='js/session-command-launcher.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/file-transfer.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/browser-filesystem.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=3"></script>

--- a/tests/js/session-command-launcher.test.js
+++ b/tests/js/session-command-launcher.test.js
@@ -1,5 +1,7 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const launcher = require('../../static/js/session-command-launcher.js');
 
@@ -103,4 +105,91 @@ test('refuses stale, disconnected, and multiline targets', () => {
     assert.equal(controller.insert('offline', 'command', 'cmd-1').ok, false);
     assert.equal(controller.insert('offline', 'command', 'cmd-multiline').ok, false);
     assert.deepEqual(emissions, []);
+});
+
+test('mounts with the real top-level const manager pattern', () => {
+    class FakeElement {
+        constructor(tagName) {
+            this.tagName = tagName;
+            this.children = [];
+            this.dataset = {};
+            this.attributes = {};
+            this.className = '';
+        }
+
+        addEventListener() {}
+
+        append(...children) {
+            children.forEach(child => this.appendChild(child));
+        }
+
+        appendChild(child) {
+            child.parentElement = this;
+            this.children.push(child);
+            return child;
+        }
+
+        remove() {
+            if (!this.parentElement) return;
+            this.parentElement.children = this.parentElement.children.filter(
+                child => child !== this
+            );
+        }
+
+        setAttribute(name, value) {
+            this.attributes[name] = String(value);
+        }
+    }
+
+    const pane = new FakeElement('div');
+    pane.dataset.paneIndex = '0';
+    const document = {
+        addEventListener() {},
+        createElement: tagName => new FakeElement(tagName),
+        querySelector: selector => (
+            selector === '.terminal-pane[data-pane-index="0"]' ? pane : null
+        ),
+        querySelectorAll: () => [],
+    };
+    const context = vm.createContext({
+        document,
+        addEventListener() {},
+        setTimeout: callback => callback(),
+    });
+    context.window = context;
+    vm.runInContext(`
+        const SessionManager = {
+            paneAssignments: ['real-session'],
+            getActivePaneIndex: () => 0,
+            getSession: id => id === 'real-session'
+                ? { connected: true, displayName: 'Production Edge' }
+                : null,
+        };
+        const CommandLibrary = {
+            commands: [{
+                id: 'status',
+                name: 'Status',
+                command: 'systemctl status webssh',
+                parameters: '',
+                description: 'Service status',
+            }],
+        };
+        const TerminalManager = { terminals: {} };
+        window.CommandSetManager = { commandSets: [] };
+    `, context);
+    const source = fs.readFileSync(
+        'static/js/session-command-launcher.js',
+        'utf8'
+    );
+
+    vm.runInContext(source, context);
+    context.SessionCommandLauncher.init();
+
+    assert.equal(
+        pane.children.some(child => child.className === 'session-command-launcher'),
+        true
+    );
+    const entries = context.SessionCommandLauncher.controller.entries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].id, 'status');
 });

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -36,7 +36,7 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
         "filename='js/jump-host-manager.js'": '?v=4',
         "filename='js/command-library.js'": '?v=3',
         "filename='js/command-set-manager.js'": '?v=2',
-        "filename='js/session-command-launcher.js'": '?v=1',
+        "filename='js/session-command-launcher.js'": '?v=2',
         "filename='js/app.js'": '?v=10',
     }
     for asset, version in expected_versions.items():


### PR DESCRIPTION
## Summary

- resolve the active session, command library, and terminal managers from their real top-level `const` bindings
- preserve the existing window fallback for isolated consumers
- bump the launcher asset version so browsers do not reuse the broken script
- add a regression test that executes the launcher with the application's real global binding pattern

## Root cause

The launcher used `window.SessionManager`, `window.CommandLibrary`, and `window.TerminalManager`. These managers are declared as top-level `const` values in classic scripts and therefore are available to later scripts but are not properties of `window`. The launcher consequently treated every real workspace as having no active session and did not mount its button.

## Security

The change only corrects frontend manager lookup. It does not add an endpoint, change session ownership checks, alter terminal payloads, or weaken the existing CR/LF insertion guard.

## Validation

- `npm run test:js` - 153 passed
- profile UI contracts - 20 passed
- JavaScript syntax and `git diff --check`
- regression test observed failing before the fix and passing afterward