### PR TITLE
Fix Quick Connect duplication and modal close icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2437,7 +2437,6 @@ body.broadcast-active .terminal-wrapper:not(.unassigned) {
     border: 0;
     background: transparent;
     font-size: 28px;
-    font-family: inherit;
     color: var(--text-secondary);
     cursor: pointer;
     line-height: 1;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1673,7 +1673,7 @@
         }
 
         const actions = [
-            { id: 'quick-connect', labelKey: 'connection.newConnection', hint: 'Ctrl+Shift+N', action: () => document.getElementById('newConnectionBtn').click() },
+            { id: 'quick-connect', labelKey: 'connection.newConnection', hint: 'Ctrl+Shift+N', action: () => openConnectionModalForPane(getDefaultPaneIndex()) },
             { id: 'command-library', labelKey: 'commands.library', hint: 'F1', action: () => CommandLibrary.openLibrary() },
             { id: 'file-transfer', labelKey: 'files.fileTransfer', hint: '', action: () => document.getElementById('fileTransferBtn').click() },
             { id: 'manage-keys', labelKey: 'keys.manageKeys', hint: '', action: () => openConnectionAssetManager('keys') },
@@ -1891,14 +1891,10 @@
             window.JumpHostManager.load();
         }
 
-        document.getElementById('newConnectionBtn').addEventListener('click', () => {
-            openConnectionModalForPane(getDefaultPaneIndex());
-        });
-
         const newTabBtn = document.getElementById('newTabBtn');
         if (newTabBtn) {
             newTabBtn.addEventListener('click', () => {
-                document.getElementById('newConnectionBtn').click();
+                openConnectionModalForPane(getDefaultPaneIndex());
             });
         }
 
@@ -2263,7 +2259,7 @@
 
             if (e.ctrlKey && e.shiftKey && e.key === 'N') {
                 e.preventDefault();
-                document.getElementById('newConnectionBtn').click();
+                openConnectionModalForPane(getDefaultPaneIndex());
             }
 
             if (e.ctrlKey && !e.shiftKey && !e.altKey && e.key >= '1' && e.key <= '9') {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -11,7 +11,7 @@
     <meta name="recovery-enabled" content="{{ 'true' if recovery_codes_enabled else 'false' }}">
     <title>Admin · Web SSH Terminal</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=23">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -6,7 +6,7 @@
     <meta name="app-root" content="{{ url_prefix }}">
     <title data-i18n="auth.changePasswordPageTitle">Change password · WebSSH</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=23">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=22">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=23">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}?v=9">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=8">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
@@ -41,8 +41,6 @@
                     <button id="manageProfilesBtn" class="global-nav-item" type="button" title="Hosts" data-i18n-title="connectionAssets.hosts"><span class="material-icons" aria-hidden="true">dns</span><span data-i18n="connectionAssets.hosts">Hosts</span></button>
                     <button id="commandLibraryBtn" class="global-nav-item" type="button"><span class="material-icons" aria-hidden="true">code</span><span data-i18n="commands.workspace">Commands</span></button>
                 </nav>
-
-                <button id="newConnectionBtn" class="btn btn-primary quick-connect-btn"><span class="material-icons" aria-hidden="true">add</span><span data-i18n="connection.newConnection">Quick Connect</span></button>
 
                 <span class="header-divider" aria-hidden="true"></span>
 
@@ -1351,7 +1349,7 @@
     <script src="{{ url_for('static', filename='js/file-workspace-state.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=15"></script>
     <script src="{{ url_for('static', filename='js/connection-history.js') }}?v=2"></script>
-    <script src="{{ url_for('static', filename='js/app.js') }}?v=19"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}?v=20"></script>
     <script>
         const flashedMessages = {{ get_flashed_messages(with_categories=true) | tojson }};
         flashedMessages.forEach(([category, message]) => {

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,7 +9,7 @@
     <meta name="webauthn-rp-id" content="{{ webauthn_rp_id }}">
     <title data-i18n="auth.loginPageTitle">Sign in · WebSSH</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=20">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=23">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}?v=3">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>

--- a/templates/register.html
+++ b/templates/register.html
@@ -6,7 +6,7 @@
     <meta name="app-root" content="{{ url_prefix }}">
     <title data-i18n="auth.registerPageTitle">Create account · WebSSH</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=20">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=23">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}?v=2">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>

--- a/templates/security.html
+++ b/templates/security.html
@@ -7,7 +7,7 @@
     <meta name="app-root" content="{{ url_prefix }}">
     <title data-i18n="security.pageTitle">Security · Web SSH Terminal</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=23">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=15">
 </head>

--- a/tests/e2e/management-dialogs-redesign.spec.js
+++ b/tests/e2e/management-dialogs-redesign.spec.js
@@ -113,3 +113,15 @@ test('exposes every modal close control as a keyboard-focusable button', async (
         expect(control.tabIndex).toBeGreaterThanOrEqual(0);
     }
 });
+
+test('renders modal close controls with the Material Icons font', async ({ page }) => {
+    const fontFamilies = await page.locator('.modal-header .close.material-icons')
+        .evaluateAll(elements => elements.map(
+            element => getComputedStyle(element).fontFamily,
+        ));
+
+    expect(fontFamilies.length).toBeGreaterThan(0);
+    for (const fontFamily of fontFamilies) {
+        expect(fontFamily).toContain('Material Icons');
+    }
+});

--- a/tests/e2e/product-captures.spec.js
+++ b/tests/e2e/product-captures.spec.js
@@ -578,7 +578,7 @@ test('captures the current Quick Connect surface at Full HD scale without outbou
     await expect(page.locator('#manageProfilesBtn')).toContainText(
         process.env.WEBSSH_CAPTURE_EXPECT_SAVED_CONNECTIONS || 'Hosts',
     );
-    await page.locator('#newConnectionBtn').click();
+    await page.locator('#newTabBtn').click();
     await expect(page.locator('#connectionModal')).toHaveClass(/show/);
     await expect(page.locator('#connectionModalTitle')).toHaveText(
         process.env.WEBSSH_CAPTURE_EXPECT_QUICK_CONNECT || 'Quick Connect',
@@ -612,7 +612,7 @@ test('captures seeded command and connection option surfaces at Full HD scale', 
     await captureDesktopStill(page, 'commandlibrary.png', testInfo);
 
     await page.locator('#closeCommandWorkspaceModal').click();
-    await page.locator('#newConnectionBtn').click();
+    await page.locator('#newTabBtn').click();
     await page.evaluate(() => window.selectConnectionProfile('post-command-set'));
     await sanitizeSeededCatalog(page);
     await expect(page.locator('#connectionModalTitle')).toHaveText('Quick Connect');
@@ -889,7 +889,7 @@ test('captures six current Command Sets animation frames without remote actions'
     await captureCssFrame(page, frameDirectory, '05-three-step-order.png');
 
     await page.locator('#closeCommandWorkspaceModal').click();
-    await page.locator('#newConnectionBtn').click();
+    await page.locator('#newTabBtn').click();
     await page.evaluate(() => window.selectConnectionProfile('post-command-set'));
     await sanitizeSeededCatalog(page);
     await expect(page.locator('#connectionModalTitle')).toHaveText('Quick Connect');

--- a/tests/e2e/quick-connect-redesign.spec.js
+++ b/tests/e2e/quick-connect-redesign.spec.js
@@ -15,6 +15,34 @@ test.afterEach(async ({ page }) => {
     await assertNoExternalRequests(page);
 });
 
+test('keeps Quick Connect in the workspace without a duplicate header action', async ({ page }) => {
+    await expect(page.locator('#newConnectionBtn')).toHaveCount(0);
+
+    const newTab = page.locator('#newTabBtn');
+    const centralLauncher = page.locator('.profile-launcher-new');
+    await expect(newTab).toBeVisible();
+    await expect(centralLauncher).toBeVisible();
+
+    await newTab.click();
+    await expect(page.locator('#connectionModal')).toHaveClass(/show/);
+    await page.locator('#cancelConnectionBtn').click();
+
+    await centralLauncher.click();
+    await expect(page.locator('#connectionModal')).toHaveClass(/show/);
+    await page.locator('#cancelConnectionBtn').click();
+
+    await page.keyboard.press('Control+Shift+N');
+    await expect(page.locator('#connectionModal')).toHaveClass(/show/);
+    await page.locator('#cancelConnectionBtn').click();
+
+    await page.keyboard.press('Control+k');
+    await page.locator('#commandPaletteInput').fill('Quick Connect');
+    await page.locator(
+        '.palette-item[data-palette-kind="action"][data-palette-id="quick-connect"]',
+    ).click();
+    await expect(page.locator('#connectionModal')).toHaveClass(/show/);
+});
+
 test('presents a focused two-column quick connect without a saved-profile picker', async ({ page }) => {
     await page.evaluate(() => {
         for (let index = 0; index < 7; index += 1) {
@@ -23,7 +51,7 @@ test('presents a focused two-column quick connect without a saved-profile picker
             );
         }
     });
-    await page.locator('#newConnectionBtn').click();
+    await page.locator('#newTabBtn').click();
 
     await expect(page.locator('#connectionModal')).toHaveClass(/show/);
     await expect(page.locator('#connectionDetailsCard')).toBeVisible();
@@ -86,7 +114,7 @@ test('presents a focused two-column quick connect without a saved-profile picker
 });
 
 test('uses the requested connection details and advanced settings hierarchy', async ({ page }) => {
-    await page.locator('#newConnectionBtn').click();
+    await page.locator('#newTabBtn').click();
 
     const hierarchy = await page.locator('#connectionModal').evaluate(modal => {
         const detailsContent = modal.querySelector('.quick-connect-details-content');
@@ -135,7 +163,7 @@ test('keeps modal actions fixed while expanded content scrolls inside', async ({
             );
         }
     });
-    await page.locator('#newConnectionBtn').click();
+    await page.locator('#newTabBtn').click();
     await page.locator('#connectionAdvancedSettings > summary').click();
 
     const before = await page.locator('#connectionModal').evaluate(modal => {
@@ -201,8 +229,7 @@ test.describe('mobile quick connect', () => {
                 'mobile.internal', 22, 'mobile'
             );
         });
-        await page.locator('#mobileMenuBtn').click();
-        await page.locator('#newConnectionBtn').click();
+        await page.locator('#newTabBtn').click();
 
         const geometry = await page.locator('#connectionModal').evaluate(modal => {
             const details = modal.querySelector('#connectionDetailsCard')

--- a/tests/test_key_management_ui.py
+++ b/tests/test_key_management_ui.py
@@ -103,8 +103,8 @@ def test_key_replacement_event_updates_ui_and_asset_version():
     assert 'ProfileManager.upsertKeySummary(data.key)' in APP
     assert "filename='js/profile-manager.js') }}?v=13" in TEMPLATE
     assert "filename='js/i18n.js') }}?v=22" in TEMPLATE
-    assert "filename='js/app.js') }}?v=19" in TEMPLATE
-    assert "filename='css/style.css') }}?v=22" in TEMPLATE
+    assert "filename='js/app.js') }}?v=20" in TEMPLATE
+    assert "filename='css/style.css') }}?v=23" in TEMPLATE
 
 
 def test_socket_events_refresh_key_ui_without_resetting_profile_editor():

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -32,7 +32,7 @@ def test_saved_connection_context_precedes_authentication_method():
 def test_merged_profile_frontend_assets_have_distinct_cache_versions():
     template = read('templates/index.html')
     expected_versions = {
-        "filename='css/style.css'": '?v=22',
+        "filename='css/style.css'": '?v=23',
         "filename='css/sftp-file-manager.css'": '?v=9',
         "filename='js/i18n.js'": '?v=22',
         "filename='js/command-workspace.js'": '?v=2',
@@ -49,7 +49,7 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
         "filename='js/command-set-manager.js'": '?v=2',
         "filename='js/session-command-launcher.js'": '?v=5',
         "filename='js/connection-history.js'": '?v=2',
-        "filename='js/app.js'": '?v=19',
+        "filename='js/app.js'": '?v=20',
     }
     for asset, version in expected_versions.items():
         asset_start = template.index(asset)
@@ -142,7 +142,7 @@ def test_mobile_launcher_stacks_status_below_profile_details():
 def test_profile_launcher_stylesheet_uses_current_cache_version():
     template = read('templates/index.html')
 
-    assert "filename='css/style.css') }}?v=22" in template
+    assert "filename='css/style.css') }}?v=23" in template
 
 
 def test_active_session_command_launcher_is_loaded_after_command_data_managers():

--- a/tests/test_webssh2_shell.py
+++ b/tests/test_webssh2_shell.py
@@ -112,6 +112,7 @@ def test_every_user_facing_page_uses_current_shared_asset_versions(app, client):
     for path in ("/", "/security", "/admin", "/change-password"):
         response = client.get(path)
         assert response.status_code == 200
+        assert b'css/style.css?v=23' in response.data
         assert b'css/webssh-2.css?v=15' in response.data
         assert b'js/i18n.js?v=22' in response.data
 
@@ -119,6 +120,7 @@ def test_every_user_facing_page_uses_current_shared_asset_versions(app, client):
     for path in ("/login", "/register"):
         response = client.get(path)
         assert response.status_code == 200
+        assert b'css/style.css?v=23' in response.data
         assert b'css/webssh-2.css?v=15' in response.data
         assert b'js/i18n.js?v=22' in response.data
 


### PR DESCRIPTION
## Summary

- remove the duplicate top-right Quick Connect action while keeping the central launcher and the + button
- route the remaining Quick Connect entry points directly to the default-pane connection modal
- restore Material Icons rendering for modal close controls and refresh the affected asset cache keys

## Scope

- addresses https://github.com/bifrost0x/webssh/discussions/133
- fixes the reported close-control bug from https://github.com/bifrost0x/webssh/discussions/134
- leaves the broader Hosts and Commands redesign for a separate follow-up

## Testing

- `python -m pytest tests -q` (1844 passed, 33 skipped)
- `npm run test:js` (286 passed)
- `npm run lint:js`
- `npm run vendor:check`
- `npm run test:e2e -- --workers=2` (85 passed)