### PR TITLE
Add safe LDAP auto-provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,7 @@ MAX_RECOVERY_JSON_SIZE=4096
 # the documented `docker-compose.ldap.yml` helper instead of placing secrets
 # here.
 LDAP_ENABLED=false
+LDAP_AUTO_PROVISION=false
 LDAP_PROVIDER_ID=default
 LDAP_URL=
 LDAP_BASE_DN=

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ docker build -t webssh:local .
 | `OIDC_ALLOWED_DOMAINS` | No | - | Optional comma-separated email-domain policy; identity linking still uses issuer and subject only |
 | `OIDC_LOGIN_RATE_LIMIT` | No | `10 per minute` | Per-IP rate limit for starting OIDC login |
 | `LDAP_ENABLED` | No | `false` | Enable optional LDAP/LDAPS authentication; the provided `docker-compose.ldap.yml` overlay sets this to `true` |
+| `LDAP_AUTO_PROVISION` | No | `false` | Create a non-admin LDAP-managed account after the first successful directory sign-in; existing local usernames are never claimed automatically |
 | `LDAP_PROVIDER_ID` | With LDAP | `default` | Stable local identifier for this directory; do not change it after linking users |
 | `LDAP_URL` | With LDAP | - | Exact `ldap://host:port` (mandatory StartTLS) or `ldaps://host:port` URL |
 | `LDAP_BASE_DN` | With LDAP | - | Subtree base for directory user searches |
@@ -557,6 +558,7 @@ and keep it on the same WebSSH release or commit as `docker-compose.yml`.
 
    ```yaml
    LDAP_ENABLED: "true"
+   LDAP_AUTO_PROVISION: "false"
    LDAP_PROVIDER_ID: primary-directory
    LDAP_URL: ldaps://ldap.example.com:636
    LDAP_BASE_DN: ou=people,dc=example,dc=com
@@ -603,11 +605,21 @@ and keep it on the same WebSSH release or commit as `docker-compose.yml`.
    docker compose -f docker-compose.yml -f docker-compose.ldap.yml -f docker-compose.production.yml up -d
    ```
 
-5. Sign in with the existing local break-glass administrator. In **Admin**,
-   create or select a non-admin WebSSH account and use **Link LDAP** to attach
-   the directory's stable identity. WebSSH deliberately does not auto-provision
-   accounts and never grants administrator rights through LDAP. Test **Sign in
-   with LDAP** before relying on it.
+5. Sign in with the existing local break-glass administrator. With the safe
+   default `LDAP_AUTO_PROVISION: "false"`, create or select a non-admin WebSSH
+   account in **Admin** and use **Link LDAP** to attach the directory's stable
+   identity. For larger directories, set `LDAP_AUTO_PROVISION: "true"` to
+   create a non-admin LDAP-managed account only after its first successful
+   directory password bind. Automatic provisioning never claims an existing
+   local username and still requires an active local break-glass administrator.
+
+The login page selects the configured `LDAP_PROVIDER_ID` by default whenever
+LDAP is enabled. Local password sign-in remains available from the
+**Authentication Source** selector. Auto-provisioned directory usernames must
+fit the 80-character local account field and contain no control characters;
+they are never silently truncated. Removed directory accounts lose access via
+the normal fail-closed revalidation, but WebSSH does not automatically delete
+their stored user data.
 
 To disable LDAP again, recreate WebSSH from the standard Compose file only:
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -128,6 +128,7 @@ def create_app(
             'webauthn_enabled': config.WEBAUTHN_ENABLED,
             'oidc_enabled': config.OIDC_ENABLED,
             'ldap_enabled': config.LDAP_ENABLED,
+            'ldap_provider_id': config.LDAP_PROVIDER_ID,
             'ldap_managed': bool(
                 current_user.is_authenticated
                 and current_user.is_ldap_managed
@@ -421,7 +422,7 @@ def create_app(
             ):
                 log_rate_limit_exceeded('login', client_ip)
                 flash('Too many login attempts. Please try again later.', 'error')
-                return render_template('login.html')
+                return render_template('login.html', auth_source='local')
 
             username = request.form.get('username')
             password = request.form.get('password')
@@ -435,7 +436,10 @@ def create_app(
             else:
                 log_login_attempt(username, False, client_ip, request.user_agent.string)
                 flash(error, 'error')
-        return render_template('login.html')
+        return render_template(
+            'login.html',
+            auth_source='local' if request.method == 'POST' else None,
+        )
 
     @app.route('/register', methods=['GET', 'POST'])
     def register():

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,8 +1,10 @@
 import bcrypt
 import config
+from contextlib import contextmanager
 from threading import Lock
 from flask_login import LoginManager
 from datetime import datetime, timedelta, timezone
+from sqlalchemy import text
 from .models import db, User, SocketSession
 from .rate_limiter import create_rate_limiter
 
@@ -16,7 +18,20 @@ _DUMMY_PASSWORD_HASH = bcrypt.hashpw(b'account-enumeration-mitigation', bcrypt.g
 # Rate limiter instance — initialized in init_auth().
 # Falls back to in-memory automatically if Redis is unavailable.
 _rate_limiter = None
-_registration_lock = Lock()
+user_creation_lock = Lock()
+
+
+@contextmanager
+def user_creation_transaction():
+    """Serialize account-name checks and writes across SQLite connections."""
+    with user_creation_lock:
+        db.session.rollback()
+        db.session.execute(text('BEGIN IMMEDIATE'))
+        try:
+            yield
+        finally:
+            if db.session().in_transaction():
+                db.session.rollback()
 
 
 def _get_rate_limiter():
@@ -136,7 +151,9 @@ def validate_new_user(username, password):
     if not username.replace('_', '').isalnum():
         return "Username can only contain letters, numbers, and underscores"
 
-    if User.query.filter_by(username=username).first():
+    normalized_username = username.casefold()
+    existing_names = User.query.with_entities(User.username).all()
+    if any(row.username.casefold() == normalized_username for row in existing_names):
         return "Username already exists"
 
     if not password or len(password) < 8:
@@ -161,7 +178,7 @@ def register_user(username, password, *, first_user_only=False):
     Returns:
         tuple: (User object, error message) - one will be None
     """
-    with _registration_lock:
+    with user_creation_transaction():
         is_first_user = User.query.order_by(User.id).first() is None
         if first_user_only and not is_first_user:
             return None, 'Registration is currently disabled.'
@@ -193,7 +210,7 @@ def is_bootstrap_registration_available():
 
 def ensure_initial_admin():
     """Return an existing admin or promote the oldest user if none exists."""
-    with _registration_lock:
+    with user_creation_lock:
         existing_admin = (
             User.query
             .filter_by(is_admin=True)

--- a/app/cli.py
+++ b/app/cli.py
@@ -9,7 +9,10 @@ from flask import current_app
 
 import config
 from .audit_logger import audit_logger, log_warning
-from .auth import validate_new_user
+from .auth import (
+    user_creation_transaction,
+    validate_new_user,
+)
 from .models import User, db
 
 
@@ -124,6 +127,10 @@ def create_admin(username, password_file):
 
     user = User.query.filter_by(username=username).first()
     if user is not None:
+        if user.is_ldap_managed:
+            raise click.ClickException(
+                'LDAP-managed accounts cannot be administrators.'
+            )
         if password_file is not None:
             raise click.ClickException(
                 '--password-file cannot be used when promoting an existing '
@@ -148,20 +155,21 @@ def create_admin(username, password_file):
     else:
         password = _read_password_file(password_file)
 
-    error = validate_new_user(username, password)
-    if error:
-        raise click.ClickException(error)
+    with user_creation_transaction():
+        error = validate_new_user(username, password)
+        if error:
+            raise click.ClickException(error)
 
-    user = User(username=username, is_admin=True)
-    user.set_password(password)
-    db.session.add(user)
-    try:
-        db.session.flush()
-        user.get_data_dir()
-        db.session.commit()
-    except Exception:
-        db.session.rollback()
-        raise
+        user = User(username=username, is_admin=True)
+        user.set_password(password)
+        db.session.add(user)
+        try:
+            db.session.flush()
+            user.get_data_dir()
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            raise
 
     _audit_admin_bootstrap(username, 'created')
     click.echo(f'Administrator created: {username}')

--- a/app/ldap_routes.py
+++ b/app/ldap_routes.py
@@ -3,6 +3,7 @@
 import logging
 import secrets
 import time
+import unicodedata
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
 
@@ -19,6 +20,7 @@ from .auth import (
     check_rate_limit,
     check_reauth_rate_limit,
     password_exceeds_bcrypt_limit,
+    user_creation_transaction,
 )
 from .decorators import admin_required
 from .ldap_service import LDAPDirectory, LDAPLookupRejected, LDAPUnavailable
@@ -35,6 +37,7 @@ from .models import (
 ldap_blueprint = Blueprint('ldap', __name__)
 _MAX_LDAP_FORM_BYTES = 4096
 _MAX_LDAP_JSON_BYTES = 4096
+_MAX_AUTO_PROVISIONED_USERNAME_LENGTH = 80
 
 
 def _bounded_json():
@@ -84,14 +87,103 @@ def _rate_limited(endpoint):
     return False
 
 
+def _auto_provision_ldap_identity(username, resolved, *, presented_username=None):
+    """Create one non-admin LDAP account after its credentials are verified."""
+    presented_username = (
+        username if presented_username is None else presented_username
+    )
+    if (
+        not username
+        or len(username) > _MAX_AUTO_PROVISIONED_USERNAME_LENGTH
+        or any(
+            unicodedata.category(character).startswith('C')
+            for character in presented_username
+        )
+    ):
+        raise LDAPLookupRejected('Directory username cannot be provisioned safely')
+
+    with user_creation_transaction():
+        local_admin = (
+            User.query
+            .filter_by(is_admin=True, is_locked=False)
+            .filter(~User.ldap_identity.has())
+            .first()
+        )
+        if local_admin is None:
+            raise LDAPLookupRejected(
+                'A local break-glass administrator is required'
+            )
+
+        normalized_username = username.casefold()
+        existing_names = User.query.with_entities(User.username).all()
+        if any(
+            row.username.casefold() == normalized_username
+            for row in existing_names
+        ):
+            raise LDAPLookupRejected(
+                'Directory username conflicts with a local account'
+            )
+
+        user = User(username=username, is_admin=False, is_locked=False)
+        user.set_password(secrets.token_urlsafe(48))
+        mapping = LDAPIdentity(
+            user=user,
+            provider=resolved.provider,
+            subject=resolved.subject,
+            directory_username=username,
+            distinguished_name=resolved.distinguished_name,
+            last_verified_at=datetime.now(timezone.utc),
+        )
+        db.session.add_all((user, mapping))
+        try:
+            db.session.flush()
+            user.get_data_dir()
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            mapping = LDAPIdentity.query.filter_by(
+                provider=resolved.provider,
+                subject=resolved.subject,
+            ).first()
+            if (
+                mapping is None
+                or mapping.user.is_locked
+                or mapping.user.is_admin
+            ):
+                raise LDAPLookupRejected(
+                    'Directory identity could not be provisioned uniquely'
+                )
+            return mapping
+        except Exception as exc:
+            db.session.rollback()
+            log_security_event(
+                'LDAP_AUTO_PROVISION_STORAGE_FAILED',
+                level=logging.ERROR,
+                user=username,
+                provider=resolved.provider,
+                error=type(exc).__name__,
+            )
+            raise LDAPUnavailable(
+                'LDAP account provisioning storage is unavailable'
+            ) from exc
+
+    log_security_event(
+        'LDAP_USER_AUTO_PROVISIONED',
+        user=user.username,
+        provider=mapping.provider,
+    )
+    return mapping
+
+
 @ldap_blueprint.post('/login/ldap')
 def ldap_login():
     if request.content_length and request.content_length > _MAX_LDAP_FORM_BYTES:
-        return render_template('login.html'), 413
+        return render_template('login.html', auth_source='ldap'), 413
     if _rate_limited('ldap_login'):
-        return render_template('login.html'), 429
+        return render_template('login.html', auth_source='ldap'), 429
 
-    username = str(request.form.get('username') or '').strip()
+    presented_username = str(request.form.get('username') or '')
+    username = presented_username.strip()
     password = request.form.get('password') or ''
     client_ip = request.remote_addr or 'unknown'
     try:
@@ -102,16 +194,23 @@ def ldap_login():
             subject=resolved.subject,
         ).first()
         if (
-            mapping is None
-            or mapping.user.is_locked
-            or mapping.user.is_admin
+            mapping is not None
+            and (mapping.user.is_locked or mapping.user.is_admin)
         ):
+            raise LDAPLookupRejected('Identity is not linked to an active user')
+        if mapping is None and not config.LDAP_AUTO_PROVISION:
             raise LDAPLookupRejected('Identity is not linked to an active user')
         if not directory.verify_password(
             resolved.distinguished_name,
             password,
         ):
             raise LDAPLookupRejected('LDAP credentials are invalid')
+        if mapping is None:
+            mapping = _auto_provision_ldap_identity(
+                username,
+                resolved,
+                presented_username=presented_username,
+            )
     except LDAPLookupRejected:
         log_security_event(
             'LDAP_LOGIN_REJECTED',
@@ -123,6 +222,7 @@ def ldap_login():
         return render_template(
             'login.html',
             ldap_error='Invalid username or password',
+            auth_source='ldap',
         ), 401
     except LDAPUnavailable as exc:
         log_security_event(
@@ -135,6 +235,7 @@ def ldap_login():
         return render_template(
             'login.html',
             ldap_error='Directory sign-in is temporarily unavailable',
+            auth_source='ldap',
         ), 503
 
     user = mapping.user

--- a/config.py
+++ b/config.py
@@ -86,6 +86,9 @@ OIDC_LOGIN_RATE_LIMIT = os.environ.get(
 # explicit feature flag is enabled; in particular, secret files are never read
 # while LDAP is disabled.
 LDAP_ENABLED = os.environ.get('LDAP_ENABLED', 'false').lower() == 'true'
+LDAP_AUTO_PROVISION = (
+    os.environ.get('LDAP_AUTO_PROVISION', 'false').lower() == 'true'
+)
 LDAP_PROVIDER_ID = os.environ.get('LDAP_PROVIDER_ID', 'default').strip()
 LDAP_URL = os.environ.get('LDAP_URL', '').strip()
 LDAP_BASE_DN = os.environ.get('LDAP_BASE_DN', '').strip()

--- a/docker-compose.ldap.yml
+++ b/docker-compose.ldap.yml
@@ -8,6 +8,7 @@ services:
   webssh:
     environment:
       LDAP_ENABLED: "true"
+      LDAP_AUTO_PROVISION: "false"
       LDAP_PROVIDER_ID: default
       LDAP_URL: ""
       LDAP_BASE_DN: ""

--- a/docs/ldap-authentication.md
+++ b/docs/ldap-authentication.md
@@ -16,14 +16,20 @@ the provided `docker-compose.ldap.yml` overlay with the same WebSSH image; no
   submitted user password is used only for the final bind and is never stored.
 - Directory usernames are escaped as RFC 4515 filter values. Searches are
   subtree-scoped, limited to two results, and must resolve to exactly one entry.
-- An administrator explicitly links a directory identity to an existing local
-  WebSSH user. There is no automatic account creation or username-only trust.
+- By default, an administrator explicitly links a directory identity to an
+  existing local WebSSH user. Optional auto-provisioning still requires a
+  successful password bind and never trusts a username by itself.
 - The stable `entryUUID` (OpenLDAP) or `objectGUID` (Active Directory) is the
   identity key. A renamed DN can be updated after successful authentication
   without changing account ownership.
 - LDAP users cannot be administrators and cannot fall back to local passwords,
   passkeys, recovery codes, or OIDC. Keep at least one unlinked local
   break-glass administrator.
+- `LDAP_AUTO_PROVISION=true` creates a non-admin LDAP-managed account only
+  after the first successful directory sign-in. It requires an active local
+  break-glass administrator and never attaches LDAP to an existing local
+  username. Case-insensitive collisions, control characters, and names longer
+  than 80 characters are rejected without truncation.
 - Linking destroys the user's dormant local password and all alternative local
   login factors. Unlinking requires a fresh local password.
 - LDAP sessions are revalidated every five minutes by default. A disabled
@@ -58,6 +64,7 @@ files from the same WebSSH release.
 
 ```yaml
 LDAP_ENABLED: "true"
+LDAP_AUTO_PROVISION: "false"
 LDAP_PROVIDER_ID: corp-ad
 LDAP_URL: ldaps://dc01.ad.example.com:636
 LDAP_BASE_DN: OU=People,DC=ad,DC=example,DC=com
@@ -74,6 +81,7 @@ Nested group semantics vary and must be validated by the AD administrator.
 
 ```yaml
 LDAP_ENABLED: "true"
+LDAP_AUTO_PROVISION: "false"
 LDAP_PROVIDER_ID: primary-openldap
 LDAP_URL: ldap://ldap.example.com:389
 LDAP_BASE_DN: ou=people,dc=example,dc=com
@@ -134,10 +142,17 @@ incomplete LDAP configuration prevents the Flask application from starting.
 4. Sign in with the local break-glass administrator.
 5. Open **Admin - Settings - LDAP directory** and run **Check connection**.
    The browser receives only ready/unavailable, transport, and provider ID.
-6. Create the target local WebSSH user if it does not exist.
-7. On the Users tab choose **Link LDAP**, enter the directory username, the
-   administrator password, and the exact target WebSSH username.
-8. Sign out and test **Sign in with LDAP** using that directory username.
+6. Keep `LDAP_AUTO_PROVISION: "false"` for explicit account lifecycle control.
+   Create the target local WebSSH user, then choose **Link LDAP** on the Users
+   tab and provide the directory username, administrator password, and exact
+   target WebSSH username.
+7. For larger directories, optionally set `LDAP_AUTO_PROVISION: "true"` and
+   recreate WebSSH with the overlay. A verified first sign-in then creates a
+   non-admin LDAP-managed account. Existing local usernames still require the
+   explicit administrator linking flow.
+8. Sign out and test the directory account. When LDAP is enabled, its
+   `LDAP_PROVIDER_ID` is the default **Authentication Source**; local sign-in
+   remains selectable.
 
 Do one non-administrator pilot account before migrating more users.
 
@@ -160,6 +175,9 @@ This removes the LDAP environment and mount from the container. The named
 secret volume remains stored but detached until the overlay is selected again.
 Existing LDAP sessions are invalidated. Local accounts continue normally, but
 linked LDAP accounts intentionally do not regain their old passwords.
+Directory removal or filter exclusion revokes access without deleting the
+account's stored WebSSH data; delete that data only through the normal explicit
+administrator lifecycle.
 
 To return one account to local authentication while LDAP is working, choose
 **Manage LDAP**, provide the administrator password, exact target username, and

--- a/scripts/run_integration_tests.py
+++ b/scripts/run_integration_tests.py
@@ -70,6 +70,7 @@ def main() -> int:
         environment = os.environ.copy()
         environment.update({
             "PARAMIKO5_INTEGRATION": "1",
+            "PARAMIKO5_DISPOSABLE_LAB": "1",
             "PARAMIKO5_TARGET_HOST": "127.0.0.1",
             "PARAMIKO5_TARGET_PORT": "2223",
             "PARAMIKO5_PROXY_TARGET_HOST": "target",

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,22 +1,22 @@
 (function() {
     'use strict';
 
-    function createLoginModeController(elements) {
+    function createAuthenticationSourceController(elements) {
         const {
-            defaultPanel,
-            ldapPanel,
-            trigger,
+            sourceSelect,
+            localForm,
+            ldapForm,
             localPassword,
             ldapPassword,
             ldapUsername,
             localUsername
         } = elements;
 
-        function applyMode(mode, { clearPassword = true, focus = true } = {}) {
-            const ldapActive = mode === 'ldap';
-            defaultPanel.classList.toggle('hidden', ldapActive);
-            ldapPanel.classList.toggle('hidden', !ldapActive);
-            trigger.setAttribute('aria-expanded', String(ldapActive));
+        function applySource(source, { clearPassword = true, focus = true } = {}) {
+            const ldapActive = source === 'ldap';
+            sourceSelect.value = ldapActive ? 'ldap' : 'local';
+            localForm.classList.toggle('hidden', ldapActive);
+            ldapForm.classList.toggle('hidden', !ldapActive);
 
             if (clearPassword) {
                 const passwordToClear = ldapActive ? localPassword : ldapPassword;
@@ -31,41 +31,38 @@
         }
 
         return {
-            showLdap() {
-                applyMode('ldap');
-            },
-            showDefault() {
-                applyMode('default');
+            select(source) {
+                applySource(source);
             },
             sync() {
-                const initialMode = ldapPanel.classList.contains('hidden')
-                    ? 'default'
-                    : 'ldap';
-                applyMode(initialMode, { clearPassword: false });
+                applySource(sourceSelect.value, {
+                    clearPassword: false,
+                    focus: false
+                });
             }
         };
     }
 
-    function setupLoginModes() {
-        const defaultPanel = document.getElementById('defaultLoginMode');
-        const ldapPanel = document.getElementById('ldapLoginMode');
-        const trigger = document.getElementById('ldapLoginBtn');
-        const backButton = document.getElementById('ldapBackBtn');
-        if (!defaultPanel || !ldapPanel || !trigger || !backButton) {
+    function setupAuthenticationSources() {
+        const sourceSelect = document.getElementById('authenticationSource');
+        const localForm = document.getElementById('localLoginForm');
+        const ldapForm = document.getElementById('ldapLoginForm');
+        if (!sourceSelect || !localForm || !ldapForm) {
             return;
         }
 
-        const controller = createLoginModeController({
-            defaultPanel,
-            ldapPanel,
-            trigger,
+        const controller = createAuthenticationSourceController({
+            sourceSelect,
+            localForm,
+            ldapForm,
             localPassword: document.getElementById('password'),
             ldapPassword: document.getElementById('ldapPassword'),
             ldapUsername: document.getElementById('ldapUsername'),
             localUsername: document.getElementById('username')
         });
-        trigger.addEventListener('click', controller.showLdap);
-        backButton.addEventListener('click', controller.showDefault);
+        sourceSelect.addEventListener('change', () => {
+            controller.select(sourceSelect.value);
+        });
         controller.sync();
     }
 
@@ -187,7 +184,7 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-        setupLoginModes();
+        setupAuthenticationSources();
         setupPasswordToggles();
         setupLoginValidation();
         setupRegisterValidation();
@@ -195,6 +192,6 @@
     });
 
     if (typeof module === 'object' && module.exports) {
-        module.exports = { createLoginModeController };
+        module.exports = { createAuthenticationSourceController };
     }
 })();

--- a/templates/login.html
+++ b/templates/login.html
@@ -42,15 +42,26 @@
                 {% endif %}
             {% endwith %}
 
-            <section id="defaultLoginMode" class="login-mode{% if ldap_error %} hidden{% endif %}">
-            <form method="POST" action="{{ url_for('login') }}">
+            {% set selected_auth_source = auth_source if auth_source in ('local', 'ldap') else ('ldap' if ldap_enabled else 'local') %}
+            <section id="passwordLoginMode" class="login-mode">
+            {% if ldap_enabled %}
+            <div class="form-group">
+                <label for="authenticationSource">Authentication Source</label>
+                <select id="authenticationSource" class="form-control" aria-controls="localLoginForm ldapLoginForm">
+                    <option value="local"{% if selected_auth_source == 'local' %} selected{% endif %}>Local account</option>
+                    <option value="ldap"{% if selected_auth_source == 'ldap' %} selected{% endif %}>{{ ldap_provider_id }}</option>
+                </select>
+            </div>
+            {% endif %}
+
+            <form method="POST" action="{{ url_for('login') }}" id="localLoginForm" class="auth-source-form{% if selected_auth_source != 'local' %} hidden{% endif %}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 <div class="form-group">
                     <label for="username" data-i18n="auth.username">Username</label>
                     <div class="input-wrapper">
                         <span class="input-icon">👤</span>
                         <input type="text" id="username" name="username" class="form-control"
-                               data-i18n="auth.username" placeholder="Username" required autofocus>
+                               data-i18n="auth.username" placeholder="Username" required{% if selected_auth_source == 'local' %} autofocus{% endif %}>
                     </div>
                     <div class="field-hint" id="loginUsernameHint"></div>
                 </div>
@@ -77,9 +88,26 @@
             </form>
 
             {% if ldap_enabled %}
-            <button type="button" class="btn-primary" id="ldapLoginBtn" aria-controls="ldapLoginMode" aria-expanded="false" style="margin-top:12px;">
-                Sign in with LDAP
-            </button>
+            <form method="POST" action="{{ url_for('ldap.ldap_login') }}" id="ldapLoginForm" class="auth-source-form{% if selected_auth_source != 'ldap' %} hidden{% endif %}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="form-group">
+                    <label for="ldapUsername">Directory username</label>
+                    <div class="input-wrapper">
+                        <span class="input-icon">&#128100;</span>
+                        <input type="text" id="ldapUsername" name="username" class="form-control" autocomplete="username" required{% if selected_auth_source == 'ldap' %} autofocus{% endif %}>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="ldapPassword">Directory password</label>
+                    <div class="input-wrapper">
+                        <span class="input-icon">&#128274;</span>
+                        <input type="password" id="ldapPassword" name="password" class="form-control" autocomplete="current-password" required>
+                        <button type="button" class="password-toggle" data-target="ldapPassword" aria-label="Toggle password visibility" data-i18n-aria-label="auth.togglePasswordVisibility">&#128065;&#65039;</button>
+                    </div>
+                </div>
+                {% if ldap_error %}<div class="alert alert-error">{{ ldap_error }}</div>{% endif %}
+                <button type="submit" class="btn-primary">Sign in</button>
+            </form>
             {% endif %}
             {% if webauthn_enabled %}
             <button type="button" class="btn-primary" id="passkeyLoginBtn" style="margin-top:12px;" data-i18n="auth.signInWithPasskey">
@@ -117,41 +145,11 @@
                 {% endif %}
             </div>
             </section>
-
-            {% if ldap_enabled %}
-            <section id="ldapLoginMode" class="login-mode{% if not ldap_error %} hidden{% endif %}" aria-labelledby="ldapLoginTitle">
-                <button type="button" class="login-mode-back" id="ldapBackBtn" aria-label="Back to sign-in options" title="Back to sign-in options">&larr;</button>
-                <div class="login-mode-heading">
-                    <h2 id="ldapLoginTitle">LDAP sign in</h2>
-                    <p>Use your directory account credentials</p>
-                </div>
-                <form method="POST" action="{{ url_for('ldap.ldap_login') }}" id="ldapLoginForm">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <div class="form-group">
-                        <label for="ldapUsername">Directory username</label>
-                        <div class="input-wrapper">
-                            <span class="input-icon">&#128100;</span>
-                            <input type="text" id="ldapUsername" name="username" class="form-control" autocomplete="username" required>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="ldapPassword">Directory password</label>
-                        <div class="input-wrapper">
-                            <span class="input-icon">&#128274;</span>
-                            <input type="password" id="ldapPassword" name="password" class="form-control" autocomplete="current-password" required>
-                            <button type="button" class="password-toggle" data-target="ldapPassword" aria-label="Toggle password visibility" data-i18n-aria-label="auth.togglePasswordVisibility">&#128065;&#65039;</button>
-                        </div>
-                    </div>
-                    {% if ldap_error %}<div class="alert alert-error">{{ ldap_error }}</div>{% endif %}
-                    <button type="submit" class="btn-primary">Sign in</button>
-                </form>
-            </section>
-            {% endif %}
         </div>
     </div>
 
     <script src="{{ url_for('static', filename='js/i18n.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/auth.js') }}?v=2"></script>
+    <script src="{{ url_for('static', filename='js/auth.js') }}?v=3"></script>
     <script src="{{ url_for('static', filename='js/webauthn.js') }}"></script>
     <script>
         function toggleLangDropdown() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,75 @@
 import os
 import tempfile
+from pathlib import Path
+from urllib.parse import urlsplit
+
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, rsa
 
-os.environ.setdefault('SECRET_KEY', 'test-secret-key-for-unit-tests-only')
-os.environ.setdefault(
-    'OIDC_REDIRECT_URI',
-    'https://localhost/oidc/callback',
+_SESSION_DATA_DIRECTORY = tempfile.TemporaryDirectory(
+    prefix='webssh-pytest-session-',
+    ignore_cleanup_errors=True,
 )
-os.environ['DEBUG'] = 'True'
+_SESSION_TEST_ROOT = Path(_SESSION_DATA_DIRECTORY.name)
+_TEST_ENVIRONMENT = {
+    'SECRET_KEY': 'test-secret-key-for-unit-tests-only',
+    'OIDC_REDIRECT_URI': 'https://localhost/oidc/callback',
+    'DEBUG': 'True',
+    'DEPLOYMENT_PROFILE': 'homelab',
+    'DATA_DIR': str(_SESSION_TEST_ROOT / 'data'),
+    'TRANSFER_TEMP_DIR': str(_SESSION_TEST_ROOT / 'transfers'),
+    'BACKUP_TEMP_DIR': str(_SESSION_TEST_ROOT / 'backups'),
+    'RATELIMIT_STORAGE_URL': 'memory://',
+    'LDAP_ENABLED': 'false',
+    'LDAP_AUTO_PROVISION': 'false',
+    'OIDC_ENABLED': 'false',
+    'TAILSCALE_SSH_ENABLED': 'false',
+}
+_ORIGINAL_TEST_ENVIRONMENT = {
+    name: os.environ.get(name)
+    for name in _TEST_ENVIRONMENT
+}
+
+
+def _validate_real_redis_target():
+    value = os.environ.get('TEST_REDIS_URL')
+    if not value:
+        return
+    try:
+        parsed = urlsplit(value)
+        database = int(parsed.path.removeprefix('/'))
+    except (TypeError, ValueError):
+        parsed = None
+        database = 0
+    if (
+        parsed is None
+        or parsed.scheme not in {'redis', 'rediss'}
+        or parsed.hostname not in {'localhost', '127.0.0.1', '::1'}
+        or not parsed.path.startswith('/')
+        or parsed.path.count('/') != 1
+        or database <= 0
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise pytest.UsageError(
+            'TEST_REDIS_URL must use loopback and an explicit non-zero database'
+        )
+
+
+_validate_real_redis_target()
+for _name, _value in _TEST_ENVIRONMENT.items():
+    os.environ[_name] = _value
+
+
+def pytest_unconfigure(config):
+    del config
+    for name, original in _ORIGINAL_TEST_ENVIRONMENT.items():
+        if original is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = original
+    _SESSION_DATA_DIRECTORY.cleanup()
 
 
 @pytest.fixture
@@ -19,7 +79,7 @@ def app(monkeypatch):
     # teardown; disposing the engine below handles the normal case, this is a
     # belt-and-suspenders guard so a stray handle never fails the test.
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-        os.environ['DATA_DIR'] = tmpdir
+        monkeypatch.setenv('DATA_DIR', tmpdir)
         # Re-import config to pick up test DATA_DIR
         import importlib
         import config

--- a/tests/fixtures/environment_probe.py
+++ b/tests/fixtures/environment_probe.py
@@ -1,0 +1,22 @@
+"""Probe imported by the test-suite isolation regression test."""
+
+import os
+from pathlib import Path
+
+import config
+
+
+def test_deployment_environment_is_neutralized_before_collection():
+    sentinel = Path(os.environ["WEBSSH_TEST_SENTINEL_DATA_DIR"])
+
+    assert Path(config.DATA_DIR).resolve() != sentinel.resolve()
+    assert not Path(config.TRANSFER_TEMP_DIR).resolve().is_relative_to(
+        sentinel.resolve()
+    )
+    assert not Path(config.BACKUP_TEMP_DIR).resolve().is_relative_to(
+        sentinel.resolve()
+    )
+    assert config.RATELIMIT_STORAGE_URL == "memory://"
+    assert config.LDAP_ENABLED is False
+    assert config.OIDC_ENABLED is False
+    assert config.TAILSCALE_SSH_ENABLED is False

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,32 @@
+"""Fail-closed guards for tests that open real SSH and SFTP connections."""
+
+import os
+
+import pytest
+
+
+_DISPOSABLE_PARAMIKO_ENVIRONMENT = {
+    'PARAMIKO5_DISPOSABLE_LAB': '1',
+    'PARAMIKO5_TARGET_HOST': '127.0.0.1',
+    'PARAMIKO5_TARGET_PORT': '2223',
+    'PARAMIKO5_PROXY_TARGET_HOST': 'target',
+    'PARAMIKO5_PROXY_TARGET_PORT': '22',
+    'PARAMIKO5_BASTION_HOST': '127.0.0.1',
+    'PARAMIKO5_BASTION_PORT': '2222',
+    'PARAMIKO5_CHANGED_HOST': '127.0.0.1',
+    'PARAMIKO5_CHANGED_PORT': '2224',
+    'PROXY_JUMP_REMOTE_DNS_ALLOWLIST': 'target',
+}
+
+
+def pytest_configure(config):
+    del config
+    if os.environ.get('PARAMIKO5_INTEGRATION') != '1':
+        return
+    if any(
+        os.environ.get(name) != expected
+        for name, expected in _DISPOSABLE_PARAMIKO_ENVIRONMENT.items()
+    ):
+        raise pytest.UsageError(
+            'Paramiko integration requires the disposable runner targets'
+        )

--- a/tests/js/login-modes.test.js
+++ b/tests/js/login-modes.test.js
@@ -2,7 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 global.document = { addEventListener() {} };
-const { createLoginModeController } = require('../../static/js/auth.js');
+const { createAuthenticationSourceController } = require('../../static/js/auth.js');
 delete global.document;
 
 function element({ hidden = false, value = '' } = {}) {
@@ -22,56 +22,56 @@ function element({ hidden = false, value = '' } = {}) {
     };
 }
 
-test('LDAP mode hides every standard sign-in option and clears local password', () => {
-    const defaultPanel = element();
-    const ldapPanel = element({ hidden: true });
-    const trigger = element();
+test('selecting LDAP shows its form and clears the local password', () => {
+    const sourceSelect = element({ value: 'local' });
+    const localForm = element();
+    const ldapForm = element({ hidden: true });
     const localPassword = element({ value: 'local-secret' });
     const ldapPassword = element();
     const ldapUsername = element();
     const localUsername = element();
-    const controller = createLoginModeController({
-        defaultPanel,
-        ldapPanel,
-        trigger,
+    const controller = createAuthenticationSourceController({
+        sourceSelect,
+        localForm,
+        ldapForm,
         localPassword,
         ldapPassword,
         ldapUsername,
         localUsername
     });
 
-    controller.showLdap();
+    controller.select('ldap');
 
-    assert.equal(defaultPanel.classList.contains('hidden'), true);
-    assert.equal(ldapPanel.classList.contains('hidden'), false);
-    assert.equal(trigger.attributes.get('aria-expanded'), 'true');
+    assert.equal(sourceSelect.value, 'ldap');
+    assert.equal(localForm.classList.contains('hidden'), true);
+    assert.equal(ldapForm.classList.contains('hidden'), false);
     assert.equal(localPassword.value, '');
     assert.equal(ldapUsername.focused, true);
 });
 
-test('back navigation restores standard sign-in and clears LDAP password', () => {
-    const defaultPanel = element({ hidden: true });
-    const ldapPanel = element();
-    const trigger = element();
+test('selecting local shows its form and clears the LDAP password', () => {
+    const sourceSelect = element({ value: 'ldap' });
+    const localForm = element({ hidden: true });
+    const ldapForm = element();
     const localPassword = element();
     const ldapPassword = element({ value: 'directory-secret' });
     const ldapUsername = element();
     const localUsername = element();
-    const controller = createLoginModeController({
-        defaultPanel,
-        ldapPanel,
-        trigger,
+    const controller = createAuthenticationSourceController({
+        sourceSelect,
+        localForm,
+        ldapForm,
         localPassword,
         ldapPassword,
         ldapUsername,
         localUsername
     });
 
-    controller.showDefault();
+    controller.select('local');
 
-    assert.equal(defaultPanel.classList.contains('hidden'), false);
-    assert.equal(ldapPanel.classList.contains('hidden'), true);
-    assert.equal(trigger.attributes.get('aria-expanded'), 'false');
+    assert.equal(sourceSelect.value, 'local');
+    assert.equal(localForm.classList.contains('hidden'), false);
+    assert.equal(ldapForm.classList.contains('hidden'), true);
     assert.equal(ldapPassword.value, '');
     assert.equal(localUsername.focused, true);
 });

--- a/tests/test_admin_cli.py
+++ b/tests/test_admin_cli.py
@@ -153,6 +153,41 @@ def test_create_admin_rejects_password_file_for_existing_user(
     assert user.password_hash == original_hash
 
 
+def test_create_admin_rejects_promoting_ldap_managed_user(app):
+    from app.auth import register_user
+    from app.models import LDAPIdentity, db
+
+    with app.app_context():
+        admin, admin_error = register_user(
+            'localadmin',
+            'local-admin-password',
+        )
+        assert admin_error is None
+        assert admin.is_admin is True
+        user, error = register_user(
+            'directoryuser',
+            'existing-user-password',
+        )
+        assert error is None
+        db.session.add(LDAPIdentity(
+            user_id=user.id,
+            provider='default',
+            subject='stable-directory-user-id',
+            directory_username='directoryuser',
+            distinguished_name='uid=directoryuser,dc=example,dc=com',
+        ))
+        db.session.commit()
+
+    result = app.test_cli_runner().invoke(
+        args=['create-admin', '--username', 'directoryuser'],
+    )
+
+    assert result.exit_code != 0
+    assert 'LDAP-managed accounts cannot be administrators' in result.output
+    user = _admin(app, 'directoryuser')
+    assert user.is_admin is False
+
+
 def test_create_admin_reads_password_file_and_strips_one_newline(
     app,
     tmp_path,

--- a/tests/test_integration_runner.py
+++ b/tests/test_integration_runner.py
@@ -1,4 +1,8 @@
 import inspect
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -95,12 +99,50 @@ def test_runner_targets_the_compose_ports_exposed_to_the_host(monkeypatch):
     assert run_integration_tests.main() == 0
 
     environment = calls[2][1]["env"]
+    assert environment["PARAMIKO5_DISPOSABLE_LAB"] == "1"
     assert environment["PARAMIKO5_TARGET_HOST"] == "127.0.0.1"
     assert environment["PARAMIKO5_TARGET_PORT"] == "2223"
     assert environment["PARAMIKO5_BASTION_HOST"] == "127.0.0.1"
     assert environment["PARAMIKO5_BASTION_PORT"] == "2222"
     assert environment["PARAMIKO5_CHANGED_HOST"] == "127.0.0.1"
     assert environment["PARAMIKO5_CHANGED_PORT"] == "2224"
+
+
+def test_direct_paramiko_integration_rejects_unmarked_targets():
+    environment = os.environ.copy()
+    environment.update({
+        "PARAMIKO5_INTEGRATION": "1",
+        "PARAMIKO5_TARGET_HOST": "ssh.production.example",
+        "PARAMIKO5_TARGET_PORT": "22",
+        "PARAMIKO5_BASTION_HOST": "bastion.production.example",
+        "PARAMIKO5_BASTION_PORT": "22",
+        "PARAMIKO5_CHANGED_HOST": "ssh.production.example",
+        "PARAMIKO5_CHANGED_PORT": "22",
+        "PARAMIKO5_PROXY_TARGET_HOST": "ssh.production.example",
+        "PARAMIKO5_PROXY_TARGET_PORT": "22",
+    })
+    environment.pop("PARAMIKO5_DISPOSABLE_LAB", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "tests/integration/test_paramiko5_openssh.py",
+            "-q",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Paramiko integration requires the disposable runner targets" in (
+        result.stdout + result.stderr
+    )
 
 
 def test_runner_targets_the_compose_service_from_inside_the_bastion(monkeypatch):

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -1,7 +1,11 @@
 """Security boundaries for optional LDAP authentication."""
 
+import sqlite3
 from dataclasses import dataclass
+from threading import Event, Thread
 from urllib.parse import urlsplit
+
+import pytest
 
 
 def _create_user(app, username, password="password123", *, is_admin=False):
@@ -111,16 +115,19 @@ def _enable_ldap_blueprint(app, monkeypatch, directory):
     import app.ldap_routes as ldap_routes
 
     monkeypatch.setattr(config, "LDAP_ENABLED", True)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", False, raising=False)
     monkeypatch.setattr(config, "LDAP_URL", "ldap://directory.example.com:389")
     monkeypatch.setattr(ldap_routes, "get_directory", lambda: directory)
     app.register_blueprint(ldap_routes.ldap_blueprint)
 
 
-def test_enabled_ldap_login_starts_as_an_isolated_hidden_mode(
+def test_enabled_ldap_login_defaults_to_named_directory_source(
     app,
     client,
     monkeypatch,
 ):
+    import config
+
     _create_user(app, "ldap_login_mode_user")
     directory = _FakeDirectory(_DirectoryIdentity(
         provider="default",
@@ -128,14 +135,41 @@ def test_enabled_ldap_login_starts_as_an_isolated_hidden_mode(
         distinguished_name="uid=unused,dc=example,dc=com",
     ))
     _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_PROVIDER_ID", "corp-directory")
 
     response = client.get("/login")
 
     assert response.status_code == 200
-    assert b'id="defaultLoginMode" class="login-mode"' in response.data
-    assert b'id="ldapLoginMode" class="login-mode hidden"' in response.data
-    assert b'id="ldapBackBtn"' in response.data
-    assert b'onclick="document.getElementById(\'ldapLoginForm\')' not in response.data
+    assert b'id="authenticationSource"' in response.data
+    assert b'<option value="ldap" selected>corp-directory</option>' in response.data
+    assert b'id="localLoginForm" class="auth-source-form hidden"' in response.data
+    assert b'id="ldapLoginForm" class="auth-source-form"' in response.data
+    assert b'id="ldapLoginBtn"' not in response.data
+    assert b'id="ldapBackBtn"' not in response.data
+
+
+def test_failed_local_login_keeps_local_source_selected(
+    app,
+    client,
+    monkeypatch,
+):
+    _create_user(app, "local_login_user")
+    directory = _FakeDirectory(_DirectoryIdentity(
+        provider="default",
+        subject="unused-id",
+        distinguished_name="uid=unused,dc=example,dc=com",
+    ))
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+
+    response = client.post(
+        "/login",
+        data={"username": "local_login_user", "password": "wrong-password"},
+    )
+
+    assert response.status_code == 200
+    assert b'<option value="local" selected>Local account</option>' in response.data
+    assert b'id="localLoginForm" class="auth-source-form"' in response.data
+    assert b'id="ldapLoginForm" class="auth-source-form hidden"' in response.data
 
 
 def test_ldap_login_accepts_only_matching_explicit_identity(
@@ -186,6 +220,367 @@ def test_ldap_login_accepts_only_matching_explicit_identity(
         assert row.last_verified_at is not None
 
 
+def test_ldap_login_auto_provisions_verified_non_admin_identity(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    _create_user(app, "local_admin", is_admin=True)
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={
+            "username": "alice@example.com",
+            "password": "directory-password",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/")
+    assert directory.binds == [(
+        identity.distinguished_name,
+        "directory-password",
+    )]
+    with app.app_context():
+        user = User.query.filter_by(username="alice@example.com").one()
+        mapping = LDAPIdentity.query.filter_by(user_id=user.id).one()
+        assert user.is_admin is False
+        assert user.is_locked is False
+        assert user.check_password("directory-password") is False
+        assert mapping.provider == "default"
+        assert mapping.subject == "stable-alice-id"
+        assert mapping.directory_username == "alice@example.com"
+
+
+def test_ldap_auto_provisioning_rejects_invalid_password_without_account(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    _create_user(app, "local_admin", is_admin=True)
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity, password_valid=False)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": "alice", "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+    assert directory.binds == [(
+        identity.distinguished_name,
+        "wrong-password",
+    )]
+    with app.app_context():
+        assert User.query.count() == 1
+        assert LDAPIdentity.query.count() == 0
+
+
+def test_ldap_auto_provisioning_never_claims_existing_local_username(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    _create_user(app, "local_admin", is_admin=True)
+    _create_user(app, "alice")
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-directory-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": "alice", "password": "directory-password"},
+    )
+
+    assert response.status_code == 401
+    assert directory.binds == [(
+        identity.distinguished_name,
+        "directory-password",
+    )]
+    with app.app_context():
+        assert User.query.count() == 2
+        assert LDAPIdentity.query.count() == 0
+
+
+def test_ldap_auto_provisioning_rejects_casefolded_local_collision(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    _create_user(app, "local_admin", is_admin=True)
+    _create_user(app, "Alice")
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-directory-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": "alice", "password": "directory-password"},
+    )
+
+    assert response.status_code == 401
+    with app.app_context():
+        assert User.query.count() == 2
+        assert LDAPIdentity.query.count() == 0
+
+
+def test_local_registration_rejects_casefolded_ldap_collision(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.auth import register_user
+    from app.models import db
+
+    _create_user(app, "local_admin", is_admin=True)
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-directory-alice-id",
+        distinguished_name="uid=Alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": "Alice", "password": "directory-password"},
+    )
+    assert response.status_code == 302
+
+    with app.app_context():
+        user, error = register_user("alice", "different-password")
+        transaction_still_open = db.session().in_transaction()
+
+    assert user is None
+    assert error == "Username already exists"
+    assert transaction_still_open is False
+
+
+def test_local_registration_serializes_casefold_check_across_connections(app):
+    import config
+    from app.auth import register_user
+
+    _create_user(app, "local_admin", is_admin=True)
+    connection = sqlite3.connect(config.DATA_DIR / "app.db", timeout=5)
+    connection.execute("BEGIN IMMEDIATE")
+    connection.execute(
+        """
+        INSERT INTO users (
+            username,
+            password_hash,
+            is_admin,
+            is_locked,
+            auth_generation
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        ("Alice", "unused", False, False, 0),
+    )
+    completed = Event()
+    result = {}
+
+    def register_casefolded_name():
+        with app.app_context():
+            try:
+                result["user"], result["error"] = register_user(
+                    "alice",
+                    "different-password",
+                )
+            finally:
+                completed.set()
+
+    worker = Thread(target=register_casefolded_name)
+    worker.start()
+    assert completed.wait(0.2) is False
+    connection.commit()
+    connection.close()
+
+    worker.join(timeout=5)
+    assert completed.is_set()
+    assert result["user"] is None
+    assert result["error"] == "Username already exists"
+
+
+def test_ldap_auto_provisioning_uses_shared_user_creation_lock(app):
+    from app.auth import user_creation_lock
+    from app.ldap_routes import _auto_provision_ldap_identity
+    from app.models import db
+
+    _create_user(app, "local_admin", is_admin=True)
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-directory-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    completed = Event()
+    result = {}
+
+    def provision():
+        with app.app_context():
+            try:
+                mapping = _auto_provision_ldap_identity(
+                    "alice",
+                    identity,
+                )
+                result["username"] = mapping.user.username
+            finally:
+                db.session.remove()
+                completed.set()
+
+    with user_creation_lock:
+        worker = Thread(target=provision)
+        worker.start()
+        assert completed.wait(0.2) is False
+
+    worker.join(timeout=5)
+    assert completed.is_set()
+    assert result["username"] == "alice"
+
+
+def test_ldap_auto_provisioning_rolls_back_when_user_storage_fails(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    _create_user(app, "local_admin", is_admin=True)
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-directory-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    def fail_user_storage(_user):
+        raise OSError("user storage unavailable")
+
+    monkeypatch.setattr(User, "get_data_dir", fail_user_storage)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": "alice", "password": "directory-password"},
+    )
+
+    assert response.status_code == 503
+    with app.app_context():
+        assert User.query.count() == 1
+        assert LDAPIdentity.query.count() == 0
+
+
+@pytest.mark.parametrize(
+    'username',
+    (
+        'a' * 81,
+        'alice\nadmin',
+        'alice\n',
+        '\talice',
+        'alice\r',
+        'ali\u200bce',
+    ),
+)
+def test_ldap_auto_provisioning_rejects_unsafe_local_account_name(
+    app,
+    client,
+    monkeypatch,
+    username,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    _create_user(app, "local_admin", is_admin=True)
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": username, "password": "directory-password"},
+    )
+
+    assert response.status_code == 401
+    with app.app_context():
+        assert User.query.count() == 1
+        assert LDAPIdentity.query.count() == 0
+
+
+def test_ldap_auto_provisioning_requires_local_break_glass_admin(
+    app,
+    client,
+    monkeypatch,
+):
+    import config
+    from app.models import LDAPIdentity, User
+
+    identity = _DirectoryIdentity(
+        provider="default",
+        subject="stable-alice-id",
+        distinguished_name="uid=alice,ou=people,dc=example,dc=com",
+    )
+    directory = _FakeDirectory(identity)
+    _enable_ldap_blueprint(app, monkeypatch, directory)
+    monkeypatch.setattr(config, "LDAP_AUTO_PROVISION", True)
+
+    response = client.post(
+        "/login/ldap",
+        data={"username": "alice", "password": "directory-password"},
+    )
+
+    assert response.status_code == 401
+    assert directory.binds == [(
+        identity.distinguished_name,
+        "directory-password",
+    )]
+    with app.app_context():
+        assert User.query.count() == 0
+        assert LDAPIdentity.query.count() == 0
+
+
 def test_ldap_login_rejects_subject_mismatch_before_password_bind(
     app,
     client,
@@ -217,8 +612,9 @@ def test_ldap_login_rejects_subject_mismatch_before_password_bind(
 
     assert response.status_code == 401
     assert b"Invalid username or password" in response.data
-    assert b'id="defaultLoginMode" class="login-mode hidden"' in response.data
-    assert b'id="ldapLoginMode" class="login-mode"' in response.data
+    assert b'<option value="ldap" selected>default</option>' in response.data
+    assert b'id="localLoginForm" class="auth-source-form hidden"' in response.data
+    assert b'id="ldapLoginForm" class="auth-source-form"' in response.data
     assert directory.binds == []
 
 

--- a/tests/test_production_config.py
+++ b/tests/test_production_config.py
@@ -17,6 +17,7 @@ SECURITY_ENV_NAMES = {
     'DEBUG',
     'DEPLOYMENT_PROFILE',
     'LDAP_BASE_DN',
+    'LDAP_AUTO_PROVISION',
     'LDAP_BIND_DN',
     'LDAP_BIND_PASSWORD_FILE',
     'LDAP_CA_FILE',
@@ -89,6 +90,23 @@ def test_ldap_is_disabled_by_default_and_ignores_incomplete_settings():
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert result.stdout.splitlines()[-1] == 'False'
+
+
+@pytest.mark.parametrize(
+    ('configured_value', 'expected'),
+    ((None, 'False'), ('true', 'True')),
+)
+def test_ldap_auto_provisioning_requires_explicit_opt_in(
+    configured_value,
+    expected,
+):
+    result = _load_config(
+        _production_env(LDAP_AUTO_PROVISION=configured_value),
+        'import config; print(config.LDAP_AUTO_PROVISION)',
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.splitlines()[-1] == expected
 
 
 @pytest.mark.parametrize(
@@ -365,6 +383,7 @@ def test_ldap_compose_overlay_supplies_complete_secret_infrastructure():
 
     for name in (
         'LDAP_ENABLED',
+        'LDAP_AUTO_PROVISION',
         'LDAP_PROVIDER_ID',
         'LDAP_URL',
         'LDAP_BASE_DN',
@@ -374,6 +393,7 @@ def test_ldap_compose_overlay_supplies_complete_secret_infrastructure():
     ):
         assert name in overlay
     assert 'LDAP_ENABLED: "true"' in overlay
+    assert 'LDAP_AUTO_PROVISION: "false"' in overlay
     assert 'webssh_auth_secrets:/run/webssh-auth:ro' in overlay
     assert 'ldap-tools:' in overlay
     assert 'profiles: ["ldap-tools"]' in overlay

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 import types
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
@@ -76,6 +77,9 @@ class StatefulRedis:
 
     def zcard(self, key):
         return len(self.members.get(key, {}))
+
+    def delete(self, key):
+        return int(self.members.pop(key, None) is not None)
 
 
 class FlakyRedis:
@@ -193,6 +197,30 @@ def test_denied_requests_do_not_grow_redis_bucket():
     assert client.zcard('ratelimit:login:attacker') == 5
 
 
+def _exercise_real_redis_probe(client, key):
+    redis_key = f'ratelimit:{key}'
+    client.delete(redis_key)
+    try:
+        limiter = RedisRateLimiter(client)
+        allowed = sum(limiter.allow(key, 5, 60) for _ in range(1000))
+        return allowed, client.zcard(redis_key)
+    finally:
+        client.delete(redis_key)
+
+
+def test_real_redis_probe_cleans_only_its_namespaced_bucket():
+    client = StatefulRedis()
+    client.members['unrelated'] = {'keep': 1.0}
+
+    allowed, stored = _exercise_real_redis_probe(
+        client,
+        'login:integration:isolated',
+    )
+
+    assert (allowed, stored) == (5, 5)
+    assert client.members == {'unrelated': {'keep': 1.0}}
+
+
 def test_runtime_fallback_skips_redis_until_retry_window(monkeypatch):
     clock = {'now': 100.0}
     monkeypatch.setattr('app.rate_limiter.time.monotonic', lambda: clock['now'])
@@ -271,10 +299,8 @@ def test_real_redis_does_not_store_denied_requests():
     import redis
 
     client = redis.from_url(os.environ['TEST_REDIS_URL'])
-    client.flushdb()
-    limiter = RedisRateLimiter(client)
-
-    allowed = sum(limiter.allow('login:integration', 5, 60) for _ in range(1000))
+    key = f'login:integration:{uuid.uuid4().hex}'
+    allowed, stored = _exercise_real_redis_probe(client, key)
 
     assert allowed == 5
-    assert client.zcard('ratelimit:login:integration') == 5
+    assert stored == 5

--- a/tests/test_security_ui.py
+++ b/tests/test_security_ui.py
@@ -58,7 +58,8 @@ def test_login_shows_only_enabled_external_authentication(
 
     assert b'id="passkeyLoginBtn"' not in disabled.data
     assert b'id="oidcLoginBtn"' not in disabled.data
-    assert b'id="ldapLoginBtn"' not in disabled.data
+    assert b'id="authenticationSource"' not in disabled.data
+    assert b'id="localLoginForm" class="auth-source-form"' in disabled.data
     assert b'id="recoveryLoginBtn"' in disabled.data
     assert b'id="recoveryLoginPanel"' in disabled.data
     assert b'id="passkeyLoginBtn"' in enabled.data

--- a/tests/test_test_safety.py
+++ b/tests/test_test_safety.py
@@ -1,0 +1,74 @@
+"""Regression tests for isolation from live deployment resources."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_pytest(*arguments, environment):
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *arguments],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pytest_neutralizes_deployment_environment_before_collection(tmp_path):
+    sentinel = tmp_path / "live-data"
+    sentinel.mkdir()
+    marker = sentinel / "app.db"
+    marker.write_bytes(b"must-not-be-opened-by-tests")
+    environment = os.environ.copy()
+    environment.update({
+        "DATA_DIR": str(sentinel),
+        "TRANSFER_TEMP_DIR": str(sentinel / "transfer-tmp"),
+        "BACKUP_TEMP_DIR": str(sentinel / "backup-tmp"),
+        "RATELIMIT_STORAGE_URL": "redis://redis.production.example:6379/0",
+        "LDAP_ENABLED": "true",
+        "OIDC_ENABLED": "true",
+        "TAILSCALE_SSH_ENABLED": "true",
+        "WEBSSH_TEST_SENTINEL_DATA_DIR": str(sentinel),
+    })
+
+    result = _run_pytest(
+        "tests/fixtures/environment_probe.py",
+        "-q",
+        environment=environment,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert marker.read_bytes() == b"must-not-be-opened-by-tests"
+
+
+@pytest.mark.parametrize(
+    "test_redis_url",
+    (
+        "redis://redis.production.example:6379/15",
+        "redis://127.0.0.1:6379/0",
+        "redis://localhost:6379",
+    ),
+)
+def test_pytest_rejects_unsafe_real_redis_targets(test_redis_url):
+    environment = os.environ.copy()
+    environment["TEST_REDIS_URL"] = test_redis_url
+
+    result = _run_pytest(
+        "--collect-only",
+        "tests/test_rate_limiter.py",
+        "-q",
+        environment=environment,
+    )
+
+    assert result.returncode != 0
+    assert "TEST_REDIS_URL must use loopback and an explicit non-zero database" in (
+        result.stdout + result.stderr
+    )


### PR DESCRIPTION
## Summary

- add an Authentication Source selector for local and LDAP password sign-in
- add opt-in LDAP auto-provisioning with break-glass and identity-collision safeguards
- harden the test suite against live deployment data and external service targets
- document the configuration and cover login, provisioning, CLI, and concurrency behavior

## Context

Discussion #110 proposes making LDAP a first-class password authentication source and optionally creating directory-managed users on their first successful sign-in. Existing deployments retain explicit account linking by default.

## Behavior

- LDAP remains opt-in, and `LDAP_AUTO_PROVISION` defaults to `false`
- auto-provisioning happens only after a successful directory bind and requires an active local break-glass administrator
- local and directory usernames are casefold-unique, with creation serialized across SQLite connections
- LDAP-managed users cannot be promoted through `create-admin`
- pytest isolates data, transfer, and backup paths and disables deployment authentication and rate-limit services before collection
- real Redis tests require a loopback URL with an explicit non-zero database and delete only their unique rate-limit bucket
- Paramiko integration tests accept only the exact disposable OpenSSH lab targets produced by the repository runner
- no database migration is required

## Validation

- `pytest tests -q` - 1,585 passed, 33 skipped
- `npm run vendor:check` - passed
- `npm run lint:js` - passed
- `npm run test:js` - 200 passed
- `docker compose -f docker-compose.yml -f docker-compose.ldap.yml config --quiet` - passed
- disposable OpenLDAP login flow exercised locally

Implements the direction discussed in #110.
