### PR TITLE
fix: stage wiki sync changes reliably

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -75,8 +75,7 @@ jobs:
           fi
 
           git -C "$RUNNER_TEMP/webssh-wiki" diff --check
-          git -C "$RUNNER_TEMP/webssh-wiki" add --all -- \
-            '*.md' '*.markdown' '*.mdown' '*.mkdn'
+          git -C "$RUNNER_TEMP/webssh-wiki" add --all
           if git -C "$RUNNER_TEMP/webssh-wiki" diff --cached --quiet; then
             echo "The live Wiki already matches docs/wiki."
             exit 0

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -129,8 +129,12 @@ def test_wiki_sync_is_main_only_and_uses_the_repository_token():
     assert 'GH_TOKEN: ${{ github.token }}' in workflow
     assert 'secrets.' not in workflow
     assert 'scripts/wiki_sync.py' in workflow
-    for markdown_pathspec in ('*.md', '*.markdown', '*.mdown', '*.mkdn'):
-        assert markdown_pathspec in workflow
+    assert re.search(
+        r'^\s*git -C "\$RUNNER_TEMP/webssh-wiki" add --all\s*$',
+        workflow,
+        re.MULTILINE,
+    )
+    assert 'add --all --' not in workflow
     assert workflow.count('git/ref/heads/main') >= 3
     assert '${{ runner.temp }}' not in workflow
     assert '"$RUNNER_TEMP/webssh-wiki"' in workflow


### PR DESCRIPTION
## Summary

- stage the complete fresh Wiki checkout without optional pathspec failures
- add a regression policy check for the staging command

## Root cause

The first Wiki Sync run after merging #127 failed because Git rejects an explicit pathspec when that Markdown extension does not exist in the Wiki checkout.

## Verification

- 22 supply-chain policy tests
- 8 Wiki sync unit tests
- successful sync and staging against a fresh clone of the live Wiki
- independent review: no findings