### PR TITLE
Improve session capability detection

### DIFF
--- a/app/paramiko_channels.py
+++ b/app/paramiko_channels.py
@@ -14,6 +14,15 @@ def _request_guard(channel, timeout):
     return guard
 
 
+def _remaining_timeout(deadline, maximum):
+    if deadline is None:
+        return maximum
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise socket.timeout('SSH channel operation exceeded its deadline')
+    return min(maximum, remaining)
+
+
 def open_shell_channel(transport, *, timeout, term, width, height):
     """Open a PTY shell without Paramiko's unbounded request waits."""
     channel = transport.open_session(timeout=timeout)
@@ -32,17 +41,20 @@ def open_shell_channel(transport, *, timeout, term, width, height):
     return channel
 
 
-def open_sftp_client(transport, *, timeout, operation_timeout):
+def open_sftp_client(transport, *, timeout, operation_timeout, deadline=None):
     """Open SFTP with a handshake deadline and bounded later operations."""
-    channel = transport.open_session(timeout=timeout)
-    channel.settimeout(timeout)
-    timeout_guard = _request_guard(channel, timeout)
+    channel = transport.open_session(
+        timeout=_remaining_timeout(deadline, timeout)
+    )
+    handshake_timeout = _remaining_timeout(deadline, timeout)
+    channel.settimeout(handshake_timeout)
+    timeout_guard = _request_guard(channel, handshake_timeout)
     try:
         channel.invoke_subsystem('sftp')
         sftp = paramiko.SFTPClient(channel)
         if channel.closed:
             raise socket.timeout('SFTP request exceeded its deadline')
-        channel.settimeout(operation_timeout)
+        channel.settimeout(_remaining_timeout(deadline, operation_timeout))
         return sftp
     except Exception:
         channel.close()

--- a/app/session_insights.py
+++ b/app/session_insights.py
@@ -5,6 +5,8 @@ import socket
 import time
 from threading import Lock
 
+from paramiko import SSHException
+
 from . import ssh_manager
 
 
@@ -19,52 +21,71 @@ _collector_locks_guard = Lock()
 LINUX_STATS_COMMAND = r"""LC_ALL=C
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 export LC_ALL PATH
-awk 'NR == 1 { $1=""; sub(/^ /, ""); print "cpu=" $0; exit }' /proc/stat
-awk '
-  /^MemTotal:/ { print "mem_total_kib=" $2 }
-  /^MemAvailable:/ { print "mem_available_kib=" $2 }
-' /proc/meminfo
-df -Pk / | awk 'NR == 2 {
-  percent=$5; sub(/%$/, "", percent)
-  print "disk_total_kib=" $2
-  print "disk_used_kib=" $3
-  print "disk_available_kib=" $4
-  print "disk_percent=" percent
-}'
-awk '{ print "uptime_seconds=" $1; exit }' /proc/uptime
-if [ -r /etc/os-release ]; then
-  os_name=$(sed -n 's/^PRETTY_NAME=//p' /etc/os-release | head -n 1)
+if [ -r /proc/stat ] && command -v awk >/dev/null 2>&1; then
+  awk 'NR == 1 { $1=""; sub(/^ /, ""); print "cpu=" $0; exit }' /proc/stat 2>/dev/null
+fi
+if [ -r /proc/meminfo ] && command -v awk >/dev/null 2>&1; then
+  awk '
+    /^MemTotal:/ { print "mem_total_kib=" $2 }
+    /^MemAvailable:/ { print "mem_available_kib=" $2 }
+  ' /proc/meminfo 2>/dev/null
+fi
+if command -v df >/dev/null 2>&1 && command -v awk >/dev/null 2>&1; then
+  df -Pk / 2>/dev/null | awk 'NR == 2 {
+    percent=$5; sub(/%$/, "", percent)
+    print "disk_total_kib=" $2
+    print "disk_used_kib=" $3
+    print "disk_available_kib=" $4
+    print "disk_percent=" percent
+  }'
+fi
+if [ -r /proc/uptime ] && command -v awk >/dev/null 2>&1; then
+  awk '{ print "uptime_seconds=" $1; exit }' /proc/uptime 2>/dev/null
+fi
+if [ -r /etc/os-release ] && command -v awk >/dev/null 2>&1; then
+  os_name=$(awk -F= '/^PRETTY_NAME=/ { sub(/^PRETTY_NAME=/, ""); print; exit }' /etc/os-release 2>/dev/null)
   os_name=${os_name#\"}; os_name=${os_name%\"}
   os_name=${os_name#\'}; os_name=${os_name%\'}
+elif command -v uname >/dev/null 2>&1; then
+  os_name=$(uname -srm 2>/dev/null)
 else
-  os_name=Linux
+  os_name=
 fi
-printf 'os_name=%s\n' "$os_name"
+[ -n "$os_name" ] && printf 'os_name=%s\n' "$os_name"
+:
 """
 
 
 LINUX_DIAGNOSTICS_COMMAND = LINUX_STATS_COMMAND + r"""
-awk '
-  /^SwapTotal:/ { print "swap_total_kib=" $2 }
-  /^SwapFree:/ { print "swap_free_kib=" $2 }
-' /proc/meminfo
-awk '{
-  print "load_1=" $1
-  print "load_5=" $2
-  print "load_15=" $3
-}' /proc/loadavg
-awk '/^cpu[0-9]+ / { count++ } END {
-  if (count > 0) print "cpu_count=" count
-}' /proc/stat
-awk -F '[: ]+' 'NR > 2 {
-  if ($2 != "lo") {
-    received += $3
-    transmitted += $11
-  }
-} END {
-  print "network_received_bytes=" received + 0
-  print "network_transmitted_bytes=" transmitted + 0
-}' /proc/net/dev
+if [ -r /proc/meminfo ] && command -v awk >/dev/null 2>&1; then
+  awk '
+    /^SwapTotal:/ { print "swap_total_kib=" $2 }
+    /^SwapFree:/ { print "swap_free_kib=" $2 }
+  ' /proc/meminfo 2>/dev/null
+fi
+if [ -r /proc/loadavg ] && command -v awk >/dev/null 2>&1; then
+  awk '{
+    print "load_1=" $1
+    print "load_5=" $2
+    print "load_15=" $3
+  }' /proc/loadavg 2>/dev/null
+fi
+if [ -r /proc/stat ] && command -v awk >/dev/null 2>&1; then
+  awk '/^cpu[0-9]+ / { count++ } END {
+    if (count > 0) print "cpu_count=" count
+  }' /proc/stat 2>/dev/null
+fi
+if [ -r /proc/net/dev ] && command -v awk >/dev/null 2>&1; then
+  awk -F '[: ]+' 'NR > 2 {
+    if ($2 != "lo") {
+      received += $3
+      transmitted += $11
+    }
+  } END {
+    print "network_received_bytes=" received + 0
+    print "network_transmitted_bytes=" transmitted + 0
+  }' /proc/net/dev 2>/dev/null
+fi
 
 process_probe=$(ps -p $$ -o pid= 2>&1)
 process_status=$?
@@ -88,6 +109,7 @@ elif printf '%s' "$process_probe" | grep -Eqi \
     'permission denied|access denied|not authorized|authorization denied'; then
   printf 'permission_denied=processes\n'
 fi
+:
 
 """
 
@@ -105,16 +127,6 @@ _MULTI_KEYS = {
     'process_cpu', 'process_memory', 'permission_denied',
 }
 _PERMISSION_SCOPES = ('processes',)
-
-
-def _non_negative_int(values, key):
-    try:
-        value = int(values[key])
-    except (KeyError, TypeError, ValueError) as exc:
-        raise ValueError(f'invalid {key}') from exc
-    if value < 0:
-        raise ValueError(f'invalid {key}')
-    return value
 
 
 def _optional_int(values, key, *, maximum=None):
@@ -189,57 +201,68 @@ def parse_linux_stats(text, *, max_bytes=DEFAULT_MAX_BYTES):
         elif key in _MULTI_KEYS and len(repeated[key]) < 16:
             repeated[key].append(value.strip())
 
+    result = {}
+
     try:
-        cpu = [int(part) for part in values['cpu'].split()]
-    except (KeyError, TypeError, ValueError) as exc:
-        raise ValueError('invalid cpu') from exc
-    if len(cpu) < 4 or any(value < 0 for value in cpu):
-        raise ValueError('invalid cpu')
+        cpu = [int(part) for part in values.get('cpu', '').split()]
+    except (TypeError, ValueError):
+        cpu = []
+    if len(cpu) >= 4 and all(value >= 0 for value in cpu):
+        result['cpu'] = cpu
 
-    mem_total = _non_negative_int(values, 'mem_total_kib')
-    mem_available = _non_negative_int(values, 'mem_available_kib')
-    if mem_total <= 0 or mem_available > mem_total:
-        raise ValueError('invalid memory')
-
-    disk_total = _non_negative_int(values, 'disk_total_kib')
-    disk_used = _non_negative_int(values, 'disk_used_kib')
-    disk_available = _non_negative_int(values, 'disk_available_kib')
-    disk_percent = _non_negative_int(values, 'disk_percent')
+    mem_total = _optional_int(
+        values, 'mem_total_kib', maximum=2 ** 63 - 1
+    )
+    mem_available = _optional_int(
+        values, 'mem_available_kib', maximum=2 ** 63 - 1
+    )
     if (
-        disk_total <= 0
-        or disk_used > disk_total
-        or disk_available > disk_total
-        or disk_percent > 100
+        mem_total is not None
+        and mem_available is not None
+        and mem_total > 0
+        and mem_available <= mem_total
     ):
-        raise ValueError('invalid disk')
-
-    try:
-        uptime_seconds = int(float(values['uptime_seconds']))
-    except (KeyError, TypeError, ValueError, OverflowError) as exc:
-        raise ValueError('invalid uptime') from exc
-    if uptime_seconds < 0:
-        raise ValueError('invalid uptime')
-
-    os_name = values.get('os_name', '').strip()
-    if not os_name or len(os_name) > 200:
-        raise ValueError('invalid os name')
-
-    result = {
-        'cpu': cpu,
-        'memory': {
+        result['memory'] = {
             'total_kib': mem_total,
             'available_kib': mem_available,
             'used_kib': mem_total - mem_available,
-        },
-        'disk': {
+        }
+
+    disk_total = _optional_int(
+        values, 'disk_total_kib', maximum=2 ** 63 - 1
+    )
+    disk_used = _optional_int(
+        values, 'disk_used_kib', maximum=2 ** 63 - 1
+    )
+    disk_available = _optional_int(
+        values, 'disk_available_kib', maximum=2 ** 63 - 1
+    )
+    disk_percent = _optional_int(values, 'disk_percent', maximum=100)
+    if (
+        disk_total is not None
+        and disk_used is not None
+        and disk_available is not None
+        and disk_percent is not None
+        and disk_total > 0
+        and disk_used <= disk_total
+        and disk_available <= disk_total
+    ):
+        result['disk'] = {
             'total_kib': disk_total,
             'used_kib': disk_used,
             'available_kib': disk_available,
             'percent': disk_percent,
-        },
-        'uptime_seconds': uptime_seconds,
-        'os_name': os_name,
-    }
+        }
+
+    uptime_value = _optional_float(
+        values, 'uptime_seconds', maximum=2 ** 63 - 1
+    )
+    if uptime_value is not None:
+        result['uptime_seconds'] = int(uptime_value)
+
+    os_name = _safe_text(values.get('os_name'), maximum=200)
+    if os_name is not None:
+        result['os_name'] = os_name
 
     load_values = (
         _optional_float(values, 'load_1'),
@@ -300,6 +323,9 @@ def parse_linux_stats(text, *, max_bytes=DEFAULT_MAX_BYTES):
     if permissions:
         result['permission_denied'] = permissions
 
+    if not result:
+        raise ValueError('no supported metrics')
+
     return result
 
 
@@ -339,7 +365,7 @@ def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
                         include_diagnostics=False):
     """Collect one Linux sample without touching the interactive PTY."""
     if not isinstance(session_id, str) or not session_id:
-        return None, 'unavailable'
+        return None, 'transient'
 
     collector_lock = _acquire_session_lock(session_id)
     if collector_lock is None:
@@ -350,12 +376,12 @@ def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
         with ssh_manager.sessions_lock:
             session = ssh_manager.sessions.get(session_id)
             if not session or not session.get('connected'):
-                return None, 'unavailable'
+                return None, 'transient'
             client = session.get('client')
 
         transport = client.get_transport() if client else None
         if not transport or not transport.is_active():
-            return None, 'unavailable'
+            return None, 'transient'
 
         command = (
             LINUX_DIAGNOSTICS_COMMAND
@@ -370,6 +396,13 @@ def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
         deadline = time.monotonic() + timeout
         output = bytearray()
 
+        def parse_output():
+            try:
+                text = output.decode('utf-8', errors='strict')
+                return parse_linux_stats(text, max_bytes=max_bytes), None
+            except (UnicodeDecodeError, ValueError):
+                return None, 'unsupported'
+
         while True:
             if channel.recv_ready():
                 chunk = channel.recv(min(4096, max_bytes + 1 - len(output)))
@@ -377,12 +410,14 @@ def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
                     break
                 output.extend(chunk)
                 if len(output) > max_bytes:
-                    return None, 'unavailable'
+                    return None, 'unsupported'
                 continue
             if channel.exit_status_ready():
                 break
             if time.monotonic() >= deadline:
-                return None, 'unavailable'
+                if output:
+                    return parse_output()
+                return None, 'transient'
             time.sleep(0.02)
 
         while channel.recv_ready():
@@ -391,20 +426,18 @@ def collect_linux_stats(session_id, *, timeout=DEFAULT_TIMEOUT,
                 break
             output.extend(chunk)
             if len(output) > max_bytes:
-                return None, 'unavailable'
+                return None, 'unsupported'
 
         if channel.recv_exit_status() != 0:
-            return None, 'unavailable'
+            return None, 'unsupported'
 
-        try:
-            text = output.decode('utf-8', errors='strict')
-            return parse_linux_stats(text, max_bytes=max_bytes), None
-        except (UnicodeDecodeError, ValueError):
-            return None, 'unavailable'
+        return parse_output()
+    except SSHException:
+        return None, 'transient'
     except (OSError, socket.timeout):
-        return None, 'unavailable'
+        return None, 'transient'
     except Exception:
-        return None, 'unavailable'
+        return None, 'transient'
     finally:
         if channel is not None:
             try:

--- a/app/sftp_handler.py
+++ b/app/sftp_handler.py
@@ -1,11 +1,13 @@
 import os
+import socket
 import stat
 import posixpath
 import secrets
 import tempfile
+import time
 import zipfile
 from pathlib import Path
-from threading import Lock
+from threading import Event, Lock, Timer
 from contextlib import contextmanager
 from paramiko import SFTPClient
 from paramiko.sftp import (
@@ -27,6 +29,42 @@ _sftp_cache_lock = Lock()
 
 _sftp_session_locks = {}
 _sftp_session_locks_lock = Lock()
+CAPABILITY_RATE_LIMIT = '10 per minute'
+CAPABILITY_TIMEOUT = 3.0
+
+_capability_probe_locks = {}
+_capability_probe_locks_guard = Lock()
+
+
+def _acquire_capability_probe(session_id):
+    with _capability_probe_locks_guard:
+        entry = _capability_probe_locks.setdefault(
+            session_id,
+            {'lock': Lock(), 'references': 0},
+        )
+        entry['references'] += 1
+        probe_lock = entry['lock']
+
+    if probe_lock.acquire(blocking=False):
+        return probe_lock
+
+    with _capability_probe_locks_guard:
+        entry = _capability_probe_locks.get(session_id)
+        if entry and entry['lock'] is probe_lock:
+            entry['references'] -= 1
+            if entry['references'] == 0:
+                _capability_probe_locks.pop(session_id, None)
+    return None
+
+
+def _release_capability_probe(session_id, probe_lock):
+    with _capability_probe_locks_guard:
+        entry = _capability_probe_locks.get(session_id)
+        probe_lock.release()
+        if entry and entry['lock'] is probe_lock:
+            entry['references'] -= 1
+            if entry['references'] == 0:
+                _capability_probe_locks.pop(session_id, None)
 
 def _get_sftp_lock(session_id):
     """Get or create a per-session lock for serializing SFTP operations."""
@@ -510,6 +548,83 @@ def list_directory(session_id, remote_path='.'):
         return None, str(e)
     except Exception as e:
         return None, str(e)
+
+
+def probe_sftp_capability(session_id):
+    """Return whether an existing SSH session can browse via SFTP.
+
+    Opening the subsystem alone is insufficient for some appliances, so the
+    probe performs one bounded directory read through a fresh short-lived
+    channel. It never waits behind cached SFTP operations and concurrent probes
+    for the same session are deduplicated. ``None`` is retryable busy/timeout.
+    Remote exception details intentionally stay server-side.
+    """
+    probe_lock = _acquire_capability_probe(session_id)
+    if probe_lock is None:
+        return None
+
+    sftp = None
+    deadline_guard = None
+    deadline = None
+    deadline_expired = Event()
+    try:
+        with ssh_manager.sessions_lock:
+            session = ssh_manager.sessions.get(session_id)
+            if not session or not session.get('connected'):
+                return None
+            client = session.get('client')
+
+        transport = client.get_transport() if client else None
+        if not transport or not transport.is_active():
+            return None
+
+        deadline = time.monotonic() + CAPABILITY_TIMEOUT
+        timeout = min(CAPABILITY_TIMEOUT, float(config.SSH_CONNECT_TIMEOUT))
+        operation_timeout = min(
+            CAPABILITY_TIMEOUT,
+            float(config.SFTP_OPERATION_TIMEOUT),
+        )
+        sftp = open_sftp_client(
+            transport,
+            timeout=timeout,
+            operation_timeout=operation_timeout,
+            deadline=deadline,
+        )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise socket.timeout('SFTP capability probe exceeded its deadline')
+        def expire_probe():
+            deadline_expired.set()
+            try:
+                sftp.close()
+            except Exception:
+                pass
+
+        deadline_guard = Timer(remaining, expire_probe)
+        deadline_guard.daemon = True
+        deadline_guard.start()
+        with _directory_entries(sftp, '.') as entries:
+            next(entries, None)
+        if time.monotonic() > deadline:
+            return None
+        return True
+    except (socket.timeout, TimeoutError):
+        return None
+    except Exception:
+        if deadline_expired.is_set() or (
+            deadline is not None and time.monotonic() >= deadline
+        ):
+            return None
+        return False
+    finally:
+        if deadline_guard is not None:
+            deadline_guard.cancel()
+        if sftp is not None:
+            try:
+                sftp.close()
+            except Exception:
+                pass
+        _release_capability_probe(session_id, probe_lock)
 
 def create_directory(session_id, remote_path):
     """Create a directory on remote server."""

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -257,7 +257,9 @@ def restore_user_sessions(user_id):
         session = ssh_manager.get_session(session_id)
 
         if session and session.get('connected'):
-            buffered_output = ssh_manager.get_output_buffer(session_id)
+            buffered_output, output_sequence = (
+                ssh_manager.get_output_snapshot(session_id)
+            )
             emit('ssh_session_restored', {
                 'session_id': session_id,
                 'host': db_session.host,
@@ -268,7 +270,8 @@ def restore_user_sessions(user_id):
                 'use_tmux': session.get('use_tmux', False),
                 'tmux_session_name': session.get('tmux_session_name'),
                 'display_name': db_session.display_name,
-                'buffered_output': buffered_output
+                'buffered_output': buffered_output,
+                'output_sequence': output_sequence,
             }, room=room)
             log_info(f"Restored SSH session {session_id}", user_id=user_id, room=room)
         else:
@@ -1047,6 +1050,64 @@ def handle_delete_key(data, current_user=None):
     except Exception:
         emit('error', {'error': 'Failed to delete key'})
 
+@socketio.on('probe_session_sftp')
+@socket_login_required
+def handle_probe_session_sftp(data, current_user=None):
+    """Check whether an owned SSH session supports browsable SFTP."""
+    session_id = data.get('session_id') if isinstance(data, dict) else None
+    request_id = data.get('request_id') if isinstance(data, dict) else None
+    valid_identifiers = (
+        isinstance(session_id, str)
+        and 0 < len(session_id) <= 128
+        and isinstance(request_id, str)
+        and 0 < len(request_id) <= 128
+    )
+    safe_session_id = session_id if valid_identifiers else ''
+    safe_request_id = request_id if valid_identifiers else ''
+
+    def emit_result(*, success, available=False):
+        emit('session_sftp_capability', {
+            'success': success,
+            'session_id': safe_session_id,
+            'request_id': safe_request_id,
+            'available': available,
+        })
+
+    if not valid_identifiers:
+        emit_result(success=False)
+        return
+    if check_socket_rate_limit(
+            current_user.id,
+            'session_sftp_capability',
+            sftp_handler.CAPABILITY_RATE_LIMIT):
+        emit_result(success=False)
+        return
+    if not verify_session_ownership(session_id, current_user.id):
+        log_warning(
+            'Unauthorized SFTP capability request',
+            user_id=current_user.id,
+            session_id=session_id,
+        )
+        emit_result(success=False)
+        return
+
+    try:
+        available = sftp_handler.probe_sftp_capability(session_id)
+    except Exception as exc:
+        log_warning(
+            'SFTP capability probe failed',
+            session_id=session_id,
+            error_type=type(exc).__name__,
+        )
+        emit_result(success=False)
+        return
+
+    if available is None:
+        emit_result(success=False)
+        return
+    emit_result(success=True, available=available is True)
+
+
 @socketio.on('list_directory')
 @socket_login_required
 def handle_list_directory(data, current_user=None):
@@ -1574,13 +1635,16 @@ def handle_request_session_insights(data, current_user=None):
     safe_session_id = session_id if valid_identifiers else ''
     safe_request_id = request_id if valid_identifiers else ''
 
-    def emit_unavailable():
-        emit('session_insights', {
+    def emit_unavailable(reason=None):
+        payload = {
             'success': False,
             'session_id': safe_session_id,
             'request_id': safe_request_id,
             'error': 'Session insights unavailable',
-        })
+        }
+        if reason in {'busy', 'transient', 'unsupported'}:
+            payload['reason'] = reason
+        emit('session_insights', payload)
 
     if not valid_identifiers:
         emit_unavailable()
@@ -1614,11 +1678,11 @@ def handle_request_session_insights(data, current_user=None):
             session_id=session_id,
             error_type=type(exc).__name__,
         )
-        emit_unavailable()
+        emit_unavailable('transient')
         return
 
     if error or stats is None:
-        emit_unavailable()
+        emit_unavailable(error)
         return
 
     emit('session_insights', {

--- a/app/ssh_manager.py
+++ b/app/ssh_manager.py
@@ -340,6 +340,7 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
                 'output_buffer': [],
                 'output_buffer_size': 0,
                 'output_buffer_max': 512000,  # 512KB max buffer
+                'output_sequence': 0,
                 'quota_reservation': reservation,
                 'reader_handle': None,
             }
@@ -422,6 +423,30 @@ def create_ssh_connection(host, port, username, password=None, key_path=None, ke
             except Exception:
                 pass
 
+def record_output(session_id, decoded_data, *, now=None):
+    """Append one output chunk and return its monotone session sequence."""
+    activity_time = time.time() if now is None else now
+    with sessions_lock:
+        session = sessions.get(session_id)
+        if not session or not session.get('connected'):
+            return None
+        sequence = session.get('output_sequence', 0) + 1
+        session['output_sequence'] = sequence
+        session['last_activity'] = activity_time
+        buf = session.get('output_buffer')
+        if buf is not None:
+            buf.append(decoded_data)
+            session['output_buffer_size'] += len(decoded_data)
+            while (
+                session['output_buffer_size']
+                > session.get('output_buffer_max', 512000)
+                and len(buf) > 1
+            ):
+                removed = buf.pop(0)
+                session['output_buffer_size'] -= len(removed)
+        return sequence
+
+
 def read_ssh_output(session_id, socketio_instance, app, cancel_event=None):
     """Continuously read SSH output and emit it until cancelled or disconnected.
 
@@ -480,23 +505,17 @@ def read_ssh_output(session_id, socketio_instance, app, cancel_event=None):
                         if not decoded_data:
                             # Nothing to emit; skip
                             continue
+                        now = time.time()
+                        sequence = record_output(
+                            session_id, decoded_data, now=now
+                        )
+                        if sequence is None:
+                            break
                         socketio_instance.emit('ssh_output', {
                             'session_id': session_id,
-                            'data': decoded_data
+                            'data': decoded_data,
+                            'sequence': sequence,
                         }, room=cached_room)
-
-                        now = time.time()
-                        with sessions_lock:
-                            if session_id in sessions:
-                                sessions[session_id]['last_activity'] = now
-                                buf = sessions[session_id].get('output_buffer')
-                                if buf is not None:
-                                    buf.append(decoded_data)
-                                    sessions[session_id]['output_buffer_size'] += len(decoded_data)
-                                    # Trim buffer if over max
-                                    while sessions[session_id]['output_buffer_size'] > sessions[session_id].get('output_buffer_max', 512000) and len(buf) > 1:
-                                        removed = buf.pop(0)
-                                        sessions[session_id]['output_buffer_size'] -= len(removed)
 
                         if now - last_db_update >= 10.0:
                             last_db_update = now
@@ -693,6 +712,11 @@ def get_session(session_id):
 
 def get_output_buffer(session_id):
     """Get buffered output for a session (for replay on reconnect)."""
+    return get_output_snapshot(session_id)[0]
+
+
+def get_output_snapshot(session_id):
+    """Return buffered output and its atomic monotone sequence watermark."""
     import re as _re
     with sessions_lock:
         if session_id in sessions:
@@ -701,8 +725,9 @@ def get_output_buffer(session_id):
                 output = ''.join(buf)
                 # Filter Device Attributes responses (ESC[c sequences only)
                 output = _re.sub(r'\x1b\[[?>]?[0-9;]*c', '', output)
-                return output
-    return ''
+                return output, sessions[session_id].get('output_sequence', 0)
+            return '', sessions[session_id].get('output_sequence', 0)
+    return '', 0
 
 def cleanup_idle_sessions():
     """Clean up sessions that have been idle too long."""

--- a/static/css/session-workspace.css
+++ b/static/css/session-workspace.css
@@ -213,6 +213,13 @@
     background: linear-gradient(145deg, var(--bg-secondary), var(--bg-tertiary));
 }
 
+.session-insights-card[hidden],
+.session-insights-grid[hidden],
+.session-resource[hidden],
+.session-insights-meta[hidden] {
+    display: none !important;
+}
+
 .session-insights-host {
     max-width: 180px;
     overflow: hidden;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -948,7 +948,7 @@
     });
 
     socket.on('ssh_output', (data) => {
-        TerminalManager.writeOutput(data.session_id, data.data);
+        TerminalManager.writeOutput(data.session_id, data.data, data.sequence);
 
     });
 

--- a/static/js/session-diagnostics.js
+++ b/static/js/session-diagnostics.js
@@ -223,7 +223,6 @@
 
     function buildViewModel(state = {}, session = null, inventoryState = {}, filters = {}) {
         const stats = state.stats || null;
-        const available = Boolean(state.sessionId && stats);
         const host = session ? `${session.username}@${session.host}` : 'No active session';
         const history = normalizedHistory(state);
         const scopedInventoryState = (
@@ -249,6 +248,28 @@
         const processes = stats?.processes;
         const topCpu = boundedProcesses(processes?.top_cpu, 'cpu_percent');
         const topMemory = boundedProcesses(processes?.top_memory, 'memory_percent');
+        const uptime = formatUptime(stats?.uptime_seconds);
+        const hasNetworkStats = (
+            finiteNumber(stats?.network?.received_bytes) !== null
+            && finiteNumber(stats?.network?.transmitted_bytes) !== null
+        );
+        const available = Boolean(state.sessionId && stats && (
+            finiteNumber(state.cpuPercent) !== null
+            || memoryPercent !== null
+            || diskPercent !== null
+            || loadPercent !== null
+            || swapPercent !== null
+            || uptime !== null
+            || hasNetworkStats
+            || topCpu.length
+            || topMemory.length
+            || (typeof stats.os_name === 'string' && stats.os_name.trim())
+        ));
+        const hasPressureHistory = history.some(sample => (
+            sample.cpuPercent !== null
+            || sample.memoryPercent !== null
+            || sample.normalizedLoadPercent !== null
+        ));
         const inventory = scopedInventoryState.inventory || null;
         const sampledAt = finiteNumber(scopedInventoryState.sampledAt);
 
@@ -260,7 +281,7 @@
             statusClass: state.status || 'disconnected',
             resources: {
                 cpu: available ? resource(
-                    finiteNumber(state.cpuPercent), 'Current utilization', 'cpuPercent', history, true,
+                    finiteNumber(state.cpuPercent), 'Current utilization', 'cpuPercent', history,
                 ) : null,
                 memory: available ? resource(
                     memoryPercent,
@@ -289,6 +310,7 @@
                     transmittedBps: sample.transmittedBps,
                 })),
             },
+            hasPressureHistory,
             secondary: {
                 swap: swapPercent === null ? null : {
                     percent: swapPercent,
@@ -297,7 +319,7 @@
                     detail: `${formatKib(stats.swap.used_kib)} of ${formatKib(stats.swap.total_kib)}`,
                     severity: severityForPercent(swapPercent),
                 },
-                uptime: formatUptime(stats?.uptime_seconds),
+                uptime,
                 processTotal: finiteNumber(processes?.total),
                 processZombies: finiteNumber(processes?.zombies),
                 received: formatRate(state.networkRates?.received_bps),
@@ -630,7 +652,7 @@
                 : (model.inventory.loading ? 'Loading inventory' : 'Inventory not loaded');
 
             ['cpu', 'memory', 'disk', 'load'].forEach(key => setResource(key, model.resources[key]));
-            elements.pressureSection.hidden = !model.available;
+            elements.pressureSection.hidden = !model.hasPressureHistory;
             const hasNetwork = Boolean(
                 model.secondary.received || model.secondary.transmitted
                 || model.charts.networkHistory.some(sample => sample.receivedBps !== null || sample.transmittedBps !== null)

--- a/static/js/session-insights.js
+++ b/static/js/session-insights.js
@@ -11,6 +11,7 @@
 
     const POLL_INTERVAL_MS = 4000;
     const RESPONSE_TIMEOUT_MS = 3500;
+    const BACKOFF_RETRY_MS = 60000;
     const HISTORY_LIMIT = 150;
 
     function calculateCpuPercent(previous, current) {
@@ -116,6 +117,25 @@
         });
     }
 
+    function metricAvailability(state) {
+        const stats = state?.stats || {};
+        const availability = {
+            cpu: boundedPercent(state?.cpuPercent) !== null,
+            memory: percent(
+                stats.memory?.used_kib,
+                stats.memory?.total_kib,
+            ) !== null,
+            disk: (
+                boundedPercent(stats.disk?.percent) !== null
+                && percent(stats.disk?.used_kib, stats.disk?.total_kib) !== null
+            ),
+            os: typeof stats.os_name === 'string' && Boolean(stats.os_name.trim()),
+            uptime: nonNegativeNumber(stats.uptime_seconds) !== null,
+        };
+        availability.any = Object.values(availability).some(Boolean);
+        return availability;
+    }
+
     function createController(options) {
         const socket = options.socket;
         const render = options.render || (() => {});
@@ -131,6 +151,7 @@
         let diagnosticsVisible = false;
         let intervalId = null;
         let responseTimeoutId = null;
+        let retryTimeoutId = null;
         let pendingRequest = null;
         let requestCounter = 0;
         let failureCount = 0;
@@ -139,6 +160,8 @@
         const metricHistoryBySession = new Map();
         const previousNetworkBySession = new Map();
         const lastGoodBySession = new Map();
+        const unsupportedSessions = new Set();
+        const unsupportedDiagnosticsSessions = new Set();
 
         function currentState(status, extra = {}) {
             return {
@@ -162,29 +185,86 @@
                 intervalId = null;
             }
             clearResponseTimeout();
+            if (retryTimeoutId !== null) {
+                clearTimeoutFn(retryTimeoutId);
+                retryTimeoutId = null;
+            }
             pendingRequest = null;
         }
 
-        function renderFailure() {
+        function pauseRegularPolling() {
+            if (intervalId !== null) {
+                clearIntervalFn(intervalId);
+                intervalId = null;
+            }
+        }
+
+        function scheduleRetry() {
+            if (retryTimeoutId !== null || unsupportedSessions.has(sessionId)) return;
+            retryTimeoutId = setTimeoutFn(() => {
+                retryTimeoutId = null;
+                if (!visible || !connected || !sessionId || unsupportedSessions.has(sessionId)) {
+                    return;
+                }
+                requestSample();
+                if (intervalId === null) {
+                    intervalId = setIntervalFn(requestSample, POLL_INTERVAL_MS);
+                }
+            }, BACKOFF_RETRY_MS);
+        }
+
+        function renderFailure(reason = 'transient', responseRequest = null) {
+            if (reason === 'unsupported') {
+                if (responseRequest?.includeDiagnostics) {
+                    unsupportedDiagnosticsSessions.add(sessionId);
+                    failureCount = 0;
+                    render(currentState(lastGood ? 'ready' : 'loading', lastGood ? { ...lastGood } : {}));
+                    requestSample();
+                    return;
+                }
+                unsupportedSessions.add(sessionId);
+                pauseRegularPolling();
+                if (retryTimeoutId !== null) {
+                    clearTimeoutFn(retryTimeoutId);
+                    retryTimeoutId = null;
+                }
+                render(currentState('unavailable', lastGood ? { ...lastGood } : {}));
+                return;
+            }
+            if (reason === 'busy') {
+                render(currentState('stale', lastGood ? { ...lastGood } : {}));
+                return;
+            }
             failureCount += 1;
             const status = failureCount >= 3 ? 'unavailable' : 'stale';
             render(currentState(status, lastGood ? { ...lastGood } : {}));
+            if (failureCount >= 3) {
+                pauseRegularPolling();
+                scheduleRetry();
+            }
         }
 
         function requestSample() {
-            if (!visible || !connected || !sessionId || pendingRequest) return;
+            if (
+                !visible
+                || !connected
+                || !sessionId
+                || pendingRequest
+                || unsupportedSessions.has(sessionId)
+            ) return;
             requestCounter += 1;
             const requestId = `insights-${requestCounter}`;
             pendingRequest = {
                 sessionId,
                 requestId,
-                includeDiagnostics: diagnosticsVisible,
+                includeDiagnostics: diagnosticsVisible
+                    && !unsupportedDiagnosticsSessions.has(sessionId),
             };
             const payload = {
                 session_id: sessionId,
                 request_id: requestId,
             };
-            if (diagnosticsVisible) payload.include_diagnostics = true;
+            if (pendingRequest.includeDiagnostics) payload.include_diagnostics = true;
             socket.emit('request_session_insights', payload);
             responseTimeoutId = setTimeoutFn(() => {
                 if (!pendingRequest || pendingRequest.requestId !== requestId) return;
@@ -195,7 +275,12 @@
         }
 
         function startPolling() {
-            if (!visible || !connected || !sessionId) return;
+            if (
+                !visible
+                || !connected
+                || !sessionId
+                || unsupportedSessions.has(sessionId)
+            ) return;
             requestSample();
             intervalId = setIntervalFn(requestSample, POLL_INTERVAL_MS);
         }
@@ -214,7 +299,7 @@
             pendingRequest = null;
             clearResponseTimeout();
             if (!payload.success || !payload.stats) {
-                renderFailure();
+                renderFailure(payload.reason, responseRequest);
                 return;
             }
 
@@ -222,7 +307,9 @@
             const stats = payload.stats;
             const previousCpu = previousCpuBySession.get(sessionId) || null;
             const cpuPercent = calculateCpuPercent(previousCpu, stats.cpu);
-            previousCpuBySession.set(sessionId, Array.isArray(stats.cpu) ? stats.cpu.slice() : null);
+            if (Array.isArray(stats.cpu)) {
+                previousCpuBySession.set(sessionId, stats.cpu.slice());
+            }
 
             let networkRates = null;
             const sampledAt = nowFn();
@@ -262,7 +349,11 @@
             };
             lastGoodBySession.set(sessionId, lastGood);
             render(currentState('ready', { ...lastGood }));
-            if (diagnosticsVisible && !responseRequest.includeDiagnostics) {
+            if (
+                diagnosticsVisible
+                && !responseRequest.includeDiagnostics
+                && !unsupportedDiagnosticsSessions.has(sessionId)
+            ) {
                 requestSample();
             }
         }
@@ -278,11 +369,12 @@
                 connected = Boolean(isConnected && sessionId);
                 failureCount = 0;
                 lastGood = sessionId ? lastGoodBySession.get(sessionId) || null : null;
+                const unsupported = sessionId && unsupportedSessions.has(sessionId);
                 render(currentState(
-                    connected ? 'loading' : 'disconnected',
+                    connected ? (unsupported ? 'unavailable' : 'loading') : 'disconnected',
                     lastGood ? { ...lastGood } : { metricHistory: [] },
                 ));
-                startPolling();
+                if (!unsupported) startPolling();
             },
 
             setVisible(nextVisible) {
@@ -292,7 +384,9 @@
                 clearPolling();
                 if (visible) {
                     render(currentState(
-                        connected ? 'loading' : 'disconnected',
+                        connected && unsupportedSessions.has(sessionId)
+                            ? 'unavailable'
+                            : (connected ? 'loading' : 'disconnected'),
                         lastGood ? { ...lastGood } : {},
                     ));
                     startPolling();
@@ -315,6 +409,8 @@
                 previousNetworkBySession.delete(removedSessionId);
                 metricHistoryBySession.delete(removedSessionId);
                 lastGoodBySession.delete(removedSessionId);
+                unsupportedSessions.delete(removedSessionId);
+                unsupportedDiagnosticsSessions.delete(removedSessionId);
                 if (sessionId !== removedSessionId) return;
                 clearPolling();
                 sessionId = null;
@@ -334,11 +430,13 @@
     return {
         POLL_INTERVAL_MS,
         RESPONSE_TIMEOUT_MS,
+        BACKOFF_RETRY_MS,
         calculateCpuPercent,
         formatKib,
         severityForPercent,
         calculateNetworkRates,
         percent,
+        metricAvailability,
         createController,
     };
 }));

--- a/static/js/session-manager.js
+++ b/static/js/session-manager.js
@@ -46,18 +46,19 @@ const SessionManager = {
             display_name: data.display_name
         };
 
+        // Seed the authoritative snapshot before terminal attachment. Any live
+        // output already received is merged behind it without replay overlap.
+        TerminalManager.seedRestoredOutput(
+            sessionId,
+            data.buffered_output,
+            data.output_sequence,
+        );
+
         const restoredId = this.createSession(sessionData);
 
         const emptyIndex = this.getFirstEmptyPaneIndex();
         const targetPane = emptyIndex !== -1 ? emptyIndex : this.activePaneIndex;
         this.assignSessionToPane(restoredId, targetPane);
-
-        // Write buffered output to the restored terminal
-        if (data.buffered_output) {
-            setTimeout(() => {
-                TerminalManager.writeOutput(sessionId, data.buffered_output);
-            }, 200);
-        }
 
     },
 

--- a/static/js/session-workspace-ui.js
+++ b/static/js/session-workspace-ui.js
@@ -78,8 +78,10 @@
             toggle: documentRef.getElementById('sessionSftpToggleBtn'),
             filesMount: documentRef.getElementById('sessionFilesMount'),
             notepadPanel: documentRef.getElementById('notepadPanel'),
+            insightsCard: documentRef.getElementById('sessionInsightsCard'),
             insightsHost: documentRef.getElementById('sessionInsightsHost'),
             insightsState: documentRef.getElementById('sessionInsightsState'),
+            cpuResource: documentRef.getElementById('sessionCpuResource'),
             cpuGauge: documentRef.getElementById('sessionCpuGauge'),
             cpuValue: documentRef.getElementById('sessionCpuValue'),
             cpuChart: documentRef.getElementById('sessionCpuChart'),
@@ -91,6 +93,7 @@
             diskBar: documentRef.getElementById('sessionDiskBar'),
             osValue: documentRef.getElementById('sessionOsValue'),
             uptimeValue: documentRef.getElementById('sessionUptimeValue'),
+            insightsMeta: documentRef.getElementById('sessionInsightsMeta'),
         };
         if (!elements.mainSplit || !elements.toggle || !elements.filesPanel || !elements.filesMount) return null;
 
@@ -114,6 +117,20 @@
         function renderInsights(state) {
             lastInsightsState = state;
             const active = sessionManager.getSession(state.sessionId);
+            const availability = insightsModule.metricAvailability(state);
+            diagnosticsController?.render(state, active, lastInventoryState);
+            elements.insightsCard.hidden = !availability.any;
+            elements.cpuResource.hidden = !availability.cpu;
+            elements.ramResource.hidden = !availability.memory;
+            elements.diskResource.hidden = !availability.disk;
+            elements.osValue.hidden = !availability.os;
+            elements.uptimeValue.hidden = !availability.uptime;
+            elements.insightsMeta.hidden = !availability.os && !availability.uptime;
+            if (!availability.any) {
+                drawCpuHistory(elements.cpuChart, []);
+                return;
+            }
+
             elements.insightsHost.textContent = active
                 ? `${active.username}@${active.host}`
                 : 'No active session';
@@ -123,39 +140,35 @@
             };
             elements.insightsState.textContent = labels[state.status] || 'Offline';
             elements.insightsState.className = `session-insights-state ${state.status || ''}`;
-            diagnosticsController?.render(state, active, lastInventoryState);
-            if (!state.stats) {
-                if (state.status === 'disconnected' || state.status === 'unavailable') {
-                    elements.cpuValue.textContent = '--';
-                    elements.cpuGauge.style.setProperty('--value', '0');
-                    elements.ramValue.textContent = '--';
-                    elements.diskValue.textContent = '--';
-                    elements.ramBar.style.width = '0%';
-                    elements.diskBar.style.width = '0%';
-                    elements.osValue.textContent = 'Linux only';
-                    elements.uptimeValue.textContent = state.status === 'unavailable'
-                        ? 'Telemetry unavailable'
-                        : 'Refreshes every 4s';
-                    drawCpuHistory(elements.cpuChart, []);
-                }
-                return;
+
+            if (availability.cpu) {
+                const cpu = state.cpuPercent;
+                elements.cpuValue.textContent = `${cpu}%`;
+                elements.cpuGauge.style.setProperty('--value', String(cpu));
+                elements.cpuGauge.classList.remove('normal', 'warning', 'critical');
+                elements.cpuGauge.classList.add(insightsModule.severityForPercent(cpu));
+                drawCpuHistory(elements.cpuChart, state.cpuHistory);
+            } else {
+                drawCpuHistory(elements.cpuChart, []);
             }
 
-            const cpu = state.cpuPercent;
-            elements.cpuValue.textContent = cpu === null ? '...' : `${cpu}%`;
-            elements.cpuGauge.style.setProperty('--value', String(cpu || 0));
-            elements.cpuGauge.classList.remove('normal', 'warning', 'critical');
-            elements.cpuGauge.classList.add(insightsModule.severityForPercent(cpu || 0));
-            drawCpuHistory(elements.cpuChart, state.cpuHistory);
-
-            const memoryPercent = percent(state.stats.memory.used_kib, state.stats.memory.total_kib);
-            const diskPercent = Number(state.stats.disk.percent) || 0;
-            elements.ramValue.textContent = `${insightsModule.formatKib(state.stats.memory.used_kib)} / ${insightsModule.formatKib(state.stats.memory.total_kib)}`;
-            elements.diskValue.textContent = `${insightsModule.formatKib(state.stats.disk.used_kib)} / ${insightsModule.formatKib(state.stats.disk.total_kib)}`;
-            setResource(elements.ramResource, elements.ramBar, memoryPercent);
-            setResource(elements.diskResource, elements.diskBar, diskPercent);
-            elements.osValue.textContent = state.stats.os_name;
-            elements.uptimeValue.textContent = formatUptime(state.stats.uptime_seconds);
+            if (availability.memory) {
+                const memoryPercent = percent(
+                    state.stats.memory.used_kib,
+                    state.stats.memory.total_kib,
+                );
+                elements.ramValue.textContent = `${insightsModule.formatKib(state.stats.memory.used_kib)} / ${insightsModule.formatKib(state.stats.memory.total_kib)}`;
+                setResource(elements.ramResource, elements.ramBar, memoryPercent);
+            }
+            if (availability.disk) {
+                const diskPercent = Number(state.stats.disk.percent);
+                elements.diskValue.textContent = `${insightsModule.formatKib(state.stats.disk.used_kib)} / ${insightsModule.formatKib(state.stats.disk.total_kib)}`;
+                setResource(elements.diskResource, elements.diskBar, diskPercent);
+            }
+            if (availability.os) elements.osValue.textContent = state.stats.os_name;
+            if (availability.uptime) {
+                elements.uptimeValue.textContent = formatUptime(state.stats.uptime_seconds);
+            }
         }
 
         filesController = filesModule.createController({
@@ -187,6 +200,10 @@
         insightsController = insightsModule.createController({ socket, render: renderInsights });
         const desktopQuery = root.matchMedia('(min-width: 851px)');
         const wideDesktopQuery = root.matchMedia('(min-width: 1440px)');
+        const sftpCapabilityTracker = workspaceModule.createSftpCapabilityTracker({
+            socket,
+            onChange: sync,
+        });
         coordinator = workspaceModule.createCoordinator({
             filesPanel: filesController,
             insights: insightsController,
@@ -197,6 +214,7 @@
                 elements.toggle.setAttribute('aria-pressed', String(state.sftpOpen));
                 elements.mainSplit.classList.toggle('sftp-open', state.sftpOpen);
                 elements.filesPanel.classList.toggle('hidden', !state.sftpOpen);
+                sftpCapabilityTracker.probeIfNeeded(state);
                 root.requestAnimationFrame(() => terminalManager?.fitAllTerminals?.());
             },
         });
@@ -210,6 +228,7 @@
                 sessionId: activeId,
                 session: activeSession,
                 sessionCount: sessionManager.getAllSessions().length,
+                sftpCapability: sftpCapabilityTracker.get(activeId),
             });
             if (activeId !== inventorySessionId || connected !== inventoryConnected) {
                 inventorySessionId = activeId || null;
@@ -241,6 +260,7 @@
             const removedSessionId = event?.detail?.sessionId;
             insightsController?.removeSession(removedSessionId);
             inventoryController?.removeSession(removedSessionId);
+            sftpCapabilityTracker.remove(removedSessionId);
         });
         documentRef.addEventListener('visibilitychange', syncInsightsVisibility);
         desktopQuery.addEventListener?.('change', () => {

--- a/static/js/session-workspace.js
+++ b/static/js/session-workspace.js
@@ -9,6 +9,120 @@
 }(typeof globalThis !== 'undefined' ? globalThis : this, function () {
     'use strict';
 
+    function createSftpCapabilityTracker(options) {
+        const socket = options.socket;
+        const onChange = options.onChange || (() => {});
+        const setTimeoutFn = options.setTimeoutFn || setTimeout;
+        const clearTimeoutFn = options.clearTimeoutFn || clearTimeout;
+        let requestSequence = 0;
+        const createRequestId = options.createRequestId || (() => (
+            `sftp:${Date.now().toString(36)}:${++requestSequence}`
+        ));
+        const capabilities = new Map();
+        const pending = new Map();
+        const retryTimers = new Map();
+        const retryCounts = new Map();
+        let activeProbeSessionId = null;
+
+        function clearRetry(sessionId) {
+            const timerId = retryTimers.get(sessionId);
+            if (timerId !== undefined) clearTimeoutFn(timerId);
+            retryTimers.delete(sessionId);
+        }
+
+        function startProbe(sessionId) {
+            if (pending.has(sessionId) || capabilities.has(sessionId)) return false;
+            const requestId = createRequestId();
+            const timeoutId = setTimeoutFn(() => {
+                const request = pending.get(sessionId);
+                if (!request || request.requestId !== requestId) return;
+                pending.delete(sessionId);
+                scheduleRetry(sessionId);
+            }, 5000);
+            pending.set(sessionId, { requestId, timeoutId });
+            socket.emit('probe_session_sftp', {
+                session_id: sessionId,
+                request_id: requestId,
+            });
+            return true;
+        }
+
+        function scheduleRetry(sessionId) {
+            const retries = retryCounts.get(sessionId) || 0;
+            if (
+                retries >= 2
+                || retryTimers.has(sessionId)
+                || activeProbeSessionId !== sessionId
+            ) return;
+            retryCounts.set(sessionId, retries + 1);
+            const timerId = setTimeoutFn(() => {
+                retryTimers.delete(sessionId);
+                if (activeProbeSessionId === sessionId) startProbe(sessionId);
+            }, 10000);
+            retryTimers.set(sessionId, timerId);
+        }
+
+        socket.on('session_sftp_capability', data => {
+            const sessionId = typeof data?.session_id === 'string'
+                ? data.session_id
+                : '';
+            const requestId = typeof data?.request_id === 'string'
+                ? data.request_id
+                : '';
+            const request = pending.get(sessionId);
+            if (!sessionId || !request || request.requestId !== requestId) return;
+            clearTimeoutFn(request.timeoutId);
+            pending.delete(sessionId);
+            if (data.success !== true) {
+                scheduleRetry(sessionId);
+                return;
+            }
+            clearRetry(sessionId);
+            retryCounts.delete(sessionId);
+            capabilities.set(
+                sessionId,
+                data.available === true ? 'available' : 'unavailable'
+            );
+            onChange(sessionId);
+        });
+
+        return {
+            get(sessionId) {
+                return capabilities.get(sessionId) || 'unknown';
+            },
+
+            probeIfNeeded(state) {
+                const targetSessionId = state?.sessionId;
+                const eligibleSessionId = state?.sftpProbeNeeded
+                    && typeof targetSessionId === 'string'
+                    && targetSessionId
+                    ? targetSessionId
+                    : null;
+                if (activeProbeSessionId !== eligibleSessionId) {
+                    if (activeProbeSessionId) clearRetry(activeProbeSessionId);
+                    activeProbeSessionId = eligibleSessionId;
+                }
+                if (
+                    !eligibleSessionId
+                    || pending.has(targetSessionId)
+                ) {
+                    return false;
+                }
+                return startProbe(targetSessionId);
+            },
+
+            remove(sessionId) {
+                clearRetry(sessionId);
+                capabilities.delete(sessionId);
+                const request = pending.get(sessionId);
+                if (request) clearTimeoutFn(request.timeoutId);
+                pending.delete(sessionId);
+                retryCounts.delete(sessionId);
+                if (activeProbeSessionId === sessionId) activeProbeSessionId = null;
+            },
+        };
+    }
+
     function createCoordinator(options) {
         const filesPanel = options.filesPanel;
         const insights = options.insights || {};
@@ -20,6 +134,7 @@
         let sessionId = null;
         let session = null;
         let sftpOpen = false;
+        let sftpCapability = 'unknown';
         let visible = true;
         const manuallyDismissedSessions = new Set();
 
@@ -33,15 +148,29 @@
         }
 
         function state() {
+            const sftpProbeNeeded = Boolean(
+                !sftpOpen
+                && layout === 1
+                && isWideDesktop()
+                && sessionId
+                && session?.connected
+                && currentSessionCount === 1
+                && sftpCapability === 'unknown'
+                && !manuallyDismissedSessions.has(sessionId)
+            );
             return {
                 layout,
                 sessionId,
                 connected: Boolean(session?.connected),
                 sftpOpen,
                 sftpEnabled: canOpenSftp(),
+                sftpCapability,
+                sftpProbeNeeded,
                 visible,
             };
         }
+
+        let currentSessionCount = 0;
 
         function renderState() {
             render(state());
@@ -67,9 +196,12 @@
                     ? next.sessionId
                     : null;
                 session = next?.session || null;
-                const sessionCount = Number.isInteger(next?.sessionCount)
+                currentSessionCount = Number.isInteger(next?.sessionCount)
                     ? next.sessionCount
                     : 0;
+                sftpCapability = ['available', 'unavailable'].includes(next?.sftpCapability)
+                    ? next.sftpCapability
+                    : 'unknown';
                 const connected = Boolean(sessionId && session?.connected);
                 const sessionChanged = sessionId !== previousSessionId;
                 const connectionChanged = connected !== wasConnected;
@@ -88,7 +220,8 @@
                 } else if (
                     !sftpOpen
                     && isWideDesktop()
-                    && sessionCount === 1
+                    && currentSessionCount === 1
+                    && sftpCapability === 'available'
                     && !manuallyDismissedSessions.has(sessionId)
                 ) {
                     openSftp();
@@ -126,5 +259,5 @@
         };
     }
 
-    return { createCoordinator };
+    return { createCoordinator, createSftpCapabilityTracker };
 }));

--- a/static/js/terminal-manager.js
+++ b/static/js/terminal-manager.js
@@ -7,6 +7,9 @@ const TerminalManager = {
     sessionTerminals: {},
     transcripts: {},
     transcriptSizes: {},
+    sequencedOutput: {},
+    sequencedOutputSizes: {},
+    lastOutputSequences: {},
     maxTranscriptSize: 200000,
 
     getCssVar(name, fallback = '') {
@@ -139,6 +142,7 @@ const TerminalManager = {
             return false;
         }
 
+        const existingOutput = [...(this.transcripts[sessionId] || [])];
         this.pendingOutput[key] = [];
         this.terminalReady[key] = false;
         if (!this.transcripts[sessionId]) {
@@ -157,11 +161,13 @@ const TerminalManager = {
 
                 setTimeout(() => {
                     terminal.clear();
-                    // Discard any output buffered before the terminal was ready
-                    // to prevent stale output from previous sessions appearing
+                    const pendingOutput = this.pendingOutput[key] || [];
                     this.pendingOutput[key] = [];
-
                     this.terminalReady[key] = true;
+
+                    existingOutput.concat(pendingOutput).forEach(data => {
+                        this.writeOutputToTerminal(key, data);
+                    });
                 }, 50);
             });
         });
@@ -169,7 +175,31 @@ const TerminalManager = {
         return true;
     },
 
-    writeOutput(sessionId, data) {
+    writeOutput(sessionId, data, sequence = null) {
+        const normalizedSequence = Number.isSafeInteger(sequence) && sequence > 0
+            ? sequence
+            : null;
+        if (normalizedSequence !== null) {
+            const lastSequence = this.lastOutputSequences[sessionId] || 0;
+            if (normalizedSequence <= lastSequence) return;
+            this.lastOutputSequences[sessionId] = normalizedSequence;
+            if (!this.sequencedOutput[sessionId]) {
+                this.sequencedOutput[sessionId] = [];
+                this.sequencedOutputSizes[sessionId] = 0;
+            }
+            this.sequencedOutput[sessionId].push({
+                sequence: normalizedSequence,
+                data,
+            });
+            this.sequencedOutputSizes[sessionId] += data.length;
+            while (
+                this.sequencedOutputSizes[sessionId] > this.maxTranscriptSize
+                && this.sequencedOutput[sessionId].length > 1
+            ) {
+                const removed = this.sequencedOutput[sessionId].shift();
+                this.sequencedOutputSizes[sessionId] -= removed.data.length;
+            }
+        }
         const terminalKeys = this.sessionTerminals[sessionId] || [];
         this.appendTranscript(sessionId, data);
         if (terminalKeys.length === 0) {
@@ -233,6 +263,32 @@ const TerminalManager = {
             const removed = this.transcripts[sessionId].shift();
             this.transcriptSizes[sessionId] -= removed.length;
         }
+    },
+
+    seedRestoredOutput(sessionId, bufferedOutput, outputSequence = null) {
+        const snapshot = typeof bufferedOutput === 'string' ? bufferedOutput : '';
+        if (!snapshot) return;
+
+        const watermark = Number.isSafeInteger(outputSequence) && outputSequence >= 0
+            ? outputSequence
+            : null;
+        let liveOutput = this.getTranscript(sessionId);
+        if (watermark !== null) {
+            const events = (this.sequencedOutput[sessionId] || [])
+                .filter(event => event.sequence > watermark);
+            liveOutput = events.map(event => event.data).join('');
+            this.sequencedOutput[sessionId] = events;
+            this.sequencedOutputSizes[sessionId] = liveOutput.length;
+            this.lastOutputSequences[sessionId] = Math.max(
+                this.lastOutputSequences[sessionId] || 0,
+                watermark,
+            );
+        }
+
+        const merged = `${snapshot}${liveOutput}`;
+        const bounded = merged.slice(-this.maxTranscriptSize);
+        this.transcripts[sessionId] = bounded ? [bounded] : [];
+        this.transcriptSizes[sessionId] = bounded.length;
     },
 
     getTranscript(sessionId) {
@@ -332,6 +388,9 @@ const TerminalManager = {
         delete this.sessionTerminals[sessionId];
         delete this.transcripts[sessionId];
         delete this.transcriptSizes[sessionId];
+        delete this.sequencedOutput[sessionId];
+        delete this.sequencedOutputSizes[sessionId];
+        delete this.lastOutputSequences[sessionId];
     },
 
     setupScrollbar(container, terminal, terminalKey) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
 
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=21">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}?v=9">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=6">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=7">
 </head>
 <body data-theme="{{ theme|default('glass') }}" data-confirm-session-close="{{ 'true' if confirm_session_close else 'false' }}" data-connection-history-scope="{{ connection_history_scope }}">
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>
@@ -175,31 +175,31 @@
                 <button id="notepadToggle" class="notepad-toggle-btn" aria-label="Toggle notepad" title="Toggle notepad">◀</button>
             </div>
             <aside class="notepad-panel" id="notepadPanel">
-                <section class="session-insights-card" id="sessionInsightsCard" aria-live="polite">
+                <section class="session-insights-card" id="sessionInsightsCard" aria-live="polite" hidden>
                     <div class="session-insights-heading">
                         <div>
-                            <div class="session-panel-eyebrow">Live Linux telemetry</div>
+                            <div class="session-panel-eyebrow">Live system telemetry</div>
                             <div class="session-insights-host" id="sessionInsightsHost">No active session</div>
                         </div>
                         <span class="session-insights-state" id="sessionInsightsState">Offline</span>
                     </div>
-                    <div class="session-insights-grid">
+                    <div class="session-insights-grid" id="sessionCpuResource" hidden>
                         <div class="session-cpu-gauge" id="sessionCpuGauge" style="--value: 0">
                             <div><strong id="sessionCpuValue">--</strong><span>CPU</span></div>
                         </div>
                         <canvas class="session-cpu-chart" id="sessionCpuChart" width="180" height="72" aria-label="Recent CPU activity"></canvas>
                     </div>
-                    <div class="session-resource" id="sessionRamResource">
+                    <div class="session-resource" id="sessionRamResource" hidden>
                         <div><span>RAM</span><strong id="sessionRamValue">--</strong></div>
                         <div class="session-resource-track"><span id="sessionRamBar"></span></div>
                     </div>
-                    <div class="session-resource" id="sessionDiskResource">
+                    <div class="session-resource" id="sessionDiskResource" hidden>
                         <div><span>Disk /</span><strong id="sessionDiskValue">--</strong></div>
                         <div class="session-resource-track"><span id="sessionDiskBar"></span></div>
                     </div>
-                    <div class="session-insights-meta">
-                        <span id="sessionOsValue">Linux only</span>
-                        <span id="sessionUptimeValue">Refreshes every 4s</span>
+                    <div class="session-insights-meta" id="sessionInsightsMeta" hidden>
+                        <span id="sessionOsValue" hidden></span>
+                        <span id="sessionUptimeValue" hidden></span>
                     </div>
                     <button class="session-diagnostics-toggle" id="sessionDiagnosticsToggle" type="button" aria-expanded="false" aria-controls="sessionDiagnosticsOverlay" disabled>
                         <span class="material-icons" aria-hidden="true">monitor_heart</span>
@@ -226,7 +226,7 @@
             <div class="session-diagnostics-header">
                 <div>
                     <div class="session-panel-eyebrow">Active session</div>
-                    <h2 id="sessionDiagnosticsTitle">Server diagnostics</h2>
+                    <h2 id="sessionDiagnosticsTitle">Session diagnostics</h2>
                     <div class="session-diagnostics-hostline">
                         <span id="sessionDiagnosticsHost">No active session</span>
                         <span id="sessionDiagnosticsOs" hidden></span>
@@ -1282,13 +1282,13 @@
     <script src="{{ url_for('static', filename='js/i18n.js') }}?v=16"></script>
 
     <script src="{{ url_for('static', filename='js/binary-transfer-client.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=4"></script>
+    <script src="{{ url_for('static', filename='js/session-insights.js') }}?v=6"></script>
     <script src="{{ url_for('static', filename='js/session-runtime-inventory.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/session-diagnostics-charts.js') }}?v=1"></script>
-    <script src="{{ url_for('static', filename='js/session-diagnostics.js') }}?v=4"></script>
+    <script src="{{ url_for('static', filename='js/session-diagnostics.js') }}?v=5"></script>
     <script src="{{ url_for('static', filename='js/session-files-panel.js') }}?v=1"></script>
-    <script src="{{ url_for('static', filename='js/session-workspace.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=5"></script>
+    <script src="{{ url_for('static', filename='js/session-workspace.js') }}?v=4"></script>
+    <script src="{{ url_for('static', filename='js/session-workspace-ui.js') }}?v=6"></script>
     <script src="{{ url_for('static', filename='js/drag-drop-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/command-set-utils.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/command-palette-utils.js') }}?v=1"></script>
@@ -1296,8 +1296,8 @@
     <script src="{{ url_for('static', filename='js/connection-launcher.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/command-workspace.js') }}?v=2"></script>
 
-    <script src="{{ url_for('static', filename='js/terminal-manager.js') }}?v=4"></script>
-    <script src="{{ url_for('static', filename='js/session-manager.js') }}?v=6"></script>
+    <script src="{{ url_for('static', filename='js/terminal-manager.js') }}?v=7"></script>
+    <script src="{{ url_for('static', filename='js/session-manager.js') }}?v=8"></script>
     <script src="{{ url_for('static', filename='js/account-workspace-pulse.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/broadcast-input.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/profile-manager.js') }}?v=12"></script>
@@ -1310,7 +1310,7 @@
     <script src="{{ url_for('static', filename='js/file-workspace-state.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=13"></script>
     <script src="{{ url_for('static', filename='js/connection-history.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/app.js') }}?v=13"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}?v=14"></script>
     <script>
         const flashedMessages = {{ get_flashed_messages(with_categories=true) | tojson }};
         flashedMessages.forEach(([category, message]) => {

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -19,13 +19,13 @@ function pngSize(filePath) {
     return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
 }
 
-async function seedLinuxSession(page) {
+async function seedLinuxSession(page, options = {}) {
     await expect.poll(() => page.evaluate(() => (
         typeof Terminal === 'function'
         && typeof SessionManager !== 'undefined'
         && typeof SessionManager.createSession === 'function'
     ))).toBe(true);
-    await page.evaluate(() => {
+    await page.evaluate(seedOptions => {
         const originalEmit = window.socket.emit.bind(window.socket);
         let insightSample = 0;
         window.__workspaceEvents = [];
@@ -97,6 +97,15 @@ async function seedLinuxSession(page) {
             }
             window.__workspaceEvents.push({ event, payload: recordedPayload });
             if (payload?.session_id === 'workspace-linux') {
+                if (event === 'probe_session_sftp') {
+                    deliver('session_sftp_capability', {
+                        success: true,
+                        available: seedOptions.sftpAvailable !== false,
+                        session_id: payload.session_id,
+                        request_id: payload.request_id,
+                    });
+                    return window.socket;
+                }
                 if (event === 'request_session_runtime_inventory') {
                     window.__workspaceInventoryRequests += 1;
                     const response = {
@@ -131,13 +140,14 @@ async function seedLinuxSession(page) {
                         [260, 0, 180, 1060],
                         [400, 0, 260, 1120],
                     ];
-                    const stats = {
+                    const memory = {
+                        total_kib: 16 * 1024 * 1024,
+                        available_kib: 6 * 1024 * 1024,
+                        used_kib: 10 * 1024 * 1024,
+                    };
+                    const stats = seedOptions.partialMetrics ? { memory } : {
                         cpu: cpuSamples[Math.min(insightSample - 1, cpuSamples.length - 1)],
-                        memory: {
-                            total_kib: 16 * 1024 * 1024,
-                            available_kib: 6 * 1024 * 1024,
-                            used_kib: 10 * 1024 * 1024,
-                        },
+                        memory,
                         disk: {
                             total_kib: 100 * 1024 * 1024,
                             available_kib: 39 * 1024 * 1024,
@@ -234,7 +244,7 @@ async function seedLinuxSession(page) {
             '- Verify deployment health',
             '- Archive audit notes',
         ].join('\n');
-    });
+    }, options);
 }
 
 test('single-session workspace combines terminal, SFTP, live Linux stats, and notepad', async ({ page }, testInfo) => {
@@ -353,8 +363,34 @@ test('mobile workspace shows dormant diagnostics without polling', async ({ page
     await page.waitForTimeout(500);
 
     expect(await page.evaluate(() => window.__workspaceInsightSample || 0)).toBe(0);
-    await expect(page.locator('#sessionInsightsCard')).toBeVisible();
+    await expect(page.locator('#sessionInsightsCard')).toBeHidden();
     await expect(page.locator('#sessionDiagnosticsToggle')).toBeDisabled();
+    await assertNoExternalRequests(page);
+});
+
+test('wide workspace keeps embedded SFTP closed when the session probe fails', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page, { sftpAvailable: false });
+
+    await expect.poll(() => page.evaluate(() => window.__workspaceEvents.filter(
+        event => event.event === 'probe_session_sftp',
+    ).length)).toBe(1);
+    await expect(page.locator('#sessionSftpToggleBtn')).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('#sessionFilesPanel')).toBeHidden();
+    await expect(page.locator('#sessionInsightsCard')).toBeVisible();
+    await assertNoExternalRequests(page);
+});
+
+test('partial telemetry shows only metrics returned by the device', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page, { partialMetrics: true, sftpAvailable: false });
+
+    await expect(page.locator('#sessionInsightsCard')).toBeVisible();
+    await expect(page.locator('#sessionRamResource')).toBeVisible();
+    await expect(page.locator('#sessionCpuResource')).toBeHidden();
+    await expect(page.locator('#sessionDiskResource')).toBeHidden();
+    await expect(page.locator('#sessionInsightsMeta')).toBeHidden();
+    await expect(page.locator('#sessionDiagnosticsToggle')).toBeEnabled();
     await assertNoExternalRequests(page);
 });
 

--- a/tests/js/session-diagnostics.test.js
+++ b/tests/js/session-diagnostics.test.js
@@ -218,3 +218,20 @@ test('returns an unavailable model without telemetry or a connected session', ()
     assert.equal(model.docker, null);
     assert.deepEqual(model.permissionNotices, []);
 });
+
+test('partial telemetry omits empty diagnostic cards and pressure chart', () => {
+    const model = diagnostics.buildViewModel({
+        status: 'ready',
+        sessionId: 'switch-a',
+        cpuPercent: null,
+        metricHistory: [],
+        stats: {
+            memory: { total_kib: 4096, available_kib: 1024, used_kib: 3072 },
+        },
+    });
+
+    assert.equal(model.available, true);
+    assert.equal(model.resources.cpu, null);
+    assert.equal(model.resources.memory.percent, 75);
+    assert.equal(model.hasPressureHistory, false);
+});

--- a/tests/js/session-insights.test.js
+++ b/tests/js/session-insights.test.js
@@ -72,6 +72,25 @@ test('formats KiB values and maps visual thresholds', () => {
     assert.equal(insights.severityForPercent(90), 'critical');
 });
 
+test('reports only telemetry sections with usable values', () => {
+    assert.deepEqual(insights.metricAvailability({
+        cpuPercent: null,
+        stats: {
+            memory: { total_kib: 4096, used_kib: 3072 },
+            os_name: 'Appliance OS',
+        },
+    }), {
+        cpu: false,
+        memory: true,
+        disk: false,
+        os: true,
+        uptime: false,
+        any: true,
+    });
+
+    assert.equal(insights.metricAvailability({ stats: {} }).any, false);
+});
+
 
 test('requests immediately and repeats on an exact four second interval', () => {
     const runtime = fakeRuntime();
@@ -282,6 +301,114 @@ test('marks one failed update stale and three consecutive failures unavailable',
     failCurrentRequest();
 
     assert.equal(runtime.renders.at(-1).status, 'unavailable');
+});
+
+test('stops probing a session after the server confirms metrics are unsupported', () => {
+    const runtime = fakeRuntime();
+    runtime.controller.setSession('switch-a', true);
+    const request = runtime.emitted.at(-1).payload;
+
+    runtime.handlers.get('session_insights')({
+        success: false,
+        reason: 'unsupported',
+        session_id: 'switch-a',
+        request_id: request.request_id,
+    });
+
+    assert.equal(runtime.intervals.size, 0);
+    assert.equal(runtime.renders.at(-1).status, 'unavailable');
+    runtime.controller.setSession('switch-a', true);
+    assert.equal(runtime.emitted.length, 1);
+
+    runtime.controller.removeSession('switch-a');
+    runtime.controller.setSession('switch-a', true);
+    assert.equal(runtime.emitted.length, 2);
+});
+
+test('keeps base telemetry polling when only expanded diagnostics are unsupported', () => {
+    const runtime = fakeRuntime();
+    runtime.controller.setSession('appliance-a', true);
+    const baseRequest = runtime.emitted.at(-1).payload;
+    runtime.handlers.get('session_insights')({
+        success: true,
+        session_id: 'appliance-a',
+        request_id: baseRequest.request_id,
+        stats: { memory: { total_kib: 1000, used_kib: 600 } },
+    });
+
+    runtime.controller.setDiagnosticsVisible(true);
+    const expandedRequest = runtime.emitted.at(-1).payload;
+    assert.equal(expandedRequest.include_diagnostics, true);
+    runtime.handlers.get('session_insights')({
+        success: false,
+        reason: 'unsupported',
+        session_id: 'appliance-a',
+        request_id: expandedRequest.request_id,
+    });
+
+    const fallbackRequest = runtime.emitted.at(-1).payload;
+    assert.notEqual(fallbackRequest.request_id, expandedRequest.request_id);
+    assert.equal('include_diagnostics' in fallbackRequest, false);
+    assert.equal(runtime.intervals.size, 1);
+    assert.equal(runtime.renders.at(-1).status, 'ready');
+    const emittedBeforeFallbackResponse = runtime.emitted.length;
+    runtime.handlers.get('session_insights')({
+        success: true,
+        session_id: 'appliance-a',
+        request_id: fallbackRequest.request_id,
+        stats: { memory: { total_kib: 1000, used_kib: 600 } },
+    });
+    assert.equal(runtime.emitted.length, emittedBeforeFallbackResponse);
+});
+
+test('keeps the previous CPU baseline across partial samples without CPU counters', () => {
+    const runtime = fakeRuntime();
+    runtime.controller.setSession('session-a', true);
+
+    function respond(stats) {
+        const request = runtime.emitted.at(-1).payload;
+        runtime.handlers.get('session_insights')({
+            success: true,
+            session_id: 'session-a',
+            request_id: request.request_id,
+            stats,
+        });
+    }
+
+    respond({ cpu: [100, 0, 50, 850] });
+    [...runtime.intervals.values()][0].callback();
+    respond({ memory: { total_kib: 1000, used_kib: 500 } });
+    [...runtime.intervals.values()][0].callback();
+    respond({ cpu: [110, 0, 60, 880] });
+
+    assert.equal(runtime.renders.at(-1).cpuPercent, 40);
+});
+
+test('backs off regular polling after three transient failures', () => {
+    const runtime = fakeRuntime();
+    runtime.controller.setSession('iot-a', true);
+
+    function failCurrentRequest() {
+        const request = runtime.emitted.at(-1).payload;
+        runtime.handlers.get('session_insights')({
+            success: false,
+            reason: 'transient',
+            session_id: 'iot-a',
+            request_id: request.request_id,
+        });
+    }
+
+    failCurrentRequest();
+    [...runtime.intervals.values()][0].callback();
+    failCurrentRequest();
+    [...runtime.intervals.values()][0].callback();
+    failCurrentRequest();
+
+    assert.equal(runtime.intervals.size, 0);
+    assert.equal(
+        [...runtime.timeouts.values()].some(timer => timer.delay === 60000),
+        true,
+    );
 });
 
 

--- a/tests/js/session-manager-close.test.js
+++ b/tests/js/session-manager-close.test.js
@@ -21,7 +21,10 @@ function loadSessionManager(confirmSessionClose = true) {
                 return null;
             },
         },
-        TerminalManager: { destroyTerminal() {} },
+        TerminalManager: {
+            destroyTerminal() {},
+            seedRestoredOutput() {},
+        },
         CustomEvent: class CustomEvent {
             constructor(type, options) {
                 this.type = type;
@@ -100,4 +103,33 @@ test('emits a session-removed event exactly once for each actual UI removal', ()
     assert.deepEqual(removedIds, ['sessionA']);
     manager.removeSessionUI('missing-session');
     assert.deepEqual(removedIds, ['sessionA']);
+});
+
+test('seeds restored output before creating and attaching the terminal', () => {
+    const { manager, context } = loadSessionManager();
+    const calls = [];
+    context.TerminalManager.seedRestoredOutput = (sessionId, output, sequence) => {
+        calls.push(['seed', sessionId, output, sequence]);
+    };
+    manager.createSession = data => {
+        calls.push(['create', data.session_id]);
+        return data.session_id;
+    };
+    manager.getFirstEmptyPaneIndex = () => 0;
+    manager.assignSessionToPane = sessionId => calls.push(['assign', sessionId]);
+
+    manager.restoreSession({
+        session_id: 'restored',
+        host: 'switch.test',
+        port: 22,
+        username: 'admin',
+        buffered_output: 'switch# ',
+        output_sequence: 14,
+    });
+
+    assert.deepEqual(calls, [
+        ['seed', 'restored', 'switch# ', 14],
+        ['create', 'restored'],
+        ['assign', 'restored'],
+    ]);
 });

--- a/tests/js/session-workspace.test.js
+++ b/tests/js/session-workspace.test.js
@@ -1,7 +1,10 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { createCoordinator } = require('../../static/js/session-workspace.js');
+const {
+    createCoordinator,
+    createSftpCapabilityTracker,
+} = require('../../static/js/session-workspace.js');
 
 function createHarness(options = {}) {
     const calls = [];
@@ -34,6 +37,7 @@ test('auto-opens embedded SFTP for the sole connected session on a wide desktop'
         sessionId: 's1',
         session: { host: 'alpha', connected: true },
         sessionCount: 1,
+        sftpCapability: 'available',
     });
 
     assert.deepEqual(calls.slice(-2), [
@@ -41,6 +45,30 @@ test('auto-opens embedded SFTP for the sole connected session on a wide desktop'
         ['files.open', 's1', 'alpha'],
     ]);
     assert.equal(coordinator.getState().sftpOpen, true);
+});
+
+test('probes before auto-opening embedded SFTP and stays closed when unavailable', () => {
+    const { coordinator, calls } = createHarness({ isWideDesktop: () => true });
+    const update = sftpCapability => coordinator.update({
+        layout: 1,
+        sessionId: 's1',
+        session: { host: 'switch', connected: true },
+        sessionCount: 1,
+        sftpCapability,
+    });
+
+    update('unknown');
+    assert.equal(coordinator.getState().sftpOpen, false);
+    assert.equal(coordinator.getState().sftpProbeNeeded, true);
+    assert.equal(calls.some(call => call[0] === 'files.open'), false);
+
+    update('unavailable');
+    assert.equal(coordinator.getState().sftpOpen, false);
+    assert.equal(coordinator.getState().sftpProbeNeeded, false);
+    assert.equal(calls.some(call => call[0] === 'files.open'), false);
+
+    assert.equal(coordinator.toggleSftp(), true);
+    assert.deepEqual(calls.slice(-1), [['files.open', 's1', 'switch']]);
 });
 
 test('does not auto-open below the wide-desktop breakpoint but keeps manual SFTP available', () => {
@@ -77,6 +105,7 @@ test('manual close suppresses automatic reopening for the same session', () => {
         sessionId: 's1',
         session: { host: 'alpha', connected: true },
         sessionCount: 1,
+        sftpCapability: 'available',
     };
     coordinator.update(update);
     assert.equal(coordinator.toggleSftp(), false);
@@ -165,4 +194,125 @@ test('visibility pauses and resumes live insights without changing SFTP state', 
         ['insights.visible', true],
     ]);
     assert.equal(coordinator.getState().sftpOpen, true);
+});
+
+test('SFTP capability tracker probes once and accepts only its correlated response', () => {
+    const handlers = {};
+    const emitted = [];
+    const changes = [];
+    const socket = {
+        on(event, handler) { handlers[event] = handler; },
+        emit(event, payload) { emitted.push([event, payload]); },
+    };
+    const tracker = createSftpCapabilityTracker({
+        socket,
+        onChange(sessionId) { changes.push(sessionId); },
+        createRequestId: () => 'probe-1',
+    });
+    const candidate = { sessionId: 's1', sftpProbeNeeded: true };
+
+    tracker.probeIfNeeded(candidate);
+    tracker.probeIfNeeded(candidate);
+    assert.deepEqual(emitted, [['probe_session_sftp', {
+        session_id: 's1',
+        request_id: 'probe-1',
+    }]]);
+
+    handlers.session_sftp_capability({
+        success: true,
+        available: true,
+        session_id: 's1',
+        request_id: 'stale-probe',
+    });
+    assert.equal(tracker.get('s1'), 'unknown');
+
+    handlers.session_sftp_capability({
+        success: true,
+        available: true,
+        session_id: 's1',
+        request_id: 'probe-1',
+    });
+    assert.equal(tracker.get('s1'), 'available');
+    assert.deepEqual(changes, ['s1']);
+
+    tracker.remove('s1');
+    assert.equal(tracker.get('s1'), 'unknown');
+});
+
+test('SFTP capability tracker retries a busy probe without opening the pane', () => {
+    const handlers = {};
+    const emitted = [];
+    const timers = new Map();
+    let nextTimer = 1;
+    let nextRequest = 1;
+    const socket = {
+        on(event, handler) { handlers[event] = handler; },
+        emit(event, payload) { emitted.push([event, payload]); },
+    };
+    const tracker = createSftpCapabilityTracker({
+        socket,
+        createRequestId: () => `probe-${nextRequest++}`,
+        setTimeoutFn(callback, delay) {
+            const id = nextTimer++;
+            timers.set(id, { callback, delay });
+            return id;
+        },
+        clearTimeoutFn(id) { timers.delete(id); },
+    });
+    const candidate = { sessionId: 's1', sftpProbeNeeded: true };
+
+    tracker.probeIfNeeded(candidate);
+    handlers.session_sftp_capability({
+        success: false,
+        available: false,
+        session_id: 's1',
+        request_id: 'probe-1',
+    });
+
+    assert.equal(tracker.get('s1'), 'unknown');
+    assert.equal(timers.size, 1);
+    assert.equal([...timers.values()][0].delay, 10000);
+    [...timers.values()][0].callback();
+    assert.deepEqual(emitted.at(-1), ['probe_session_sftp', {
+        session_id: 's1',
+        request_id: 'probe-2',
+    }]);
+});
+
+test('SFTP capability tracker expires a lost request and ignores its late response', () => {
+    const handlers = {};
+    const emitted = [];
+    const timers = new Map();
+    let nextTimer = 1;
+    let nextRequest = 1;
+    const tracker = createSftpCapabilityTracker({
+        socket: {
+            on(event, handler) { handlers[event] = handler; },
+            emit(event, payload) { emitted.push([event, payload]); },
+        },
+        createRequestId: () => `probe-${nextRequest++}`,
+        setTimeoutFn(callback, delay) {
+            const id = nextTimer++;
+            timers.set(id, { callback, delay });
+            return id;
+        },
+        clearTimeoutFn(id) { timers.delete(id); },
+    });
+
+    tracker.probeIfNeeded({ sessionId: 's1', sftpProbeNeeded: true });
+    const [deadlineId, deadline] = [...timers.entries()]
+        .find(([_id, timer]) => timer.delay === 5000);
+    timers.delete(deadlineId);
+    deadline.callback();
+    handlers.session_sftp_capability({
+        success: true,
+        available: true,
+        session_id: 's1',
+        request_id: 'probe-1',
+    });
+
+    assert.equal(tracker.get('s1'), 'unknown');
+    const retry = [...timers.values()].find(timer => timer.delay === 10000);
+    retry.callback();
+    assert.equal(emitted.at(-1)[1].request_id, 'probe-2');
 });

--- a/tests/js/terminal-manager-layout.test.js
+++ b/tests/js/terminal-manager-layout.test.js
@@ -87,3 +87,87 @@ test('font size changes update hidden options without fitting hidden terminals',
     assert.equal(visible.cols, 96);
     assert.equal(hidden.cols, 120);
 });
+
+test('attachTerminal replays output received before and during terminal attachment', async () => {
+    const originalGetElementById = global.document.getElementById;
+    const originalRequestAnimationFrame = global.requestAnimationFrame;
+    const originalSetupScrollbar = TerminalManager.setupScrollbar;
+    const originalFitTerminal = TerminalManager.fitTerminal;
+    const originalConsoleError = console.error;
+    const writes = [];
+    const terminal = {
+        buffer: { active: { viewportY: 0, baseY: 0 } },
+        open() {},
+        clear() {},
+        write(data, callback) {
+            writes.push(data);
+            callback?.();
+        },
+        scrollToBottom() {},
+    };
+
+    try {
+        TerminalManager.terminals = {};
+        TerminalManager.sessionTerminals = {};
+        TerminalManager.pendingOutput = {};
+        TerminalManager.terminalReady = {};
+        TerminalManager.transcripts = {};
+        TerminalManager.transcriptSizes = {};
+        console.error = () => {};
+
+        TerminalManager.writeOutput('switch-session', 'Switch#');
+
+        TerminalManager.terminals.switchTerminal = terminal;
+        TerminalManager.sessionTerminals['switch-session'] = ['switchTerminal'];
+        global.document.getElementById = () => ({ appendChild() {} });
+        global.requestAnimationFrame = callback => callback();
+        TerminalManager.setupScrollbar = () => {};
+        TerminalManager.fitTerminal = () => {};
+
+        assert.equal(
+            TerminalManager.attachTerminal('switch-session', 'terminal-container', 'switchTerminal'),
+            true
+        );
+        TerminalManager.writeOutputToTerminal('switchTerminal', ' ready');
+
+        await new Promise(resolve => setTimeout(resolve, 80));
+
+        assert.deepEqual(writes, ['Switch#', ' ready']);
+    } finally {
+        global.document.getElementById = originalGetElementById;
+        global.requestAnimationFrame = originalRequestAnimationFrame;
+        TerminalManager.setupScrollbar = originalSetupScrollbar;
+        TerminalManager.fitTerminal = originalFitTerminal;
+        console.error = originalConsoleError;
+    }
+});
+
+test('restored output is seeded before attach without duplicating overlapping live output', () => {
+    TerminalManager.transcripts = {};
+    TerminalManager.transcriptSizes = {};
+    TerminalManager.sequencedOutput = {};
+    TerminalManager.lastOutputSequences = {};
+    TerminalManager.writeOutput('restored', 'switch# show version\r\n', 7);
+
+    TerminalManager.seedRestoredOutput(
+        'restored',
+        'boot complete\r\nswitch# show version\r\n',
+        7,
+    );
+
+    assert.equal(
+        TerminalManager.transcripts.restored.join(''),
+        'boot complete\r\nswitch# show version\r\n',
+    );
+
+    TerminalManager.writeOutput('restored', 'switch# ', 8);
+    TerminalManager.seedRestoredOutput('restored', 'older snapshot\r\nswitch# ', 7);
+
+    assert.equal(
+        TerminalManager.transcripts.restored.join(''),
+        'older snapshot\r\nswitch# switch# ',
+    );
+
+    TerminalManager.writeOutput('restored', 'duplicate snapshot event', 7);
+    assert.equal(TerminalManager.getTranscript('restored'), 'older snapshot\r\nswitch# switch# ');
+});

--- a/tests/test_key_management_ui.py
+++ b/tests/test_key_management_ui.py
@@ -103,7 +103,7 @@ def test_key_replacement_event_updates_ui_and_asset_version():
     assert 'ProfileManager.upsertKeySummary(data.key)' in APP
     assert "filename='js/profile-manager.js') }}?v=12" in TEMPLATE
     assert "filename='js/i18n.js') }}?v=16" in TEMPLATE
-    assert "filename='js/app.js') }}?v=13" in TEMPLATE
+    assert "filename='js/app.js') }}?v=14" in TEMPLATE
     assert "filename='css/style.css') }}?v=21" in TEMPLATE
 
 

--- a/tests/test_paramiko_channels.py
+++ b/tests/test_paramiko_channels.py
@@ -134,3 +134,42 @@ def test_open_sftp_sets_bounded_normal_operation_timeout(monkeypatch):
     assert result is marker
     assert transport.channel.timeouts == [3, 17]
     assert transport.channel.closed is False
+
+
+def test_open_sftp_uses_one_shared_absolute_deadline(monkeypatch):
+    from app import paramiko_channels
+
+    now = iter([10.0, 10.4, 10.8])
+    monkeypatch.setattr(paramiko_channels.time, 'monotonic', lambda: next(now))
+
+    class Channel:
+        closed = False
+
+        def __init__(self):
+            self.timeouts = []
+
+        def settimeout(self, timeout):
+            self.timeouts.append(timeout)
+
+        def invoke_subsystem(self, _name):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    channel = Channel()
+
+    class Transport:
+        def open_session(self, timeout=None):
+            assert timeout == pytest.approx(2.0)
+            return channel
+
+    guard = type('Guard', (), {'cancel': lambda self: None})()
+    monkeypatch.setattr(paramiko_channels, '_request_guard', lambda *_args: guard)
+    monkeypatch.setattr(paramiko_channels.paramiko, 'SFTPClient', lambda _channel: object())
+
+    paramiko_channels.open_sftp_client(
+        Transport(), timeout=5, operation_timeout=5, deadline=12.0
+    )
+
+    assert channel.timeouts == pytest.approx([1.6, 1.2])

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -40,15 +40,15 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
         "filename='js/profile-launcher-utils.js'": '?v=5',
         "filename='js/connection-launcher.js'": '?v=1',
         "filename='js/profile-manager.js'": '?v=12',
-        "filename='js/session-manager.js'": '?v=6',
-        "filename='js/terminal-manager.js'": '?v=4',
+        "filename='js/session-manager.js'": '?v=8',
+        "filename='js/terminal-manager.js'": '?v=7',
         "filename='js/sftp-file-manager.js'": '?v=13',
         "filename='js/jump-host-manager.js'": '?v=4',
         "filename='js/command-library.js'": '?v=3',
         "filename='js/command-set-manager.js'": '?v=2',
         "filename='js/session-command-launcher.js'": '?v=3',
         "filename='js/connection-history.js'": '?v=2',
-        "filename='js/app.js'": '?v=13',
+        "filename='js/app.js'": '?v=14',
     }
     for asset, version in expected_versions.items():
         asset_start = template.index(asset)

--- a/tests/test_session_insights.py
+++ b/tests/test_session_insights.py
@@ -56,20 +56,82 @@ def test_parse_linux_stats_returns_normalized_numeric_values():
     }
 
 
+def test_parse_linux_stats_keeps_supported_partial_metrics():
+    result = session_insights.parse_linux_stats("""\
+disk_total_kib=2048000
+disk_used_kib=1024000
+disk_available_kib=1024000
+disk_percent=50
+os_name=Network appliance OS
+""")
+
+    assert result == {
+        'disk': {
+            'total_kib': 2048000,
+            'used_kib': 1024000,
+            'available_kib': 1024000,
+            'percent': 50,
+        },
+        'os_name': 'Network appliance OS',
+    }
+
+
+def test_parse_linux_stats_ignores_invalid_section_when_another_is_valid():
+    result = session_insights.parse_linux_stats("""\
+cpu=not counters
+mem_total_kib=4096
+mem_available_kib=1024
+""")
+
+    assert result == {
+        'memory': {
+            'total_kib': 4096,
+            'available_kib': 1024,
+            'used_kib': 3072,
+        },
+    }
+
+
+def test_parse_linux_stats_rejects_payload_without_supported_metrics():
+    with pytest.raises(ValueError, match='no supported metrics'):
+        session_insights.parse_linux_stats('vendor_prompt=Switch#\n')
+
+
 @pytest.mark.parametrize(
-    'mutation',
+    ('mutation', 'omitted_section'),
     [
-        lambda value: value.replace('cpu=100 5 50 800 20 10 5 10\n', ''),
-        lambda value: value.replace('mem_total_kib=16384000', 'mem_total_kib=-1'),
-        lambda value: value.replace('mem_available_kib=6144000', 'mem_available_kib=20000000'),
-        lambda value: value.replace('disk_percent=60', 'disk_percent=101'),
-        lambda value: value.replace('uptime_seconds=93784.75', 'uptime_seconds=unknown'),
-        lambda value: value.replace('os_name=Ubuntu 24.04.2 LTS', 'os_name='),
+        (
+            lambda value: value.replace('cpu=100 5 50 800 20 10 5 10\n', ''),
+            'cpu',
+        ),
+        (
+            lambda value: value.replace('mem_total_kib=16384000', 'mem_total_kib=-1'),
+            'memory',
+        ),
+        (
+            lambda value: value.replace('mem_available_kib=6144000', 'mem_available_kib=20000000'),
+            'memory',
+        ),
+        (
+            lambda value: value.replace('disk_percent=60', 'disk_percent=101'),
+            'disk',
+        ),
+        (
+            lambda value: value.replace('uptime_seconds=93784.75', 'uptime_seconds=unknown'),
+            'uptime_seconds',
+        ),
+        (
+            lambda value: value.replace('os_name=Ubuntu 24.04.2 LTS', 'os_name='),
+            'os_name',
+        ),
     ],
 )
-def test_parse_linux_stats_rejects_missing_or_invalid_linux_values(mutation):
-    with pytest.raises(ValueError):
-        session_insights.parse_linux_stats(mutation(VALID_PAYLOAD))
+def test_parse_linux_stats_omits_only_missing_or_invalid_section(
+        mutation, omitted_section):
+    result = session_insights.parse_linux_stats(mutation(VALID_PAYLOAD))
+
+    assert omitted_section not in result
+    assert result
 
 
 def test_parse_linux_stats_rejects_output_above_bound():
@@ -175,6 +237,9 @@ def test_remote_diagnostics_use_a_fixed_safe_environment_without_elevation():
         assert forbidden not in session_insights.LINUX_DIAGNOSTICS_COMMAND
     assert 'comm=' in session_insights.LINUX_DIAGNOSTICS_COMMAND
     assert 'args=' not in session_insights.LINUX_DIAGNOSTICS_COMMAND
+    assert 'if [ -r /proc/stat ]' in session_insights.LINUX_STATS_COMMAND
+    assert 'command -v df' in session_insights.LINUX_STATS_COMMAND
+    assert 'command -v uname' in session_insights.LINUX_STATS_COMMAND
 
 
 class FakeChannel:
@@ -261,6 +326,30 @@ def test_collect_linux_stats_uses_separate_fixed_exec_channel(monkeypatch):
     assert channel.closed is True
 
 
+def test_collect_linux_stats_accepts_bounded_metrics_without_exit_status(
+        monkeypatch):
+    install_session(monkeypatch)
+
+    class NoExitStatusChannel(FakeChannel):
+        def exit_status_ready(self):
+            return False
+
+    channel = NoExitStatusChannel()
+    monkeypatch.setattr(
+        session_insights.ssh_manager,
+        '_open_exec_channel',
+        lambda *_args, **_kwargs: channel,
+    )
+
+    stats, error = session_insights.collect_linux_stats(
+        'owned-session', timeout=0.01
+    )
+
+    assert error is None
+    assert stats['os_name'] == 'Ubuntu 24.04.2 LTS'
+    assert channel.closed is True
+
+
 def test_collect_linux_stats_uses_expanded_fixed_command_only_when_requested(
         monkeypatch):
     transport = install_session(monkeypatch)
@@ -296,8 +385,8 @@ def test_collect_linux_stats_uses_expanded_fixed_command_only_when_requested(
 @pytest.mark.parametrize(
     ('connected', 'transport_active', 'expected_error'),
     [
-        (False, True, 'unavailable'),
-        (True, False, 'unavailable'),
+        (False, True, 'transient'),
+        (True, False, 'transient'),
     ],
 )
 def test_collect_linux_stats_rejects_inactive_sessions(
@@ -322,7 +411,7 @@ def test_collect_linux_stats_rejects_missing_session(monkeypatch):
     stats, error = session_insights.collect_linux_stats('owned-session')
 
     assert stats is None
-    assert error == 'unavailable'
+    assert error == 'transient'
 
 
 def test_collect_linux_stats_rejects_overlapping_collection(monkeypatch):
@@ -397,7 +486,7 @@ def test_collect_linux_stats_rejects_nonzero_remote_status(monkeypatch):
     stats, error = session_insights.collect_linux_stats('owned-session')
 
     assert stats is None
-    assert error == 'unavailable'
+    assert error == 'unsupported'
     assert channel.closed is True
 
 
@@ -415,5 +504,23 @@ def test_collect_linux_stats_rejects_output_above_collection_bound(monkeypatch):
     )
 
     assert stats is None
-    assert error == 'unavailable'
+    assert error == 'unsupported'
     assert channel.closed is True
+
+
+def test_collect_linux_stats_treats_generic_ssh_channel_race_as_transient(monkeypatch):
+    from paramiko import SSHException
+
+    install_session(monkeypatch)
+    monkeypatch.setattr(
+        session_insights.ssh_manager,
+        '_open_exec_channel',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            SSHException('channel closed during transport race')
+        ),
+    )
+
+    stats, error = session_insights.collect_linux_stats('owned-session')
+
+    assert stats is None
+    assert error == 'transient'

--- a/tests/test_session_insights_socket.py
+++ b/tests/test_session_insights_socket.py
@@ -137,7 +137,7 @@ def test_session_insights_socket_returns_generic_collector_failure(monkeypatch):
     emitted, calls = invoke(
         monkeypatch,
         {'session_id': 'owned-session', 'request_id': 'sample-3'},
-        collector_result=(None, 'unavailable'),
+        collector_result=(None, 'unsupported'),
     )
 
     assert calls == [('owned-session', False)]
@@ -146,6 +146,7 @@ def test_session_insights_socket_returns_generic_collector_failure(monkeypatch):
         'session_id': 'owned-session',
         'request_id': 'sample-3',
         'error': 'Session insights unavailable',
+        'reason': 'unsupported',
     })]
 
 

--- a/tests/test_sftp_handler.py
+++ b/tests/test_sftp_handler.py
@@ -3,6 +3,162 @@
 import pytest
 
 
+def test_probe_sftp_capability_verifies_directory_access(monkeypatch):
+    import app.sftp_handler as sftp_handler
+
+    class ClosingIterator:
+        def __init__(self):
+            self.closed = False
+            self.used = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.used:
+                raise StopIteration
+            self.used = True
+            return object()
+
+        def close(self):
+            self.closed = True
+
+    entries = ClosingIterator()
+    fake_sftp = type('FakeSFTP', (), {
+        'listdir_iter': lambda self, path: entries,
+        'close': lambda self: None,
+    })()
+    transport = type('Transport', (), {'is_active': lambda self: True})()
+    client = type('Client', (), {'get_transport': lambda self: transport})()
+    monkeypatch.setitem(sftp_handler.ssh_manager.sessions, 'session-a', {
+        'connected': True,
+        'client': client,
+    })
+    monkeypatch.setattr(
+        sftp_handler,
+        'open_sftp_client',
+        lambda *_args, **_kwargs: fake_sftp,
+    )
+
+    assert sftp_handler.probe_sftp_capability('session-a') is True
+    assert entries.closed is True
+
+
+def test_probe_sftp_capability_hides_remote_failure(monkeypatch):
+    import app.sftp_handler as sftp_handler
+
+    transport = type('Transport', (), {'is_active': lambda self: True})()
+    client = type('Client', (), {'get_transport': lambda self: transport})()
+    monkeypatch.setitem(sftp_handler.ssh_manager.sessions, 'session-a', {
+        'connected': True,
+        'client': client,
+    })
+    monkeypatch.setattr(
+        sftp_handler,
+        'open_sftp_client',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError('device-specific secret failure')
+        ),
+    )
+
+    assert sftp_handler.probe_sftp_capability('session-a') is False
+
+
+def test_probe_sftp_capability_uses_a_fresh_bounded_client(monkeypatch):
+    import app.sftp_handler as sftp_handler
+
+    class FakeSFTP:
+        def __init__(self):
+            self.closed = False
+
+        def listdir_iter(self, _path):
+            return iter([object()])
+
+        def close(self):
+            self.closed = True
+
+    class FakeClient:
+        def get_transport(self):
+            return type('Transport', (), {'is_active': lambda self: True})()
+
+    fake_sftp = FakeSFTP()
+    monkeypatch.setitem(sftp_handler.ssh_manager.sessions, 'session-a', {
+        'connected': True,
+        'client': FakeClient(),
+    })
+    observed = {}
+
+    def open_client(transport, *, timeout, operation_timeout, deadline):
+        observed.update(
+            transport=transport,
+            timeout=timeout,
+            operation_timeout=operation_timeout,
+            deadline=deadline,
+        )
+        return fake_sftp
+
+    monkeypatch.setattr(sftp_handler, 'open_sftp_client', open_client)
+    monkeypatch.setattr(
+        sftp_handler,
+        'sftp_session',
+        lambda _session_id: pytest.fail('capability probe used cached SFTP'),
+    )
+
+    assert sftp_handler.probe_sftp_capability('session-a') is True
+    assert observed['timeout'] <= 3
+    assert observed['operation_timeout'] <= 3
+    assert observed['deadline'] > 0
+    assert fake_sftp.closed is True
+
+
+def test_probe_sftp_capability_returns_retryable_busy_without_waiting(monkeypatch):
+    import app.sftp_handler as sftp_handler
+
+    held_lock = sftp_handler._acquire_capability_probe('session-a')
+    assert held_lock is not None
+    try:
+        assert sftp_handler.probe_sftp_capability('session-a') is None
+    finally:
+        sftp_handler._release_capability_probe('session-a', held_lock)
+
+
+def test_probe_sftp_capability_treats_deadline_closed_channel_as_retryable(monkeypatch):
+    import app.sftp_handler as sftp_handler
+
+    transport = type('Transport', (), {'is_active': lambda self: True})()
+    client = type('Client', (), {'get_transport': lambda self: transport})()
+    monkeypatch.setitem(sftp_handler.ssh_manager.sessions, 'session-a', {
+        'connected': True,
+        'client': client,
+    })
+
+    class DeadlineClosedSFTP:
+        def listdir_iter(self, _path):
+            raise EOFError('channel closed by deadline guard')
+
+        def close(self):
+            pass
+
+    clock = iter([10.0, 10.1, 13.1])
+    monkeypatch.setattr(sftp_handler.time, 'monotonic', lambda: next(clock))
+    monkeypatch.setattr(
+        sftp_handler,
+        'open_sftp_client',
+        lambda *_args, **_kwargs: DeadlineClosedSFTP(),
+    )
+    monkeypatch.setattr(
+        sftp_handler,
+        'Timer',
+        lambda *_args, **_kwargs: type('Guard', (), {
+            'daemon': True,
+            'start': lambda self: None,
+            'cancel': lambda self: None,
+        })(),
+    )
+
+    assert sftp_handler.probe_sftp_capability('session-a') is None
+
+
 class TestSanitizePath:
     """Tests for the sanitize_path function."""
 

--- a/tests/test_sftp_request_correlation.py
+++ b/tests/test_sftp_request_correlation.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from app import socket_events
 
 
@@ -104,3 +106,74 @@ def test_sftp_request_handlers_reject_malformed_payloads(monkeypatch):
             'request_id': None,
         }),
     ]
+
+
+def test_sftp_capability_probe_returns_only_correlated_availability(monkeypatch):
+    emitted, user = _capture(monkeypatch)
+    monkeypatch.setattr(socket_events, 'check_socket_rate_limit', lambda *_args: False)
+    monkeypatch.setattr(
+        socket_events.sftp_handler,
+        'probe_sftp_capability',
+        lambda _session_id: False,
+    )
+
+    socket_events.handle_probe_session_sftp.__wrapped__({
+        'session_id': 'session-a',
+        'request_id': 'sftp-probe:4',
+    }, current_user=user)
+
+    assert emitted == [('session_sftp_capability', {
+        'success': True,
+        'session_id': 'session-a',
+        'request_id': 'sftp-probe:4',
+        'available': False,
+    })]
+
+
+def test_sftp_capability_probe_reports_busy_as_retryable_generic_failure(monkeypatch):
+    emitted, user = _capture(monkeypatch)
+    monkeypatch.setattr(socket_events, 'check_socket_rate_limit', lambda *_args: False)
+    monkeypatch.setattr(
+        socket_events.sftp_handler,
+        'probe_sftp_capability',
+        lambda _session_id: None,
+    )
+
+    socket_events.handle_probe_session_sftp.__wrapped__({
+        'session_id': 'session-a',
+        'request_id': 'sftp-probe:busy',
+    }, current_user=user)
+
+    assert emitted == [('session_sftp_capability', {
+        'success': False,
+        'session_id': 'session-a',
+        'request_id': 'sftp-probe:busy',
+        'available': False,
+    })]
+
+
+def test_sftp_capability_probe_rejects_unowned_session_generically(monkeypatch):
+    emitted, user = _capture(monkeypatch)
+    monkeypatch.setattr(socket_events, 'check_socket_rate_limit', lambda *_args: False)
+    monkeypatch.setattr(
+        socket_events,
+        'verify_session_ownership',
+        lambda _session_id, _user_id: False,
+    )
+    monkeypatch.setattr(
+        socket_events.sftp_handler,
+        'probe_sftp_capability',
+        lambda _session_id: pytest.fail('unowned session reached SFTP'),
+    )
+
+    socket_events.handle_probe_session_sftp.__wrapped__({
+        'session_id': 'session-a',
+        'request_id': 'sftp-probe:5',
+    }, current_user=user)
+
+    assert emitted == [('session_sftp_capability', {
+        'success': False,
+        'session_id': 'session-a',
+        'request_id': 'sftp-probe:5',
+        'available': False,
+    })]

--- a/tests/test_ssh_manager.py
+++ b/tests/test_ssh_manager.py
@@ -129,6 +129,23 @@ def clean_sessions():
         ssh_manager.close_session(session_id)
 
 
+def test_output_snapshot_carries_a_monotone_sequence_watermark():
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions['session-1'] = {
+            'connected': True,
+            'output_buffer': [],
+            'output_buffer_size': 0,
+            'output_buffer_max': 512000,
+            'output_sequence': 0,
+        }
+
+    assert ssh_manager.record_output('session-1', 'switch# ', now=1) == 1
+    assert ssh_manager.record_output('session-1', 'switch# ', now=2) == 2
+    assert ssh_manager.get_output_snapshot('session-1') == ('switch# switch# ', 2)
+    with ssh_manager.sessions_lock:
+        ssh_manager.sessions.pop('session-1', None)
+
+
 def install_ssh_clients(monkeypatch, *connect_errors):
     clients = ClientList()
     opened_sockets = []


### PR DESCRIPTION
## What changed

- collect session metrics with guarded POSIX and BusyBox-compatible probes
- render only metrics and diagnostic sections that returned usable data
- keep base telemetry active when optional expanded diagnostics are unsupported
- probe SFTP capability on a fresh, bounded channel before auto-opening the embedded SFTP pane
- retry transient SFTP probe failures without treating them as permanent incompatibility
- preserve early terminal output and switch or appliance prompts during attachment and restore

## Why

Servers, switches, and appliances expose different command sets and SSH subsystems. Empty metric panels and an automatically opened but unusable SFTP pane created unnecessary errors for unsupported targets. The session workspace now adapts to the capabilities actually available while keeping probes bounded and read-only.

The standalone SFTP Manager is unchanged, and no SCP fallback is introduced.

## Validation

- `pytest tests -q`: 1603 passed, 33 skipped
- `npm run test:js`: 216 passed
- `npm run test:e2e`: 6 passed
- `npm run lint:js`
- `npm run vendor:check`
- `git diff --check`

Implements the compatibility behavior discussed in Discussion #116.