### PR TITLE
docs: publish versioned wiki automatically

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -75,7 +75,8 @@ jobs:
           fi
 
           git -C "$RUNNER_TEMP/webssh-wiki" diff --check
-          git -C "$RUNNER_TEMP/webssh-wiki" add --all -- '*.md' '*.markdown'
+          git -C "$RUNNER_TEMP/webssh-wiki" add --all -- \
+            '*.md' '*.markdown' '*.mdown' '*.mkdn'
           if git -C "$RUNNER_TEMP/webssh-wiki" diff --cached --quiet; then
             echo "The live Wiki already matches docs/wiki."
             exit 0

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -15,15 +15,13 @@ permissions:
 
 concurrency:
   group: wiki-sync
+  queue: max
   cancel-in-progress: false
 
 jobs:
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    env:
-      GH_TOKEN: ${{ github.token }}
-      WIKI_CHECKOUT: ${{ runner.temp }}/webssh-wiki
     steps:
       - name: Checkout canonical Wiki source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -36,11 +34,15 @@ jobs:
           python-version: '3.11'
 
       - name: Configure repository authentication
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: gh auth setup-git
 
       - name: Check whether this is still the current main revision
         id: current-main
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           current_main=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           if [[ "$current_main" != "$GITHUB_SHA" ]]; then
@@ -52,15 +54,19 @@ jobs:
 
       - name: Clone the live Wiki
         if: steps.current-main.outputs.publish == 'true'
-        run: git clone "https://github.com/${GITHUB_REPOSITORY}.wiki.git" "$WIKI_CHECKOUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git clone "https://github.com/${GITHUB_REPOSITORY}.wiki.git" "$RUNNER_TEMP/webssh-wiki"
 
       - name: Mirror versioned Wiki pages
         if: steps.current-main.outputs.publish == 'true'
-        run: python scripts/wiki_sync.py docs/wiki "$WIKI_CHECKOUT"
+        run: python scripts/wiki_sync.py docs/wiki "$RUNNER_TEMP/webssh-wiki"
 
       - name: Publish changed Wiki pages
         if: steps.current-main.outputs.publish == 'true'
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           current_main=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
           if [[ "$current_main" != "$GITHUB_SHA" ]]; then
@@ -68,14 +74,20 @@ jobs:
             exit 0
           fi
 
-          git -C "$WIKI_CHECKOUT" diff --check
-          git -C "$WIKI_CHECKOUT" add --all -- '*.md'
-          if git -C "$WIKI_CHECKOUT" diff --cached --quiet; then
+          git -C "$RUNNER_TEMP/webssh-wiki" diff --check
+          git -C "$RUNNER_TEMP/webssh-wiki" add --all -- '*.md' '*.markdown'
+          if git -C "$RUNNER_TEMP/webssh-wiki" diff --cached --quiet; then
             echo "The live Wiki already matches docs/wiki."
             exit 0
           fi
 
-          git -C "$WIKI_CHECKOUT" config user.name "github-actions[bot]"
-          git -C "$WIKI_CHECKOUT" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C "$WIKI_CHECKOUT" commit -m "docs: sync wiki from ${GITHUB_SHA:0:12}"
-          git -C "$WIKI_CHECKOUT" push origin HEAD
+          git -C "$RUNNER_TEMP/webssh-wiki" config user.name "github-actions[bot]"
+          git -C "$RUNNER_TEMP/webssh-wiki" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$RUNNER_TEMP/webssh-wiki" commit -m "docs: sync wiki from ${GITHUB_SHA:0:12}"
+
+          current_main=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          if [[ "$current_main" != "$GITHUB_SHA" ]]; then
+            echo "Skipping superseded revision $GITHUB_SHA; main is $current_main."
+            exit 0
+          fi
+          git -C "$RUNNER_TEMP/webssh-wiki" push origin HEAD

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,81 @@
+name: Wiki Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/wiki/**
+      - scripts/wiki_sync.py
+      - .github/workflows/wiki-sync.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      WIKI_CHECKOUT: ${{ runner.temp }}/webssh-wiki
+    steps:
+      - name: Checkout canonical Wiki source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up supported Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Configure repository authentication
+        run: gh auth setup-git
+
+      - name: Check whether this is still the current main revision
+        id: current-main
+        shell: bash
+        run: |
+          current_main=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          if [[ "$current_main" != "$GITHUB_SHA" ]]; then
+            echo "Skipping superseded revision $GITHUB_SHA; main is $current_main."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: Clone the live Wiki
+        if: steps.current-main.outputs.publish == 'true'
+        run: git clone "https://github.com/${GITHUB_REPOSITORY}.wiki.git" "$WIKI_CHECKOUT"
+
+      - name: Mirror versioned Wiki pages
+        if: steps.current-main.outputs.publish == 'true'
+        run: python scripts/wiki_sync.py docs/wiki "$WIKI_CHECKOUT"
+
+      - name: Publish changed Wiki pages
+        if: steps.current-main.outputs.publish == 'true'
+        shell: bash
+        run: |
+          current_main=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')
+          if [[ "$current_main" != "$GITHUB_SHA" ]]; then
+            echo "Skipping superseded revision $GITHUB_SHA; main is $current_main."
+            exit 0
+          fi
+
+          git -C "$WIKI_CHECKOUT" diff --check
+          git -C "$WIKI_CHECKOUT" add --all -- '*.md'
+          if git -C "$WIKI_CHECKOUT" diff --cached --quiet; then
+            echo "The live Wiki already matches docs/wiki."
+            exit 0
+          fi
+
+          git -C "$WIKI_CHECKOUT" config user.name "github-actions[bot]"
+          git -C "$WIKI_CHECKOUT" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$WIKI_CHECKOUT" commit -m "docs: sync wiki from ${GITHUB_SHA:0:12}"
+          git -C "$WIKI_CHECKOUT" push origin HEAD

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ unchanged. Use the production overlay, an HTTPS reverse proxy, exact origins,
 secure cookies, disabled browser registration, internal-target blocking, and
 explicit trusted-proxy settings.
 
-Read the [Quick Start](docs/wiki/Quick-Start.md) or
-the complete [Production Deployment](docs/wiki/Production-Deployment.md)
+Read the [Quick Start](https://github.com/bifrost0x/webssh/wiki/Quick-Start) or
+the complete [Production Deployment](https://github.com/bifrost0x/webssh/wiki/Production-Deployment)
 guide before accepting users.
 
 ## Security Boundary
@@ -200,7 +200,7 @@ Keep these deployment contracts intact:
 - Backups can contain the persisted application secret and encrypted private
   keys together. Protect and test them accordingly.
 
-See the [Security Model and Hardening](docs/wiki/Security-Model-and-Hardening.md)
+See the [Security Model and Hardening](https://github.com/bifrost0x/webssh/wiki/Security-Model-and-Hardening)
 guide and the project's [security policy](SECURITY.md) before exposing WebSSH
 to untrusted networks.
 
@@ -208,21 +208,23 @@ to untrusted networks.
 
 The README is the project entry point. Detailed installation, operation,
 security, authentication, recovery, and development guidance lives in the
-[WebSSH Wiki](docs/wiki/Home.md).
+[WebSSH Wiki](https://github.com/bifrost0x/webssh/wiki). Its
+[versioned source](docs/wiki/Home.md) is reviewed with the code through pull
+requests and published automatically after changes reach `main`.
 
 | Goal | Guide |
 |---|---|
-| Install with Docker | [Docker and Docker Compose](docs/wiki/Docker-and-Docker-Compose.md) |
-| Deploy behind HTTPS | [Production Deployment](docs/wiki/Production-Deployment.md) |
-| Configure every setting | [Configuration Reference](docs/wiki/Configuration-Reference.md) |
-| Connect and verify hosts | [SSH Connections and Host Keys](docs/wiki/SSH-Connections-and-Host-Keys.md) |
-| Use terminal and tmux sessions | [Terminal and Persistent tmux Sessions](docs/wiki/Terminal-and-Persistent-tmux-Sessions.md) |
-| Work with files and transfers | [SFTP File Workspace and Transfers](docs/wiki/SFTP-File-Workspace-and-Transfers.md) |
-| Configure authentication | [Authentication Overview](docs/wiki/Authentication-Overview.md) |
-| Run backup or restore | [Backup, Restore and Secret Rotation](docs/wiki/Backup-Restore-and-Secret-Rotation.md) |
-| Troubleshoot health checks | [Health Checks and Troubleshooting](docs/wiki/Health-Checks-and-Troubleshooting.md) |
-| Understand the runtime | [Architecture and Runtime Lifecycle](docs/wiki/Architecture-and-Runtime-Lifecycle.md) |
-| Develop and test locally | [Development and Testing](docs/wiki/Development-and-Testing.md) |
+| Install with Docker | [Docker and Docker Compose](https://github.com/bifrost0x/webssh/wiki/Docker-and-Docker-Compose) |
+| Deploy behind HTTPS | [Production Deployment](https://github.com/bifrost0x/webssh/wiki/Production-Deployment) |
+| Configure every setting | [Configuration Reference](https://github.com/bifrost0x/webssh/wiki/Configuration-Reference) |
+| Connect and verify hosts | [SSH Connections and Host Keys](https://github.com/bifrost0x/webssh/wiki/SSH-Connections-and-Host-Keys) |
+| Use terminal and tmux sessions | [Terminal and Persistent tmux Sessions](https://github.com/bifrost0x/webssh/wiki/Terminal-and-Persistent-tmux-Sessions) |
+| Work with files and transfers | [SFTP File Workspace and Transfers](https://github.com/bifrost0x/webssh/wiki/SFTP-File-Workspace-and-Transfers) |
+| Configure authentication | [Authentication Overview](https://github.com/bifrost0x/webssh/wiki/Authentication-Overview) |
+| Run backup or restore | [Backup, Restore and Secret Rotation](https://github.com/bifrost0x/webssh/wiki/Backup-Restore-and-Secret-Rotation) |
+| Troubleshoot health checks | [Health Checks and Troubleshooting](https://github.com/bifrost0x/webssh/wiki/Health-Checks-and-Troubleshooting) |
+| Understand the runtime | [Architecture and Runtime Lifecycle](https://github.com/bifrost0x/webssh/wiki/Architecture-and-Runtime-Lifecycle) |
+| Develop and test locally | [Development and Testing](https://github.com/bifrost0x/webssh/wiki/Development-and-Testing) |
 
 Additional project views:
 
@@ -236,7 +238,7 @@ Bug reports and focused pull requests are welcome. For feature proposals and
 architecture ideas, start with [GitHub Discussions](https://github.com/bifrost0x/webssh/discussions)
 so the security and runtime boundaries can be reviewed before implementation.
 
-- Read [Development and Testing](docs/wiki/Development-and-Testing.md).
+- Read [Development and Testing](https://github.com/bifrost0x/webssh/wiki/Development-and-Testing).
 - Use [Issues](https://github.com/bifrost0x/webssh/issues) for reproducible bugs.
 - Report vulnerabilities privately through
   [GitHub Security Advisories](https://github.com/bifrost0x/webssh/security/advisories/new).

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,1 +1,3 @@
 WebSSH documentation - [Project](https://github.com/bifrost0x/webssh) - [Issues](https://github.com/bifrost0x/webssh/issues) - [Discussions](https://github.com/bifrost0x/webssh/discussions) - [Security](https://github.com/bifrost0x/webssh/security/policy)
+
+This Wiki is published from the versioned [`docs/wiki`](https://github.com/bifrost0x/webssh/tree/main/docs/wiki) source. Please propose documentation changes through a pull request.

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -7,12 +7,13 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 import shutil
+import stat
 import subprocess
 import tempfile
 
 
 REQUIRED_PAGES = {"Home.md", "_Sidebar.md", "_Footer.md"}
-PUBLISHED_PAGE_SUFFIXES = {".md", ".markdown"}
+PUBLISHED_PAGE_SUFFIXES = {".md", ".markdown", ".mdown", ".mkdn"}
 
 
 @dataclass(frozen=True)
@@ -22,9 +23,20 @@ class SyncResult:
     unchanged: int
 
 
+def _is_symlink_or_reparse(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    return path.is_symlink() or bool(
+        getattr(metadata, "st_file_attributes", 0) & reparse_flag
+    )
+
+
 def _existing_directory(path: Path, label: str) -> Path:
-    if path.is_symlink():
-        raise ValueError(f"{label} must not be a symbolic link")
+    if _is_symlink_or_reparse(path):
+        raise ValueError(f"{label} must not be a symbolic link or reparse point")
     try:
         resolved = path.resolve(strict=True)
     except FileNotFoundError as exc:
@@ -37,7 +49,11 @@ def _existing_directory(path: Path, label: str) -> Path:
 def _canonical_pages(source: Path) -> dict[str, Path]:
     pages: dict[str, Path] = {}
     for entry in source.iterdir():
-        if entry.is_symlink() or not entry.is_file() or entry.suffix != ".md":
+        if (
+            _is_symlink_or_reparse(entry)
+            or not entry.is_file()
+            or entry.suffix != ".md"
+        ):
             raise ValueError(
                 "The canonical Wiki source may contain Markdown files only: "
                 f"{entry.name}"
@@ -54,6 +70,8 @@ def _canonical_pages(source: Path) -> dict[str, Path]:
 
 
 def _require_git_toplevel(destination: Path) -> None:
+    if _is_symlink_or_reparse(destination / ".git"):
+        raise ValueError("Wiki destination must be an existing Git checkout")
     result = subprocess.run(
         ["git", "-C", str(destination), "rev-parse", "--show-toplevel"],
         check=False,
@@ -77,7 +95,7 @@ def _published_pages(destination: Path) -> dict[str, Path]:
     for entry in destination.iterdir():
         if entry.suffix.lower() not in PUBLISHED_PAGE_SUFFIXES:
             continue
-        if entry.is_symlink():
+        if _is_symlink_or_reparse(entry):
             raise ValueError(
                 f"Wiki destination page must not be a symbolic link: {entry.name}"
             )
@@ -101,7 +119,7 @@ def _copy_page(source: Path, destination: Path) -> None:
             shutil.copyfileobj(input_file, output)
             output.flush()
             os.fsync(output.fileno())
-        if destination.is_symlink() or (
+        if _is_symlink_or_reparse(destination) or (
             destination.exists() and not destination.is_file()
         ):
             raise ValueError(
@@ -140,7 +158,7 @@ def sync_wiki(source: Path | str, destination: Path | str) -> SyncResult:
     unchanged = 0
     for name, source_page in sorted(pages.items()):
         destination_page = destination_path / name
-        if destination_page.is_symlink():
+        if _is_symlink_or_reparse(destination_page):
             raise ValueError(
                 f"Wiki destination page must not be a symbolic link: {name}"
             )

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -70,7 +70,8 @@ def _canonical_pages(source: Path) -> dict[str, Path]:
 
 
 def _require_git_toplevel(destination: Path) -> None:
-    if _is_symlink_or_reparse(destination / ".git"):
+    git_metadata = destination / ".git"
+    if _is_symlink_or_reparse(git_metadata) or not git_metadata.is_dir():
         raise ValueError("Wiki destination must be an existing Git checkout")
     result = subprocess.run(
         ["git", "-C", str(destination), "rev-parse", "--show-toplevel"],

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -7,9 +7,12 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 import shutil
+import subprocess
+import tempfile
 
 
 REQUIRED_PAGES = {"Home.md", "_Sidebar.md", "_Footer.md"}
+PUBLISHED_PAGE_SUFFIXES = {".md", ".markdown"}
 
 
 @dataclass(frozen=True)
@@ -50,6 +53,66 @@ def _canonical_pages(source: Path) -> dict[str, Path]:
     return pages
 
 
+def _require_git_toplevel(destination: Path) -> None:
+    result = subprocess.run(
+        ["git", "-C", str(destination), "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError("Wiki destination must be an existing Git checkout")
+    try:
+        top_level = Path(result.stdout.strip()).resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ValueError(
+            "Wiki destination must be an existing Git checkout"
+        ) from exc
+    if top_level != destination:
+        raise ValueError("Wiki destination must be the Git checkout top-level")
+
+
+def _published_pages(destination: Path) -> dict[str, Path]:
+    pages: dict[str, Path] = {}
+    for entry in destination.iterdir():
+        if entry.suffix.lower() not in PUBLISHED_PAGE_SUFFIXES:
+            continue
+        if entry.is_symlink():
+            raise ValueError(
+                f"Wiki destination page must not be a symbolic link: {entry.name}"
+            )
+        if not entry.is_file():
+            raise ValueError(
+                f"Wiki destination page must be a regular file: {entry.name}"
+            )
+        pages[entry.name] = entry
+    return pages
+
+
+def _copy_page(source: Path, destination: Path) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".wiki-sync-{destination.name}-",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    temporary_page = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as output, source.open("rb") as input_file:
+            shutil.copyfileobj(input_file, output)
+            output.flush()
+            os.fsync(output.fileno())
+        if destination.is_symlink() or (
+            destination.exists() and not destination.is_file()
+        ):
+            raise ValueError(
+                "Wiki destination page must be a regular non-symlink file: "
+                f"{destination.name}"
+            )
+        os.replace(temporary_page, destination)
+    finally:
+        temporary_page.unlink(missing_ok=True)
+
+
 def sync_wiki(source: Path | str, destination: Path | str) -> SyncResult:
     """Mirror top-level Markdown pages without deleting non-page attachments."""
     source_path = _existing_directory(Path(source), "Wiki source")
@@ -64,17 +127,11 @@ def sync_wiki(source: Path | str, destination: Path | str) -> SyncResult:
     ):
         raise ValueError("Wiki source and destination must not overlap")
 
-    git_metadata = destination_path / ".git"
-    if git_metadata.is_symlink() or not git_metadata.exists():
-        raise ValueError("Wiki destination must be an existing Git checkout")
-
+    _require_git_toplevel(destination_path)
     pages = _canonical_pages(source_path)
+    published_pages = _published_pages(destination_path)
     removed = 0
-    for existing in destination_path.glob("*.md"):
-        if existing.is_symlink():
-            raise ValueError(
-                f"Wiki destination page must not be a symbolic link: {existing.name}"
-            )
+    for existing in published_pages.values():
         if existing.name not in pages:
             existing.unlink()
             removed += 1
@@ -94,12 +151,7 @@ def sync_wiki(source: Path | str, destination: Path | str) -> SyncResult:
             unchanged += 1
             continue
 
-        temporary_page = destination_path / f".{name}.wiki-sync.tmp"
-        try:
-            shutil.copyfile(source_page, temporary_page)
-            os.replace(temporary_page, destination_page)
-        finally:
-            temporary_page.unlink(missing_ok=True)
+        _copy_page(source_page, destination_page)
         copied += 1
 
     return SyncResult(copied=copied, removed=removed, unchanged=unchanged)

--- a/scripts/wiki_sync.py
+++ b/scripts/wiki_sync.py
@@ -1,0 +1,128 @@
+"""Mirror the versioned Wiki pages into a cloned GitHub Wiki checkout."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+
+
+REQUIRED_PAGES = {"Home.md", "_Sidebar.md", "_Footer.md"}
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    copied: int
+    removed: int
+    unchanged: int
+
+
+def _existing_directory(path: Path, label: str) -> Path:
+    if path.is_symlink():
+        raise ValueError(f"{label} must not be a symbolic link")
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError(f"{label} does not exist: {path}") from exc
+    if not resolved.is_dir():
+        raise ValueError(f"{label} is not a directory: {path}")
+    return resolved
+
+
+def _canonical_pages(source: Path) -> dict[str, Path]:
+    pages: dict[str, Path] = {}
+    for entry in source.iterdir():
+        if entry.is_symlink() or not entry.is_file() or entry.suffix != ".md":
+            raise ValueError(
+                "The canonical Wiki source may contain Markdown files only: "
+                f"{entry.name}"
+            )
+        pages[entry.name] = entry
+
+    missing = sorted(REQUIRED_PAGES - pages.keys())
+    if missing:
+        raise ValueError(
+            "The canonical Wiki source is missing required pages: "
+            + ", ".join(missing)
+        )
+    return pages
+
+
+def sync_wiki(source: Path | str, destination: Path | str) -> SyncResult:
+    """Mirror top-level Markdown pages without deleting non-page attachments."""
+    source_path = _existing_directory(Path(source), "Wiki source")
+    destination_path = _existing_directory(
+        Path(destination), "Wiki destination"
+    )
+
+    if (
+        source_path == destination_path
+        or source_path in destination_path.parents
+        or destination_path in source_path.parents
+    ):
+        raise ValueError("Wiki source and destination must not overlap")
+
+    git_metadata = destination_path / ".git"
+    if git_metadata.is_symlink() or not git_metadata.exists():
+        raise ValueError("Wiki destination must be an existing Git checkout")
+
+    pages = _canonical_pages(source_path)
+    removed = 0
+    for existing in destination_path.glob("*.md"):
+        if existing.is_symlink():
+            raise ValueError(
+                f"Wiki destination page must not be a symbolic link: {existing.name}"
+            )
+        if existing.name not in pages:
+            existing.unlink()
+            removed += 1
+
+    copied = 0
+    unchanged = 0
+    for name, source_page in sorted(pages.items()):
+        destination_page = destination_path / name
+        if destination_page.is_symlink():
+            raise ValueError(
+                f"Wiki destination page must not be a symbolic link: {name}"
+            )
+        if (
+            destination_page.is_file()
+            and destination_page.read_bytes() == source_page.read_bytes()
+        ):
+            unchanged += 1
+            continue
+
+        temporary_page = destination_path / f".{name}.wiki-sync.tmp"
+        try:
+            shutil.copyfile(source_page, temporary_page)
+            os.replace(temporary_page, destination_page)
+        finally:
+            temporary_page.unlink(missing_ok=True)
+        copied += 1
+
+    return SyncResult(copied=copied, removed=removed, unchanged=unchanged)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("destination", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        result = sync_wiki(args.source, args.destination)
+    except ValueError as exc:
+        parser.exit(2, f"wiki-sync: {exc}\n")
+
+    print(
+        "Wiki pages synchronized: "
+        f"{result.copied} copied, {result.removed} removed, "
+        f"{result.unchanged} unchanged"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_documentation_surface.py
+++ b/tests/test_documentation_surface.py
@@ -247,8 +247,8 @@ def test_readme_uses_the_new_product_media():
         assert f"assets/{name}" in readme
 
 
-def test_readme_moves_long_form_runbooks_to_the_wiki():
-    """Operational detail lives in the versioned Wiki instead of the README."""
+def test_readme_routes_long_form_runbooks_to_the_published_wiki():
+    """Readers use the live Wiki while its canonical source remains reviewable."""
     readme = README.read_text(encoding="utf-8")
     for removed_heading in (
         "### Environment Variables",
@@ -257,7 +257,9 @@ def test_readme_moves_long_form_runbooks_to_the_wiki():
         "### Project Structure",
     ):
         assert removed_heading not in readme
-    assert "https://github.com/bifrost0x/webssh/wiki/" not in readme
+    live_wiki = "https://github.com/bifrost0x/webssh/wiki"
+    assert f"[WebSSH Wiki]({live_wiki})" in readme
+    assert "[versioned source](docs/wiki/Home.md)" in readme
     for guide in (
         "Quick-Start.md",
         "Production-Deployment.md",
@@ -265,7 +267,7 @@ def test_readme_moves_long_form_runbooks_to_the_wiki():
         "Configuration-Reference.md",
         "Development-and-Testing.md",
     ):
-        assert f"docs/wiki/{guide}" in readme
+        assert f"{live_wiki}/{guide.removesuffix('.md')}" in readme
 
 
 def test_current_diagrams_are_embedded_on_the_relevant_wiki_pages():

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -122,14 +122,23 @@ def test_wiki_sync_is_main_only_and_uses_the_repository_token():
     assert re.search(r'push:\s*\n\s+branches:\s*\n\s+- main\b', workflow)
     assert "if: github.ref == 'refs/heads/main'" in workflow
     assert re.search(r'permissions:\s*\n\s+contents:\s+write\b', workflow)
+    assert re.search(r'concurrency:.*?queue:\s+max\b', workflow, re.DOTALL)
     assert 'persist-credentials: false' in workflow
     assert 'actions/setup-python@' in workflow
     assert "python-version: '3.11'" in workflow
     assert 'GH_TOKEN: ${{ github.token }}' in workflow
     assert 'secrets.' not in workflow
     assert 'scripts/wiki_sync.py' in workflow
-    assert 'git/ref/heads/main' in workflow
+    assert workflow.count('git/ref/heads/main') >= 3
+    assert '${{ runner.temp }}' not in workflow
+    assert '"$RUNNER_TEMP/webssh-wiki"' in workflow
     assert 'push origin HEAD' in workflow
+
+    publish = workflow.split('- name: Publish changed Wiki pages', 1)[1]
+    commit = publish.index(' commit -m ')
+    final_main_check = publish.rindex('git/ref/heads/main')
+    push = publish.index(' push origin HEAD')
+    assert commit < final_main_check < push
 
 
 def test_container_build_inputs_and_ci_services_are_digest_pinned():

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -129,6 +129,8 @@ def test_wiki_sync_is_main_only_and_uses_the_repository_token():
     assert 'GH_TOKEN: ${{ github.token }}' in workflow
     assert 'secrets.' not in workflow
     assert 'scripts/wiki_sync.py' in workflow
+    for markdown_pathspec in ('*.md', '*.markdown', '*.mdown', '*.mkdn'):
+        assert markdown_pathspec in workflow
     assert workflow.count('git/ref/heads/main') >= 3
     assert '${{ runner.temp }}' not in workflow
     assert '"$RUNNER_TEMP/webssh-wiki"' in workflow

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -115,6 +115,23 @@ def test_node_workflows_use_current_lts():
         assert "node-version: '22'" not in text, workflow
 
 
+def test_wiki_sync_is_main_only_and_uses_the_repository_token():
+    workflow = (WORKFLOWS / 'wiki-sync.yml').read_text(encoding='utf-8')
+
+    assert 'pull_request:' not in workflow
+    assert re.search(r'push:\s*\n\s+branches:\s*\n\s+- main\b', workflow)
+    assert "if: github.ref == 'refs/heads/main'" in workflow
+    assert re.search(r'permissions:\s*\n\s+contents:\s+write\b', workflow)
+    assert 'persist-credentials: false' in workflow
+    assert 'actions/setup-python@' in workflow
+    assert "python-version: '3.11'" in workflow
+    assert 'GH_TOKEN: ${{ github.token }}' in workflow
+    assert 'secrets.' not in workflow
+    assert 'scripts/wiki_sync.py' in workflow
+    assert 'git/ref/heads/main' in workflow
+    assert 'push origin HEAD' in workflow
+
+
 def test_container_build_inputs_and_ci_services_are_digest_pinned():
     dockerfiles = [
         ROOT / 'Dockerfile',

--- a/tests/test_wiki_sync.py
+++ b/tests/test_wiki_sync.py
@@ -151,6 +151,32 @@ class WikiSyncTests(unittest.TestCase):
 
             self.assertEqual(valuable.read_text(encoding="utf-8"), "keep")
 
+    def test_sync_refuses_external_gitdir_pointer_before_removing_pages(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            real_repository = root / "real-repository"
+            real_repository.mkdir()
+            subprocess.run(
+                ["git", "init", "--quiet", str(real_repository)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            destination = root / "pointer-checkout"
+            destination.mkdir()
+            (destination / ".git").write_text(
+                f"gitdir: {(real_repository / '.git').as_posix()}\n",
+                encoding="utf-8",
+            )
+            valuable = destination / "valuable.md"
+            valuable.write_text("keep", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "Git checkout"):
+                sync_wiki(source, destination)
+
+            self.assertEqual(valuable.read_text(encoding="utf-8"), "keep")
+
     def test_sync_rejects_page_symlinks_before_removing_stale_pages(self):
         with TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_wiki_sync.py
+++ b/tests/test_wiki_sync.py
@@ -1,0 +1,93 @@
+"""Behavioral tests for publishing the canonical Wiki source."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from scripts.wiki_sync import sync_wiki
+
+
+class WikiSyncTests(unittest.TestCase):
+    def make_wiki_source(self, root: Path) -> Path:
+        source = root / "source"
+        source.mkdir()
+        (source / "Home.md").write_text("# Home\n", encoding="utf-8")
+        (source / "_Sidebar.md").write_text("[Home](Home)\n", encoding="utf-8")
+        (source / "_Footer.md").write_text("Versioned source\n", encoding="utf-8")
+        return source
+
+    def make_wiki_checkout(self, root: Path) -> Path:
+        destination = root / "wiki"
+        destination.mkdir()
+        (destination / ".git").mkdir()
+        return destination
+
+    def test_sync_mirrors_markdown_pages_without_touching_other_files(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            destination = self.make_wiki_checkout(root)
+            (source / "Quick-Start.md").write_text(
+                "# Quick Start\n", encoding="utf-8"
+            )
+            (destination / "Home.md").write_text(
+                "# Stale home\n", encoding="utf-8"
+            )
+            (destination / "Removed-Page.md").write_text(
+                "# Removed\n", encoding="utf-8"
+            )
+            (destination / "attachment.png").write_bytes(b"keep")
+
+            result = sync_wiki(source, destination)
+
+            self.assertEqual(
+                {path.name for path in destination.glob("*.md")},
+                {"Home.md", "Quick-Start.md", "_Sidebar.md", "_Footer.md"},
+            )
+            self.assertEqual(
+                (destination / "Home.md").read_text(encoding="utf-8"),
+                "# Home\n",
+            )
+            self.assertEqual((destination / "attachment.png").read_bytes(), b"keep")
+            self.assertEqual(result.copied, 4)
+            self.assertEqual(result.removed, 1)
+
+    def test_sync_rejects_non_markdown_source_artifacts(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            destination = self.make_wiki_checkout(root)
+            (source / "notes.txt").write_text("not a Wiki page", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "Markdown files"):
+                sync_wiki(source, destination)
+
+    def test_sync_requires_the_navigation_pages(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            destination = self.make_wiki_checkout(root)
+            (source / "_Footer.md").unlink()
+
+            with self.assertRaisesRegex(ValueError, "_Footer.md"):
+                sync_wiki(source, destination)
+
+    def test_sync_refuses_a_destination_that_is_not_a_git_checkout(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            destination = root / "not-a-checkout"
+            destination.mkdir()
+            (destination / "valuable.md").write_text("keep", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "Git checkout"):
+                sync_wiki(source, destination)
+
+            self.assertEqual(
+                (destination / "valuable.md").read_text(encoding="utf-8"),
+                "keep",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wiki_sync.py
+++ b/tests/test_wiki_sync.py
@@ -1,6 +1,7 @@
 """Behavioral tests for publishing the canonical Wiki source."""
 
 from pathlib import Path
+import subprocess
 from tempfile import TemporaryDirectory
 import unittest
 
@@ -19,7 +20,12 @@ class WikiSyncTests(unittest.TestCase):
     def make_wiki_checkout(self, root: Path) -> Path:
         destination = root / "wiki"
         destination.mkdir()
-        (destination / ".git").mkdir()
+        subprocess.run(
+            ["git", "init", "--quiet", str(destination)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
         return destination
 
     def test_sync_mirrors_markdown_pages_without_touching_other_files(self):
@@ -36,7 +42,12 @@ class WikiSyncTests(unittest.TestCase):
             (destination / "Removed-Page.md").write_text(
                 "# Removed\n", encoding="utf-8"
             )
+            (destination / "Rogue.markdown").write_text(
+                "# Rogue\n", encoding="utf-8"
+            )
             (destination / "attachment.png").write_bytes(b"keep")
+            temporary_attachment = destination / ".Home.md.wiki-sync.tmp"
+            temporary_attachment.write_bytes(b"keep temporary attachment")
 
             result = sync_wiki(source, destination)
 
@@ -49,8 +60,11 @@ class WikiSyncTests(unittest.TestCase):
                 "# Home\n",
             )
             self.assertEqual((destination / "attachment.png").read_bytes(), b"keep")
+            self.assertEqual(
+                temporary_attachment.read_bytes(), b"keep temporary attachment"
+            )
             self.assertEqual(result.copied, 4)
-            self.assertEqual(result.removed, 1)
+            self.assertEqual(result.removed, 2)
 
     def test_sync_rejects_non_markdown_source_artifacts(self):
         with TemporaryDirectory() as directory:
@@ -87,6 +101,43 @@ class WikiSyncTests(unittest.TestCase):
                 (destination / "valuable.md").read_text(encoding="utf-8"),
                 "keep",
             )
+
+    def test_sync_refuses_fake_git_metadata_before_removing_pages(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            destination = root / "fake-checkout"
+            destination.mkdir()
+            (destination / ".git").write_text("not Git metadata", encoding="utf-8")
+            valuable = destination / "valuable.md"
+            valuable.write_text("keep", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "Git checkout"):
+                sync_wiki(source, destination)
+
+            self.assertEqual(valuable.read_text(encoding="utf-8"), "keep")
+
+    def test_sync_rejects_page_symlinks_before_removing_stale_pages(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            (source / "ZZZ.md").write_text("linked", encoding="utf-8")
+            destination = self.make_wiki_checkout(root)
+            outside = root / "outside.md"
+            outside.write_text("outside", encoding="utf-8")
+            stale = destination / "AAA-Stale.md"
+            stale.write_text("stale", encoding="utf-8")
+            linked_page = destination / "ZZZ.md"
+            try:
+                linked_page.symlink_to(outside)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+
+            with self.assertRaisesRegex(ValueError, "symbolic link"):
+                sync_wiki(source, destination)
+
+            self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
+            self.assertEqual(stale.read_text(encoding="utf-8"), "stale")
 
 
 if __name__ == "__main__":

--- a/tests/test_wiki_sync.py
+++ b/tests/test_wiki_sync.py
@@ -45,6 +45,12 @@ class WikiSyncTests(unittest.TestCase):
             (destination / "Rogue.markdown").write_text(
                 "# Rogue\n", encoding="utf-8"
             )
+            (destination / "Rogue.mdown").write_text(
+                "# Rogue\n", encoding="utf-8"
+            )
+            (destination / "Legacy.mkdn").write_text(
+                "# Legacy\n", encoding="utf-8"
+            )
             (destination / "attachment.png").write_bytes(b"keep")
             temporary_attachment = destination / ".Home.md.wiki-sync.tmp"
             temporary_attachment.write_bytes(b"keep temporary attachment")
@@ -64,7 +70,7 @@ class WikiSyncTests(unittest.TestCase):
                 temporary_attachment.read_bytes(), b"keep temporary attachment"
             )
             self.assertEqual(result.copied, 4)
-            self.assertEqual(result.removed, 2)
+            self.assertEqual(result.removed, 4)
 
     def test_sync_rejects_non_markdown_source_artifacts(self):
         with TemporaryDirectory() as directory:
@@ -109,6 +115,34 @@ class WikiSyncTests(unittest.TestCase):
             destination = root / "fake-checkout"
             destination.mkdir()
             (destination / ".git").write_text("not Git metadata", encoding="utf-8")
+            valuable = destination / "valuable.md"
+            valuable.write_text("keep", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "Git checkout"):
+                sync_wiki(source, destination)
+
+            self.assertEqual(valuable.read_text(encoding="utf-8"), "keep")
+
+    def test_sync_refuses_symlinked_git_metadata_before_removing_pages(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self.make_wiki_source(root)
+            real_repository = root / "real-repository"
+            real_repository.mkdir()
+            subprocess.run(
+                ["git", "init", "--quiet", str(real_repository)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            destination = root / "linked-checkout"
+            destination.mkdir()
+            try:
+                (destination / ".git").symlink_to(
+                    real_repository / ".git", target_is_directory=True
+                )
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
             valuable = destination / "valuable.md"
             valuable.write_text("keep", encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- publish the versioned `docs/wiki` source to the GitHub Wiki after trusted changes reach `main`
- route README readers to the live Wiki while keeping the reviewable source visible
- mirror all GitHub Markdown page variants and preserve non-page attachments

## Safety

- runs only for `main` pushes or an explicit dispatch on `main`
- uses the repository token with scoped `contents: write`; no additional secret or PAT
- pins all external actions and serializes publication with a full pending queue
- rejects superseded revisions before work and immediately before the Wiki push
- refuses overlapping paths, linked/reparse metadata, external Gitdir pointers, and page symlinks before mutation

## Validation

- `python -m unittest tests.test_wiki_sync -v` (8 passed)
- 43 documentation and supply-chain policy checks passed
- temporary live-Wiki clone: 27/27 pages matched, all supported stale Markdown variants removed, non-page attachment preserved
- `git diff --check`