### PR TITLE
Keep code graph focused on project sources

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,3 @@
+# Keep the public code graph focused on first-party project code.
+/static/vendor/
+/site/vendor/

--- a/tests/test_public_product_surface.py
+++ b/tests/test_public_product_surface.py
@@ -8,6 +8,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 PAGES_WORKFLOW = ROOT / ".github" / "workflows" / "graph-pages.yml"
+GRAPHIFY_IGNORE = ROOT / ".graphifyignore"
 LANDING_PAGE = ROOT / "site" / "index.html"
 SESSION_WORKSPACE_IMAGE = ROOT / "assets" / "session-workspace.png"
 SESSION_DIAGNOSTICS_IMAGE = ROOT / "assets" / "session-diagnostics.png"
@@ -33,6 +34,18 @@ def test_pages_workflow_publishes_product_root_and_code_graph_subpath():
     assert "cp -R site/. _site/" in workflow
     assert "mkdir -p _site/code-graph" in workflow
     assert "cp graphify-out/graph.html _site/code-graph/index.html" in workflow
+
+
+def test_code_graph_excludes_vendored_runtime_dependencies():
+    """The public code graph stays focused on first-party project code."""
+    patterns = {
+        line.strip()
+        for line in GRAPHIFY_IGNORE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert "/static/vendor/" in patterns
+    assert "/site/vendor/" in patterns
 
 
 def test_readme_code_map_badge_targets_graph_subpath():


### PR DESCRIPTION
## Summary
- Exclude committed third-party runtime bundles from Graphify scans
- Add a repository contract test for the exclusions

## Why
The xterm.js 6 vendor update pushed the raw graph above Graphify's 5,000-node visualization limit. GitHub Pages therefore published an aggregated community view instead of the full code-level graph.

## Impact
The generated graph returns to a full node-level view while application runtime assets and vendoring behavior remain unchanged.

## Validation
- `python -m pytest tests -q` - 1,560 passed, 33 skipped
- Focused repository policy tests - 9 passed
- Graphify 0.9.39 rebuild - 4,366 nodes, 10,294 edges, 204 communities, no vendored nodes
- `git diff --check`