### PR TITLE
Fix SFTP panel restoration and Paper Ops contrast

### DIFF
--- a/static/css/webssh-2.css
+++ b/static/css/webssh-2.css
@@ -1,5 +1,13 @@
 /* WebSSH product shell and shared calm infrastructure styling. */
 :root {
+    --ws2-radius-sm: 5px;
+    --ws2-radius: 8px;
+    --ws2-radius-lg: 12px;
+    --font-sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-mono: "IBM Plex Mono", "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+}
+
+body {
     --ws2-canvas: var(--bg-primary);
     --ws2-surface: var(--bg-secondary);
     --ws2-panel: var(--bg-tertiary);
@@ -7,6 +15,7 @@
     --ws2-border: var(--border-color);
     --ws2-border-strong: var(--border-hover);
     --ws2-text: var(--text-primary);
+    --ws2-text-primary: var(--text-primary);
     --ws2-text-secondary: var(--text-secondary);
     --ws2-text-muted: var(--text-muted);
     --ws2-accent: var(--accent-primary);
@@ -15,15 +24,7 @@
     --ws2-warning: var(--warning-color);
     --ws2-danger: var(--error-color);
     --ws2-focus: color-mix(in srgb, var(--accent-primary) 76%, white);
-    --ws2-radius-sm: 5px;
-    --ws2-radius: 8px;
-    --ws2-radius-lg: 12px;
     --ws2-shadow: 0 12px 32px rgb(0 0 0 / 32%);
-    --font-sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --font-mono: "IBM Plex Mono", "Cascadia Code", "SFMono-Regular", Consolas, monospace;
-}
-
-body {
     background: var(--ws2-canvas);
     color: var(--ws2-text);
     letter-spacing: 0;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2292,6 +2292,7 @@
                     TerminalSearch.close();
                 } else {
                     document.querySelectorAll('.modal.show').forEach(modal => {
+                        if (modal.id === 'sftpFileManager') return;
                         window.ModalManager.close(modal);
                     });
                 }

--- a/static/js/sftp-file-manager.js
+++ b/static/js/sftp-file-manager.js
@@ -6,6 +6,8 @@ class SFTPFileManager {
         this.isOpen = false;
         this.displayMode = 'closed';
         this.embeddedContainer = null;
+        this.embeddedTarget = null;
+        this.suspendedEmbeddedTarget = null;
 
         this.initializeWorkspaceState();
 
@@ -1444,8 +1446,7 @@ class SFTPFileManager {
 
     open() {
         if (this.displayMode === 'embedded') {
-            window.dispatchEvent?.(new CustomEvent('session-sftp-request-close'));
-            if (this.displayMode === 'embedded') this.closeEmbedded();
+            this.suspendEmbedded();
         }
         this.isOpen = true;
         this.displayMode = 'modal';
@@ -1479,6 +1480,8 @@ class SFTPFileManager {
             this.closeEmbedded();
             return;
         }
+        const embeddedTarget = this.suspendedEmbeddedTarget;
+        this.suspendedEmbeddedTarget = null;
         this.isOpen = false;
         this.displayMode = 'closed';
         this.closeSourceLauncher();
@@ -1505,11 +1508,22 @@ class SFTPFileManager {
             this.uploadProgressNotification.remove();
             this.uploadProgressNotification = null;
         }
+
+        if (embeddedTarget) {
+            void this.openEmbedded(
+                embeddedTarget.container,
+                embeddedTarget.sessionId,
+                embeddedTarget.session,
+            );
+        }
     }
 
     async openEmbedded(container, sessionId, session = {}) {
         if (!container || !sessionId) return false;
-        if (this.displayMode === 'modal') this.close();
+        if (this.displayMode === 'modal') {
+            this.suspendedEmbeddedTarget = null;
+            this.close();
+        }
 
         this.enterEmbeddedPaneState();
         this.isOpen = true;
@@ -1526,6 +1540,11 @@ class SFTPFileManager {
             id: sessionId,
             connected: session.connected !== false,
         };
+        this.embeddedTarget = {
+            container,
+            sessionId,
+            session: sessionRecord,
+        };
         const index = this.availableSessions.findIndex(item => item.id === sessionId);
         if (index >= 0) this.availableSessions[index] = sessionRecord;
         else this.availableSessions.push(sessionRecord);
@@ -1536,20 +1555,60 @@ class SFTPFileManager {
     }
 
     async followEmbedded(sessionId, session = {}) {
-        if (this.displayMode !== 'embedded' || !sessionId) return false;
+        if (!sessionId) return false;
+        if (this.displayMode === 'modal' && this.suspendedEmbeddedTarget) {
+            const sessionRecord = {
+                ...session,
+                id: sessionId,
+                connected: session.connected !== false,
+            };
+            this.suspendedEmbeddedTarget = {
+                ...this.suspendedEmbeddedTarget,
+                sessionId,
+                session: sessionRecord,
+            };
+            this.embeddedTarget = this.suspendedEmbeddedTarget;
+            return true;
+        }
+        if (this.displayMode !== 'embedded') return false;
         if (this.panes.left.sessionId === sessionId) {
             this.panes.left.hostInfo = {
                 host: session.host,
                 username: session.username,
                 port: session.port,
             };
+            if (this.embeddedTarget) {
+                this.embeddedTarget = {
+                    ...this.embeddedTarget,
+                    session: {
+                        ...this.embeddedTarget.session,
+                        ...session,
+                        id: sessionId,
+                    },
+                };
+            }
             this.updatePaneBadge('left');
             return true;
         }
         return this.openEmbedded(this.embeddedContainer, sessionId, session);
     }
 
-    closeEmbedded() {
+    suspendEmbedded() {
+        if (this.displayMode !== 'embedded') return false;
+        const sessionId = this.panes.left.sessionId;
+        const session = this.availableSessions.find(item => item.id === sessionId)
+            || this.embeddedTarget?.session
+            || { id: sessionId, ...this.panes.left.hostInfo, connected: true };
+        this.suspendedEmbeddedTarget = {
+            container: this.embeddedContainer,
+            sessionId,
+            session,
+        };
+        this.detachEmbedded();
+        return true;
+    }
+
+    detachEmbedded() {
         if (this.displayMode !== 'embedded') return;
         this.closeContextMenu();
         this.resetPane('left');
@@ -1561,15 +1620,26 @@ class SFTPFileManager {
         this.restoreStandalonePaneState();
     }
 
+    closeEmbedded() {
+        this.suspendedEmbeddedTarget = null;
+        this.embeddedTarget = null;
+        this.detachEmbedded();
+    }
+
     isEmbeddedOpen() {
         return this.displayMode === 'embedded';
     }
 
     handleEmbeddedDisconnect(sessionId) {
+        if (this.suspendedEmbeddedTarget?.sessionId === sessionId) {
+            this.suspendedEmbeddedTarget = null;
+            this.embeddedTarget = null;
+        }
         if (
             this.displayMode === 'embedded'
             && this.panes.left.sessionId === sessionId
         ) {
+            this.embeddedTarget = null;
             this.resetPane('left');
         }
     }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>
 <body data-theme="{{ theme|default('glass') }}">
     <header class="header">

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>
 <body data-theme="{{ theme }}">
     <div class="auth-shell">

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=22">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}?v=9">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=8">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>
 <body data-theme="{{ theme|default('glass') }}" data-confirm-session-close="{{ 'true' if confirm_session_close else 'false' }}" data-disconnect-session-action="{{ disconnect_session_action }}" data-connection-history-scope="{{ connection_history_scope }}">
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>
@@ -1349,7 +1349,7 @@
     <script src="{{ url_for('static', filename='js/session-command-launcher.js') }}?v=5"></script>
     <script src="{{ url_for('static', filename='js/file-transfer.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/file-workspace-state.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=14"></script>
+    <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=15"></script>
     <script src="{{ url_for('static', filename='js/connection-history.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}?v=18"></script>
     <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1351,7 +1351,7 @@
     <script src="{{ url_for('static', filename='js/file-workspace-state.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=15"></script>
     <script src="{{ url_for('static', filename='js/connection-history.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/app.js') }}?v=18"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}?v=19"></script>
     <script>
         const flashedMessages = {{ get_flashed_messages(with_categories=true) | tojson }};
         flashedMessages.forEach(([category, message]) => {

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=20">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}?v=3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>
 <body data-theme="glass" data-use-theme-preference>
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=20">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}?v=2">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>
 <body data-theme="glass" data-use-theme-preference>
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>

--- a/templates/security.html
+++ b/templates/security.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=14">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>
 <body data-theme="{{ theme|default('glass') }}" data-ldap-managed="{{ 'true' if ldap_managed else 'false' }}" data-recovery-mode="{{ 'true' if recovery_mode else 'false' }}">
     <header class="header">

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -798,6 +798,30 @@ test('closing the full File Manager restores the active embedded Files context',
     await assertNoExternalRequests(page);
 });
 
+test('Escape closes the source launcher before restoring embedded Files', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page);
+
+    await expect(page.locator('#sessionFilesPanel')).toBeVisible();
+    await expect(page.locator('#sessionFilesPanel #fmLeftList .fm-file-item')).toHaveCount(5);
+
+    await page.locator('#fileTransferBtn').click();
+    await expect(page.locator('#sftpFileManager')).toHaveClass(/show/);
+    await expect(page.locator('#fmSourceLauncher')).toHaveClass(/show/);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#fmSourceLauncher')).not.toHaveClass(/show/);
+    await expect(page.locator('#sftpFileManager')).toHaveClass(/show/);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#sftpFileManager')).not.toHaveClass(/show/);
+    await expect(page.locator('#contextFilesTab')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('#sessionFilesPanel')).toBeVisible();
+    await expect(page.locator('#sessionFilesPanel #fmLeftBadge')).toHaveText('ops@edge-01.example');
+    await expect(page.locator('#sessionFilesPanel #fmLeftList .fm-file-item')).toHaveCount(5);
+    await assertNoExternalRequests(page);
+});
+
 test('partial telemetry shows only metrics returned by the device', async ({ page }) => {
     await login(page);
     await seedLinuxSession(page, { partialMetrics: true, sftpAvailable: false });

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -96,6 +96,10 @@ async function seedLinuxSession(page, options = {}) {
                 // Socket callbacks are not part of the observability requests under test.
             }
             window.__workspaceEvents.push({ event, payload: recordedPayload });
+            if (event === 'list_profiles') {
+                deliver('profiles_list', { profiles: [] });
+                return window.socket;
+            }
             if (payload?.session_id === 'workspace-cisco') {
                 if (event === 'probe_session_sftp') {
                     deliver('session_sftp_capability', {
@@ -769,6 +773,28 @@ test('Files context follows session capability and stays mounted while tools swi
     await filesTab.click();
     await expect(panel).toBeVisible();
     await expect(page.locator('#fmLeftPath')).toHaveValue('/srv/webssh/current');
+    await assertNoExternalRequests(page);
+});
+
+test('closing the full File Manager restores the active embedded Files context', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page);
+
+    await expect(page.locator('#sessionFilesPanel')).toBeVisible();
+    await expect(page.locator('#sessionFilesPanel #fmLeftList .fm-file-item')).toHaveCount(5);
+
+    await page.locator('#fileTransferBtn').click();
+    await expect(page.locator('#sftpFileManager')).toHaveClass(/show/);
+    await expect(page.locator('#fmSourceLauncher')).toHaveClass(/show/);
+    await page.locator('[data-source-key="ssh:workspace-linux"]').click();
+    await expect(page.locator('#sftpFileManager #fmLeftList .fm-file-item')).toHaveCount(5);
+    await page.locator('#fmClose').click();
+
+    await expect(page.locator('#sftpFileManager')).not.toHaveClass(/show/);
+    await expect(page.locator('#contextFilesTab')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('#sessionFilesPanel')).toBeVisible();
+    await expect(page.locator('#sessionFilesPanel #fmLeftBadge')).toHaveText('ops@edge-01.example');
+    await expect(page.locator('#sessionFilesPanel #fmLeftList .fm-file-item')).toHaveCount(5);
     await assertNoExternalRequests(page);
 });
 

--- a/tests/e2e/theme-system.spec.js
+++ b/tests/e2e/theme-system.spec.js
@@ -110,6 +110,16 @@ async function readThemeState(page) {
                     bodyStyle.getPropertyValue('--text-muted').trim(),
                     bodyStyle.getPropertyValue('--bg-secondary').trim(),
                 ),
+                settingsLabel: getComputedStyle(
+                    document.querySelector('#settingsModal .settings-field label'),
+                ).color,
+                primaryText: rgb(bodyStyle.getPropertyValue('--text-primary').trim()),
+                settingsLabelContrast: contrast(
+                    getComputedStyle(
+                        document.querySelector('#settingsModal .settings-field label'),
+                    ).color,
+                    bodyStyle.getPropertyValue('--bg-secondary').trim(),
+                ),
             },
         };
     });
@@ -168,6 +178,9 @@ test('Paper Ops uses a tinted Blueprint Steel canvas instead of white surfaces',
     expect(state.colors.secondaryBlueBias).toBeGreaterThanOrEqual(8);
     expect(state.background.opacity).toBeGreaterThanOrEqual(0.17);
     expect(state.colors.mutedContrast).toBeGreaterThanOrEqual(4.5);
+    expect(state.colors.settingsLabelContrast).toBeGreaterThanOrEqual(4.5);
+    expect(state.colors.settingsLabel.match(/[\d.]+/g).map(Number).slice(0, 3))
+        .toEqual(state.colors.primaryText);
 });
 
 test('professional themes use restrained local backgrounds', async ({ page }) => {

--- a/tests/js/sftp-transfer-queue.test.js
+++ b/tests/js/sftp-transfer-queue.test.js
@@ -1081,31 +1081,133 @@ test('embedded drag and drop uses the existing directory upload path', () => {
     assert.equal(uploaded.target, manager.panes.left);
 });
 
-test('opening the full modal closes embedded mode before restoring dual-pane UI', () => {
+test('the full modal suspends embedded Files and restores it when closed', async () => {
     const manager = Object.create(SFTPFileManager.prototype);
     manager.initializeWorkspaceState();
     let closed = 0;
     let shown = 0;
+    let hidden = 0;
+    let dispatched = 0;
+    let restored = null;
+    const embeddedContainer = {};
+    const embeddedSession = {
+        id: 'session-a', username: 'ops', host: 'edge.example', port: 22, connected: true,
+    };
     Object.assign(manager, {
-        displayMode: 'embedded', isOpen: true, modal: { style: {}, classList: classList() },
+        displayMode: 'embedded', isOpen: true, embeddedContainer,
+        availableSessions: [embeddedSession],
+        panes: {
+            left: { sessionId: 'session-a', path: '/', selected: new Set() },
+            right: { sessionId: null, path: '/', selected: new Set() },
+        },
+        modal: { style: {}, classList: classList() },
         closeEmbedded() { closed += 1; this.displayMode = 'closed'; this.isOpen = false; },
+        suspendEmbedded() {
+            this.suspendedEmbeddedTarget = {
+                container: this.embeddedContainer,
+                sessionId: this.panes.left.sessionId,
+                session: this.availableSessions[0],
+            };
+            this.displayMode = 'closed';
+            this.isOpen = false;
+        },
+        openEmbedded(container, sessionId, session) {
+            restored = { container, sessionId, session };
+            this.displayMode = 'embedded';
+            this.isOpen = true;
+            return Promise.resolve(true);
+        },
         updateSessionLists() {}, restoreLastSources() {}, applyTranslations() {},
         loadWorkspaceProfiles() {}, updatePathInput() {}, updatePaneBadge() {}, renderPane() {},
-        renderWorkspaceChrome() {}, openSourceLauncher() {},
+        renderWorkspaceChrome() {}, openSourceLauncher() {}, closeSourceLauncher() {},
+        closeContextMenu() {},
         isMobile() { return false; }, setActivePane() {}, updateMobilePaneTabs() {},
     });
-    global.window.ModalManager = { open() { shown += 1; } };
-    global.window.dispatchEvent = () => {};
+    global.window.ModalManager = {
+        open() { shown += 1; },
+        close() { hidden += 1; },
+    };
+    global.window.dispatchEvent = () => { dispatched += 1; };
     const originalGetElementById = global.document.getElementById;
     global.document.getElementById = () => ({ style: {}, classList: classList(), value: '' });
 
     manager.open();
 
-    assert.equal(closed, 1);
+    assert.equal(closed, 0);
+    assert.equal(dispatched, 0);
     assert.equal(shown, 1);
     assert.equal(manager.displayMode, 'modal');
+    manager.close();
+    await Promise.resolve();
+
+    assert.equal(hidden, 1);
+    assert.deepEqual(restored, {
+        container: embeddedContainer,
+        sessionId: 'session-a',
+        session: embeddedSession,
+    });
+    assert.equal(manager.displayMode, 'embedded');
     global.document.getElementById = originalGetElementById;
     delete global.window.ModalManager;
+});
+
+test('manual embedded close cancels a pending restore while the modal is open', () => {
+    const target = { container: {}, sessionId: 'session-a', session: { id: 'session-a' } };
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        displayMode: 'modal',
+        embeddedTarget: target,
+        suspendedEmbeddedTarget: target,
+    });
+
+    manager.closeEmbedded();
+
+    assert.equal(manager.embeddedTarget, null);
+    assert.equal(manager.suspendedEmbeddedTarget, null);
+    assert.equal(manager.displayMode, 'modal');
+});
+
+test('active session changes replace the pending embedded restore target', async () => {
+    const container = {};
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        displayMode: 'modal',
+        embeddedTarget: null,
+        suspendedEmbeddedTarget: {
+            container, sessionId: 'session-a', session: { id: 'session-a' },
+        },
+    });
+
+    const followed = await manager.followEmbedded('session-b', {
+        username: 'deploy', host: 'next.example', port: 2222, connected: true,
+    });
+
+    assert.equal(followed, true);
+    assert.deepEqual(manager.suspendedEmbeddedTarget, {
+        container,
+        sessionId: 'session-b',
+        session: {
+            id: 'session-b', username: 'deploy', host: 'next.example', port: 2222, connected: true,
+        },
+    });
+    assert.equal(manager.embeddedTarget, manager.suspendedEmbeddedTarget);
+});
+
+test('disconnect cancels only the matching pending embedded restore target', () => {
+    const target = { container: {}, sessionId: 'session-a', session: { id: 'session-a' } };
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        displayMode: 'modal',
+        embeddedTarget: target,
+        suspendedEmbeddedTarget: target,
+    });
+
+    manager.handleEmbeddedDisconnect('session-b');
+    assert.equal(manager.suspendedEmbeddedTarget, target);
+
+    manager.handleEmbeddedDisconnect('session-a');
+    assert.equal(manager.embeddedTarget, null);
+    assert.equal(manager.suspendedEmbeddedTarget, null);
 });
 
 test('generic transfer failures are localized before entering the queue', () => {

--- a/tests/test_key_management_ui.py
+++ b/tests/test_key_management_ui.py
@@ -103,7 +103,7 @@ def test_key_replacement_event_updates_ui_and_asset_version():
     assert 'ProfileManager.upsertKeySummary(data.key)' in APP
     assert "filename='js/profile-manager.js') }}?v=13" in TEMPLATE
     assert "filename='js/i18n.js') }}?v=22" in TEMPLATE
-    assert "filename='js/app.js') }}?v=18" in TEMPLATE
+    assert "filename='js/app.js') }}?v=19" in TEMPLATE
     assert "filename='css/style.css') }}?v=22" in TEMPLATE
 
 

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -49,7 +49,7 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
         "filename='js/command-set-manager.js'": '?v=2',
         "filename='js/session-command-launcher.js'": '?v=5',
         "filename='js/connection-history.js'": '?v=2',
-        "filename='js/app.js'": '?v=18',
+        "filename='js/app.js'": '?v=19',
     }
     for asset, version in expected_versions.items():
         asset_start = template.index(asset)

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -43,7 +43,7 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
         "filename='js/session-workspace.js'": '?v=9',
         "filename='js/session-manager.js'": '?v=11',
         "filename='js/terminal-manager.js'": '?v=10',
-        "filename='js/sftp-file-manager.js'": '?v=14',
+        "filename='js/sftp-file-manager.js'": '?v=15',
         "filename='js/jump-host-manager.js'": '?v=4',
         "filename='js/command-library.js'": '?v=3',
         "filename='js/command-set-manager.js'": '?v=2',

--- a/tests/test_webssh2_shell.py
+++ b/tests/test_webssh2_shell.py
@@ -112,14 +112,14 @@ def test_every_user_facing_page_uses_current_shared_asset_versions(app, client):
     for path in ("/", "/security", "/admin", "/change-password"):
         response = client.get(path)
         assert response.status_code == 200
-        assert b'css/webssh-2.css?v=14' in response.data
+        assert b'css/webssh-2.css?v=15' in response.data
         assert b'js/i18n.js?v=22' in response.data
 
     client.post("/logout")
     for path in ("/login", "/register"):
         response = client.get(path)
         assert response.status_code == 200
-        assert b'css/webssh-2.css?v=14' in response.data
+        assert b'css/webssh-2.css?v=15' in response.data
         assert b'js/i18n.js?v=22' in response.data
 
 


### PR DESCRIPTION
## Summary

- preserve the active embedded SFTP target while the full File Manager is open and restore it when the modal closes
- let `SFTPFileManager` own Escape handling so the source launcher closes before the modal and embedded Files is restored
- keep manual close, active-session changes, and disconnects authoritative during that handoff
- resolve shared WebSSH 2 theme aliases against the active body theme so Paper Ops settings text remains readable
- add focused unit and Playwright regressions for both reported paths and the reviewed Escape sequence

## Root cause

Opening the full File Manager dispatched the same event as a manual embedded-SFTP close, so the workspace persisted a closed preference and never remounted the embedded manager body. The page-level Escape handler also closed the lazily created File Manager directly before its own handler could consume Escape for the source launcher, bypassing `SFTPFileManager.close()` and the embedded restore path.

Separately, the shared `--ws2-*` aliases were computed on `:root` before the Paper Ops variables applied on `body[data-theme]`, leaving light Paper surfaces with dark-theme text values.

## Validation

- `npm run lint:js`
- `npm run test:js` — 286 passed
- `npm run vendor:check` — 10 assets verified
- Python 3.14 targeted UI suite — 71 passed
- `npx playwright test tests/e2e/theme-system.spec.js tests/e2e/session-workspace.spec.js --forbid-only` — 20 passed
- independent follow-up diff review — no findings
- `git diff --check origin/main...HEAD`

Fixes #130
Fixes #131
