### PR TITLE
Bind remote reads to opened SFTP and SMB objects

### DIFF
--- a/app/binary_transfer.py
+++ b/app/binary_transfer.py
@@ -29,12 +29,8 @@ def handle_binary_download(session_id, remote_path, socketio_instance=None,
         if safe_path is None:
             return None, "Invalid remote path"
 
-        with sftp_handler.sftp_session(session_id) as (sftp, source_type):
-            try:
-                file_stat = sftp.stat(safe_path)
-                file_size = file_stat.st_size
-            except FileNotFoundError:
-                return None, "Remote file not found"
+        with sftp_handler.open_bound_reader(session_id, safe_path) as lease:
+            file_size = lease.size
 
             limit = config.MAX_DOWNLOAD_SIZE if max_size is None else max_size
             if file_size > limit:
@@ -47,38 +43,38 @@ def handle_binary_download(session_id, remote_path, socketio_instance=None,
 
             binary_data = io.BytesIO()
 
-            with sftp.file(safe_path, 'rb') as remote_file:
-                while True:
-                    chunk = remote_file.read(chunk_size)
-                    if not chunk:
-                        break
+            remote_file = lease.reader
+            while True:
+                chunk = remote_file.read(chunk_size)
+                if not chunk:
+                    break
 
-                    observed_size = transferred + len(chunk)
-                    if observed_size > limit:
-                        max_mb = limit // (1024 * 1024)
-                        return None, (
-                            "File too large for download "
-                            f"({observed_size // (1024 * 1024)}MB). "
-                            f"Maximum: {max_mb}MB"
-                        )
+                observed_size = transferred + len(chunk)
+                if observed_size > limit:
+                    max_mb = limit // (1024 * 1024)
+                    return None, (
+                        "File too large for download "
+                        f"({observed_size // (1024 * 1024)}MB). "
+                        f"Maximum: {max_mb}MB"
+                    )
 
-                    binary_data.write(chunk)
-                    transferred = observed_size
+                binary_data.write(chunk)
+                transferred = observed_size
 
-                    if socketio_instance:
-                        progress_total = max(file_size, transferred, 1)
-                        percent = min(
-                            100,
-                            int((transferred / progress_total) * 100),
-                        )
-                        socketio_instance.emit('file_progress', {
-                            'session_id': session_id,
-                            'type': 'download',
-                            'filename': filename,
-                            'transferred': transferred,
-                            'total': file_size,
-                            'percent': percent
-                        })
+                if socketio_instance:
+                    progress_total = max(file_size, transferred, 1)
+                    percent = min(
+                        100,
+                        int((transferred / progress_total) * 100),
+                    )
+                    socketio_instance.emit('file_progress', {
+                        'session_id': session_id,
+                        'type': 'download',
+                        'filename': filename,
+                        'transferred': transferred,
+                        'total': file_size,
+                        'percent': percent
+                    })
 
             return binary_data.getvalue(), None
 

--- a/app/file_backend.py
+++ b/app/file_backend.py
@@ -19,6 +19,42 @@ _WRITE_WARNING_CODES = frozenset({
 
 
 @dataclass(frozen=True, slots=True)
+class FileReaderLease:
+    """One readable remote object and metadata obtained from that handle."""
+
+    reader: Any
+    size: int
+    mode: int | None = None
+    modified: int | float | None = None
+    is_dir: bool = False
+    is_symlink: bool = False
+
+    def __post_init__(self):
+        if not callable(getattr(self.reader, 'read', None)):
+            raise ValueError('reader must expose read')
+        if type(self.size) is not int or self.size < 0:
+            raise ValueError('size must be a non-negative integer')
+        if self.mode is not None and (
+            type(self.mode) is not int or self.mode < 0
+        ):
+            raise ValueError('mode must be a non-negative integer or None')
+        if self.modified is not None and (
+            isinstance(self.modified, bool)
+            or not isinstance(self.modified, (int, float))
+            or self.modified < 0
+        ):
+            raise ValueError('modified must be non-negative or None')
+        if type(self.is_dir) is not bool:
+            raise ValueError('is_dir must be boolean')
+        if type(self.is_symlink) is not bool:
+            raise ValueError('is_symlink must be boolean')
+        if self.is_dir:
+            raise ValueError('reader lease cannot represent a directory')
+        if self.is_symlink:
+            raise ValueError('reader lease cannot represent a symbolic link')
+
+
+@dataclass(frozen=True, slots=True)
 class FileWriteOutcome:
     """Validated result of an editor save without backend exception leakage."""
 
@@ -140,7 +176,7 @@ class FileBackend(Protocol):
         path: str,
         *,
         io_lane: str = 'control',
-    ) -> Any:
+    ) -> FileReaderLease:
         ...
 
     def open_atomic_writer(

--- a/app/remote_transfer.py
+++ b/app/remote_transfer.py
@@ -12,6 +12,7 @@ import config
 
 from .smb_backend import FileConflict, NonAtomicOverwriteRequired
 from .smb_protocol import SMBProtocolError
+from .file_backend import FileReaderLease
 
 
 class RemoteTransferError(RuntimeError):
@@ -173,15 +174,18 @@ def _copy_file(
         raise RemoteTransferError('Source file unavailable')
     if file_stat.get('is_symlink'):
         raise RemoteTransferError('Reparse points are not supported')
-    declared_size = int(file_stat.get('size', 0))
-    budget.ensure_declared_bytes(declared_size)
     _check_cancelled(cancel_event)
 
     copied = 0
     try:
         with source.backend.open_reader(
             source, source_path, io_lane='transfer'
-        ) as reader:
+        ) as lease:
+            if not isinstance(lease, FileReaderLease):
+                raise RemoteTransferError('Source reader is unavailable')
+            declared_size = lease.size
+            budget.ensure_declared_bytes(declared_size)
+            _check_cancelled(cancel_event)
             with destination.backend.open_atomic_writer(
                 destination,
                 destination_path,
@@ -191,7 +195,7 @@ def _copy_file(
             ) as writer:
                 while True:
                     _check_cancelled(cancel_event)
-                    chunk = reader.read(chunk_size)
+                    chunk = lease.reader.read(chunk_size)
                     if not chunk:
                         break
                     if not isinstance(chunk, (bytes, bytearray, memoryview)):

--- a/app/sftp_backend.py
+++ b/app/sftp_backend.py
@@ -106,14 +106,12 @@ class SFTPBackend:
 
     @contextmanager
     def open_reader(self, source, path, *, io_lane='control'):
-        safe_path = self.normalize_path(path)
-        if safe_path is None:
-            raise sftp_handler.SFTPOperationError('invalid remote path')
-        with sftp_handler.sftp_session(
-            source.handle_id, io_lane=io_lane
-        ) as (sftp, _source_type):
-            with sftp.file(safe_path, 'rb') as remote_file:
-                yield remote_file
+        with sftp_handler.open_bound_reader(
+            source.handle_id,
+            path,
+            io_lane=io_lane,
+        ) as lease:
+            yield lease
 
     @contextmanager
     def open_atomic_writer(

--- a/app/sftp_handler.py
+++ b/app/sftp_handler.py
@@ -24,7 +24,7 @@ import config
 from . import ssh_manager
 from .paramiko_channels import open_sftp_client
 from .audit_logger import log_warning, log_error
-from .file_backend import FileWriteOutcome
+from .file_backend import FileReaderLease, FileWriteOutcome
 
 _sftp_cache = {}
 _sftp_cache_lock = Lock()
@@ -123,6 +123,54 @@ def sftp_session(identifier, *, io_lane='control'):
 class SFTPOperationError(Exception):
     """Raised when an SFTP operation cannot be performed (no connection, etc.)."""
     pass
+
+
+@contextmanager
+def open_bound_reader(session_id, path, *, io_lane='control'):
+    """Open one SFTP object and derive all read metadata through FSTAT."""
+    safe_path = sanitize_path(path)
+    if safe_path is None:
+        raise SFTPOperationError('Invalid remote path')
+
+    session_context = (
+        sftp_session(session_id)
+        if io_lane == 'control'
+        else sftp_session(session_id, io_lane=io_lane)
+    )
+    with session_context as (sftp, _source_type):
+        with _open_bound_reader_from_client(sftp, safe_path) as lease:
+            yield lease
+
+
+@contextmanager
+def _open_bound_reader_from_client(sftp, safe_path):
+    """Bind one already-owned SFTP client read to its opened handle."""
+    with sftp.file(safe_path, 'rb') as remote_file:
+        handle_stat = getattr(remote_file, 'stat', None)
+        if not callable(handle_stat):
+            raise SFTPOperationError('Remote file metadata unavailable')
+        try:
+            file_stat = handle_stat()
+            mode = getattr(file_stat, 'st_mode', None)
+            size = getattr(file_stat, 'st_size', None)
+            modified = getattr(file_stat, 'st_mtime', None)
+            if type(mode) is not int or not stat.S_ISREG(mode):
+                raise SFTPOperationError('Remote file is not readable')
+            lease = FileReaderLease(
+                reader=remote_file,
+                size=size,
+                mode=mode,
+                modified=modified,
+                is_dir=stat.S_ISDIR(mode),
+                is_symlink=stat.S_ISLNK(mode),
+            )
+        except SFTPOperationError:
+            raise
+        except Exception as exc:
+            raise SFTPOperationError(
+                'Remote file metadata unavailable'
+            ) from exc
+        yield lease
 
 
 def normalize_file_preview_options(max_bytes=512000, offset=0, tail_lines=None):
@@ -392,13 +440,15 @@ def build_fallback_zip_to_disk(sftp, remote_folder, folder_name, *,
                         archive, source_path, archive_pathname, depth + 1
                     )
                     continue
-                declared_size = getattr(entry_stat, 'st_size', 0) or 0
-                if transferred + declared_size > max_bytes:
-                    raise TransferSizeExceeded()
-                with sftp.file(source_path, 'rb') as remote_file:
+                with _open_bound_reader_from_client(
+                    sftp,
+                    source_path,
+                ) as lease:
+                    if transferred + lease.size > max_bytes:
+                        raise TransferSizeExceeded()
                     with archive.open(archive_pathname, 'w') as zip_entry:
                         copied = copy_sftp_stream(
-                            remote_file,
+                            lease.reader,
                             zip_entry,
                             cancel_event=cancel_event,
                             max_bytes=max_bytes - transferred,
@@ -922,9 +972,8 @@ def read_file_preview(session_id, path, max_bytes=512000, offset=0, tail_lines=N
         if safe_path is None:
             return None, "Invalid path"
 
-        with sftp_session(session_id) as (sftp, source_type):
-            file_stat = sftp.stat(safe_path)
-            file_size = file_stat.st_size
+        with open_bound_reader(session_id, safe_path) as lease:
+            file_size = lease.size
 
             max_supported_file = config.MAX_SUPPORTED_FILE_SIZE
             if file_size > max_supported_file:
@@ -935,20 +984,22 @@ def read_file_preview(session_id, path, max_bytes=512000, offset=0, tail_lines=N
 
             content = b''
 
-            with sftp.file(safe_path, 'rb') as remote_file:
-                if tail_lines:
-                    seek_pos = max(0, file_size - max_bytes)
-                    remote_file.seek(seek_pos)
-                    content = remote_file.read(max_bytes)
+            remote_file = lease.reader
+            if tail_lines:
+                seek_pos = max(0, file_size - max_bytes)
+                remote_file.seek(seek_pos)
+                content = remote_file.read(max_bytes)
 
-                    lines = content.split(b'\n')
-                    if len(lines) > tail_lines:
-                        content = b'\n'.join(lines[-tail_lines:])
-                        truncated = True
-                else:
-                    if offset > 0:
-                        remote_file.seek(offset)
-                    content = remote_file.read(read_size)
+                lines = content.split(b'\n')
+                if len(lines) > tail_lines:
+                    content = b'\n'.join(lines[-tail_lines:])
+                    truncated = True
+            else:
+                if offset > 0:
+                    remote_file.seek(offset)
+                content = remote_file.read(read_size)
+            if len(content) > max_bytes:
+                return None, 'Preview exceeds the configured size limit'
 
         is_binary = False
         try:
@@ -1010,17 +1061,21 @@ def read_file_for_edit(session_id, path, max_bytes=None):
         if max_bytes is None:
             max_bytes = getattr(config, 'MAX_EDITOR_FILE_SIZE', 5 * 1024 * 1024)
 
-        with sftp_session(session_id) as (sftp, source_type):
-            file_stat = sftp.stat(safe_path)
-            file_size = file_stat.st_size
+        with open_bound_reader(session_id, safe_path) as lease:
+            file_size = lease.size
 
             if file_size > max_bytes:
                 max_mb = max_bytes // (1024 * 1024)
                 return None, (f"File too large to edit ({file_size // (1024 * 1024)}MB). "
                               f"Maximum: {max_mb}MB")
 
-            with sftp.file(safe_path, 'rb') as remote_file:
-                raw = remote_file.read(file_size)
+            raw = lease.reader.read(max_bytes + 1)
+            if len(raw) > max_bytes:
+                max_mb = max_bytes // (1024 * 1024)
+                return None, (
+                    f"File too large to edit ({len(raw) // (1024 * 1024)}MB). "
+                    f"Maximum: {max_mb}MB"
+                )
 
         # Binary detection mirrors read_file_preview.
         is_binary = b'\x00' in raw[:1024]
@@ -1097,16 +1152,14 @@ def write_file_text(
         tmp_path = safe_path + '.webssh-tmp-' + os.urandom(4).hex()
 
         with sftp_session(session_id) as (sftp, source_type):
-            file_stat = sftp.stat(safe_path)
-            file_size = file_stat.st_size
             maximum = getattr(config, 'MAX_EDITOR_FILE_SIZE', 5 * 1024 * 1024)
-            if file_size > maximum:
-                return FileWriteOutcome(
-                    success=False,
-                    error='File too large to edit',
-                )
-            with sftp.file(safe_path, 'rb') as original_file:
-                original = original_file.read(maximum + 1)
+            with _open_bound_reader_from_client(sftp, safe_path) as lease:
+                if lease.size > maximum:
+                    return FileWriteOutcome(
+                        success=False,
+                        error='File too large to edit',
+                    )
+                original = lease.reader.read(maximum + 1)
             if len(original) > maximum:
                 return FileWriteOutcome(
                     success=False,

--- a/app/smb_backend.py
+++ b/app/smb_backend.py
@@ -10,7 +10,7 @@ import stat as stat_module
 
 import config
 
-from .file_backend import FileWriteOutcome
+from .file_backend import FileReaderLease, FileWriteOutcome
 from .smb_paths import SMBPath, SMBPathRejected
 from .smb_protocol import SMBProtocolError
 
@@ -128,6 +128,52 @@ class SMBBackend:
         return bool(attributes & 0x10) or stat_module.S_ISDIR(
             getattr(file_stat, 'st_mode', 0)
         )
+
+    @staticmethod
+    def _reader_lease(remote_file):
+        """Build metadata from the connected SMB handle's CREATE response."""
+        handle = getattr(remote_file, 'fd', None)
+        size = getattr(handle, 'end_of_file', None)
+        attributes = getattr(handle, 'file_attributes', None)
+        if isinstance(attributes, bool):
+            raise SMBBackendError('File metadata is unavailable')
+        try:
+            attributes = int(attributes)
+        except (TypeError, ValueError) as exc:
+            raise SMBBackendError('File metadata is unavailable') from exc
+        if attributes < 0:
+            raise SMBBackendError('File metadata is unavailable')
+        is_reparse = bool(attributes & _REPARSE_POINT)
+        is_directory = bool(attributes & 0x10)
+        if is_reparse or is_directory:
+            raise SMBBackendError('File is not readable')
+        try:
+            return FileReaderLease(
+                reader=remote_file,
+                size=size,
+                is_dir=is_directory,
+                is_symlink=is_reparse,
+            )
+        except ValueError as exc:
+            raise SMBBackendError('File metadata is unavailable') from exc
+
+    @contextmanager
+    def _open_reader_locked(self, actual, smb_path, session):
+        """Open and validate one object while the caller owns its I/O lane."""
+        unc = smb_path.to_unc(actual.target_ip, actual.share)
+        self._validate_path_components(
+            actual,
+            smb_path,
+            session=session,
+        )
+        remote_file = session.invoke(
+            'open_file_no_follow',
+            unc,
+            mode='rb',
+            buffering=0,
+        )
+        with remote_file:
+            yield self._reader_lease(remote_file)
 
     @staticmethod
     def _io_lane(actual, io_lane):
@@ -378,21 +424,9 @@ class SMBBackend:
         actual = self._owned_source(source)
         session, lane_lock = self._io_lane(actual, io_lane)
         smb_path = self._path(path)
-        unc = smb_path.to_unc(actual.target_ip, actual.share)
         with lane_lock:
-            self._validate_path_components(
-                actual, smb_path, session=session
-            )
-            file_stat = session.invoke(
-                'stat', unc, follow_symlinks=False
-            )
-            if self._is_reparse(file_stat) or self._is_directory(file_stat):
-                raise SMBBackendError('File is not readable')
-            remote_file = session.invoke(
-                'open_file_no_follow', unc, mode='rb', buffering=0
-            )
-            with remote_file:
-                yield remote_file
+            with self._open_reader_locked(actual, smb_path, session) as lease:
+                yield lease
 
     @contextmanager
     def open_atomic_writer(
@@ -584,39 +618,27 @@ class SMBBackend:
             raise SMBBackendError('Invalid read range')
         actual = self._owned_source(source)
         smb_path = self._path(path)
-        unc = smb_path.to_unc(actual.target_ip, actual.share)
         with actual.lock:
-            self._validate_path_components(actual, smb_path)
-            file_stat = actual.session.invoke(
-                'stat', unc, follow_symlinks=False
-            )
-            if self._is_reparse(file_stat) or self._is_directory(file_stat):
-                raise SMBBackendError('File is not readable')
-            file_size = getattr(file_stat, 'st_size', 0) or 0
-            remote_file = actual.session.invoke(
-                'open_file_no_follow', unc, mode='rb', buffering=0
-            )
-            with remote_file:
+            with self._open_reader_locked(
+                actual,
+                smb_path,
+                actual.session,
+            ) as lease:
                 if offset:
-                    remote_file.seek(offset)
-                data = remote_file.read(maximum + 1)
-        return file_size, data
+                    lease.reader.seek(offset)
+                data = lease.reader.read(maximum + 1)
+                return lease.size, data
 
     def _editor_revision_locked(self, actual, destination):
         """Hash one validated editor target while the caller owns its lane."""
-        self._validate_path_components(actual, destination)
-        unc = destination.to_unc(actual.target_ip, actual.share)
-        file_stat = actual.session.invoke('stat', unc, follow_symlinks=False)
-        if self._is_reparse(file_stat) or self._is_directory(file_stat):
-            raise SMBBackendError('File is not readable')
-        file_size = getattr(file_stat, 'st_size', 0) or 0
-        if file_size > config.MAX_EDITOR_FILE_SIZE:
-            raise SMBBackendError('File too large to edit')
-        remote_file = actual.session.invoke(
-            'open_file_no_follow', unc, mode='rb', buffering=0
-        )
-        with remote_file:
-            data = remote_file.read(config.MAX_EDITOR_FILE_SIZE + 1)
+        with self._open_reader_locked(
+            actual,
+            destination,
+            actual.session,
+        ) as lease:
+            if lease.size > config.MAX_EDITOR_FILE_SIZE:
+                raise SMBBackendError('File too large to edit')
+            data = lease.reader.read(config.MAX_EDITOR_FILE_SIZE + 1)
         if len(data) > config.MAX_EDITOR_FILE_SIZE:
             raise SMBBackendError('File too large to edit')
         return hashlib.sha256(data).hexdigest()
@@ -775,27 +797,21 @@ class SMBBackend:
 
             actual = self._owned_source(source)
             smb_path = self._path(path)
-            unc = smb_path.to_unc(actual.target_ip, actual.share)
             with actual.lock:
-                self._validate_path_components(actual, smb_path)
-                file_stat = actual.session.invoke(
-                    'stat', unc, follow_symlinks=False
-                )
-                if self._is_reparse(file_stat) or self._is_directory(file_stat):
-                    raise SMBBackendError('File is not readable')
-                file_size = getattr(file_stat, 'st_size', 0) or 0
-                if file_size > config.MAX_SUPPORTED_FILE_SIZE:
-                    raise SMBBackendError('File exceeds supported size')
-                read_offset = (
-                    max(0, file_size - max_bytes) if tail_lines else offset
-                )
-                remote_file = actual.session.invoke(
-                    'open_file_no_follow', unc, mode='rb', buffering=0
-                )
-                with remote_file:
+                with self._open_reader_locked(
+                    actual,
+                    smb_path,
+                    actual.session,
+                ) as lease:
+                    file_size = lease.size
+                    if file_size > config.MAX_SUPPORTED_FILE_SIZE:
+                        raise SMBBackendError('File exceeds supported size')
+                    read_offset = (
+                        max(0, file_size - max_bytes) if tail_lines else offset
+                    )
                     if read_offset:
-                        remote_file.seek(read_offset)
-                    data = remote_file.read(max_bytes + 1)
+                        lease.reader.seek(read_offset)
+                    data = lease.reader.read(max_bytes + 1)
             available_at_stat = max(0, file_size - read_offset)
             if len(data) > max_bytes and available_at_stat <= max_bytes:
                 raise SMBBackendError('File exceeds preview limit')

--- a/app/transfer_routes.py
+++ b/app/transfer_routes.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+from contextlib import ExitStack
 from urllib.parse import quote
 import zipfile
 from pathlib import Path
@@ -19,6 +20,7 @@ from flask_login import current_user, login_required
 import config
 from . import sftp_handler
 from .audit_logger import log_error, log_file_source_operation
+from .file_backend import FileReaderLease
 from .file_sources import (
     FileCapability,
     FileSourceUnavailable,
@@ -407,18 +409,47 @@ def download_transfer(token):
         finish('failed', failure)
         return _json_failure(failure)
 
+    reader_stack = ExitStack()
+    size = 0
     try:
-        backend = _transfer_backend(source)
+        active_source = _resolve_transfer_source(record, user_id)
+        backend = _transfer_backend(active_source)
         if backend is None:
-            with sftp_handler.sftp_session(source.handle_id) as (sftp, _source):
-                size = sftp.stat(remote_path).st_size
+            reader_context = sftp_handler.open_bound_reader(
+                active_source.handle_id,
+                remote_path,
+            )
         else:
-            file_stat = _stat_transfer_source(backend, source, remote_path)
-            if not file_stat or file_stat.get('is_dir'):
-                raise FolderUnavailable()
-            size = int(file_stat.get('size', 0))
+            reader_context = backend.open_reader(
+                active_source,
+                remote_path,
+                io_lane='transfer',
+            )
+        lease = reader_stack.enter_context(reader_context)
+        if not isinstance(lease, FileReaderLease):
+            raise FolderUnavailable()
+        size = lease.size
+        if size > config.MAX_DOWNLOAD_SIZE:
+            raise DownloadLimitExceeded()
     except Exception as error:
-        failure = classify_transfer_failure(error, operation='download')
+        try:
+            reader_stack.close()
+        except Exception as close_error:
+            log_error(
+                'HTTP download reader close failed',
+                user_id=user_id,
+                exception_type=type(close_error).__name__,
+            )
+        limit_arguments = ({
+            'limit_kind': 'download',
+            'limit_bytes': config.MAX_DOWNLOAD_SIZE,
+            'actual_bytes': size,
+        } if isinstance(error, DownloadLimitExceeded) else {})
+        failure = classify_transfer_failure(
+            error,
+            operation='download',
+            **limit_arguments,
+        )
         log_error(
             'HTTP download preparation failed',
             user_id=user_id,
@@ -433,26 +464,7 @@ def download_transfer(token):
             operation='download',
             result=failure.code,
             filename=record.metadata.get('filename'),
-            size=0,
-        )
-        finish('failed', failure)
-        return _json_failure(failure)
-    if size > config.MAX_DOWNLOAD_SIZE:
-        failure = classify_transfer_failure(
-            DownloadLimitExceeded(),
-            operation='download',
-            limit_kind='download',
-            limit_bytes=config.MAX_DOWNLOAD_SIZE,
-            actual_bytes=size,
-        )
-        _audit_transfer_source(
-            source,
-            username=audit_username,
-            ip_address=audit_ip,
-            operation='download',
-            result='LIMIT_EXCEEDED',
-            filename=record.metadata.get('filename'),
-            size=size,
+            size=size if isinstance(error, DownloadLimitExceeded) else 0,
         )
         finish('failed', failure)
         return _json_failure(failure)
@@ -462,28 +474,13 @@ def download_transfer(token):
         failure = None
         transferred = 0
         try:
-            # Recheck directly before remote I/O because response iteration starts
-            # after headers have been constructed.
-            active_source = _resolve_transfer_source(record, user_id)
-            backend = _transfer_backend(active_source)
-            if backend is None:
-                reader_context = sftp_handler.sftp_session(
-                    active_source.handle_id
-                )
-                with reader_context as (sftp, _source):
-                    with sftp.file(remote_path, 'rb') as remote_file:
-                        transferred = yield from _stream_download_chunks(
-                            remote_file, record, user_id, size
-                        )
-            else:
-                with backend.open_reader(
-                    active_source,
-                    remote_path,
-                    io_lane='transfer',
-                ) as remote_file:
-                    transferred = yield from _stream_download_chunks(
-                        remote_file, record, user_id, size
-                    )
+            transferred = yield from _stream_download_chunks(
+                lease.reader,
+                record,
+                user_id,
+                lease.size,
+            )
+            reader_stack.close()
             outcome = 'completed'
         except GeneratorExit:
             outcome = 'cancelled'
@@ -506,22 +503,43 @@ def download_transfer(token):
             )
             raise
         finally:
-            _audit_transfer_source(
-                source,
-                username=audit_username,
-                ip_address=audit_ip,
-                operation='download',
-                result=failure.code if failure is not None else outcome,
-                filename=record.metadata['filename'],
-                size=transferred,
+            try:
+                reader_stack.close()
+            except Exception as close_error:
+                log_error(
+                    'HTTP download reader close failed',
+                    user_id=user_id,
+                    exception_type=type(close_error).__name__,
+                )
+            finally:
+                _audit_transfer_source(
+                    source,
+                    username=audit_username,
+                    ip_address=audit_ip,
+                    operation='download',
+                    result=failure.code if failure is not None else outcome,
+                    filename=record.metadata['filename'],
+                    size=transferred,
+                )
+                finish(outcome, failure)
+
+    def close_unstarted_response():
+        try:
+            reader_stack.close()
+        except Exception as close_error:
+            log_error(
+                'HTTP download reader close failed',
+                user_id=user_id,
+                exception_type=type(close_error).__name__,
             )
-            finish(outcome, failure)
+        finish('cancelled')
 
     response = Response(stream_with_context(generate()), mimetype='application/octet-stream')
     response.headers['Content-Disposition'] = _content_disposition(record.metadata['filename'])
     response.headers['Cache-Control'] = 'no-store'
     response.headers['Referrer-Policy'] = 'no-referrer'
-    response.call_on_close(lambda: finish('cancelled'))
+    response.headers['Accept-Ranges'] = 'none'
+    response.call_on_close(close_unstarted_response)
     return response
 
 
@@ -666,14 +684,20 @@ def _build_backend_zip_to_disk(
                     continue
                 with source.backend.open_reader(
                     source, entry_path, io_lane='transfer'
-                ) as reader:
+                ) as lease:
+                    if not isinstance(lease, FileReaderLease):
+                        raise RemoteTransferError('Source reader unavailable')
+                    if transferred + lease.size > max_bytes:
+                        raise RemoteTransferLimitExceeded(
+                            'Folder exceeds transfer size limit'
+                        )
                     with archive.open(archive_name, 'w') as archive_member:
                         while True:
                             if cancel_event.is_set():
                                 raise RemoteTransferCancelled(
                                     'Transfer cancelled'
                                 )
-                            chunk = reader.read(chunk_size)
+                            chunk = lease.reader.read(chunk_size)
                             if not chunk:
                                 break
                             transferred += len(chunk)
@@ -710,6 +734,8 @@ def download_folder_transfer(token):
     archive_size = None
     local_archive = None
     temp_reservation = None
+    remote_reader_stack = ExitStack()
+    remote_lease = None
 
     def cleanup_resources():
         if remote_archive is not None:
@@ -836,10 +862,40 @@ def download_folder_transfer(token):
                                 local_archive.unlink(missing_ok=True)
                         finally:
                             temp_reservation.release()
-                            temp_reservation = None
+                        temp_reservation = None
                         raise
+        if remote_archive is not None:
+            active_source = _resolve_transfer_source(record, user_id)
+            remote_lease = remote_reader_stack.enter_context(
+                sftp_handler.open_bound_reader(
+                    active_source.handle_id,
+                    remote_archive,
+                )
+            )
+            if remote_lease.size > config.MAX_ZIP_DOWNLOAD_SIZE:
+                raise DownloadLimitExceeded()
+            archive_size = remote_lease.size
     except Exception as error:
-        failure = classify_transfer_failure(error, operation='folder_download')
+        try:
+            remote_reader_stack.close()
+        except Exception as close_error:
+            log_error(
+                'Folder download reader close failed',
+                user_id=user_id,
+                exception_type=type(close_error).__name__,
+            )
+        limit_arguments = ({
+            'limit_kind': 'archive',
+            'limit_bytes': config.MAX_ZIP_DOWNLOAD_SIZE,
+            'actual_bytes': (
+                remote_lease.size if remote_lease is not None else archive_size
+            ),
+        } if isinstance(error, DownloadLimitExceeded) else {})
+        failure = classify_transfer_failure(
+            error,
+            operation='folder_download',
+            **limit_arguments,
+        )
         outcome = 'cancelled' if failure.code == 'CANCELLED' else 'failed'
         log_error(
             'Folder download preparation failed',
@@ -851,7 +907,13 @@ def download_folder_transfer(token):
         _audit_transfer_source(
             source, username=audit_username, ip_address=audit_ip,
             operation='folder_download', result=failure.code,
-            filename=f'{folder_name}.zip', size=0,
+            filename=f'{folder_name}.zip',
+            size=(
+                remote_lease.size
+                if isinstance(error, DownloadLimitExceeded)
+                and remote_lease is not None
+                else 0
+            ),
         )
         finish(outcome, failure)
         return _json_failure(failure)
@@ -862,20 +924,20 @@ def download_folder_transfer(token):
         transferred = 0
         try:
             if remote_archive is not None:
-                active_source = _resolve_transfer_source(record, user_id)
-                with sftp_handler.sftp_session(active_source.handle_id) as (sftp, _source):
-                    with sftp.file(remote_archive, 'rb') as remote_file:
-                        for chunk in sftp_handler.stream_remote_zip(
-                            remote_file,
-                            cancel_event=record.cancel_event,
-                            max_bytes=config.MAX_ZIP_DOWNLOAD_SIZE,
-                            chunk_size=TRANSFER_CHUNK_SIZE,
-                        ):
-                            transferred += len(chunk)
-                            _emit_download_progress(
-                                record, user_id, transferred, archive_size
-                            )
-                            yield chunk
+                for chunk in sftp_handler.stream_remote_zip(
+                    remote_lease.reader,
+                    cancel_event=record.cancel_event,
+                    max_bytes=config.MAX_ZIP_DOWNLOAD_SIZE,
+                    chunk_size=TRANSFER_CHUNK_SIZE,
+                ):
+                    transferred += len(chunk)
+                    _emit_download_progress(
+                        record,
+                        user_id,
+                        transferred,
+                        remote_lease.size,
+                    )
+                    yield chunk
             else:
                 with open(local_archive, 'rb') as archive:
                     while True:
@@ -889,6 +951,7 @@ def download_folder_transfer(token):
                             record, user_id, transferred, archive_size
                         )
                         yield chunk
+            remote_reader_stack.close()
             outcome = 'completed'
         except GeneratorExit:
             outcome = 'cancelled'
@@ -916,16 +979,36 @@ def download_folder_transfer(token):
             )
             raise
         finally:
-            _audit_transfer_source(
-                source,
-                username=audit_username,
-                ip_address=audit_ip,
-                operation='folder_download',
-                result=failure.code if failure is not None else outcome,
-                filename=f'{folder_name}.zip',
-                size=transferred,
+            try:
+                remote_reader_stack.close()
+            except Exception as close_error:
+                log_error(
+                    'Folder download reader close failed',
+                    user_id=user_id,
+                    exception_type=type(close_error).__name__,
+                )
+            finally:
+                _audit_transfer_source(
+                    source,
+                    username=audit_username,
+                    ip_address=audit_ip,
+                    operation='folder_download',
+                    result=failure.code if failure is not None else outcome,
+                    filename=f'{folder_name}.zip',
+                    size=transferred,
+                )
+                finish(outcome, failure)
+
+    def close_unstarted_response():
+        try:
+            remote_reader_stack.close()
+        except Exception as close_error:
+            log_error(
+                'Folder download reader close failed',
+                user_id=user_id,
+                exception_type=type(close_error).__name__,
             )
-            finish(outcome, failure)
+        finish('cancelled')
 
     response = Response(
         stream_with_context(generate()), mimetype='application/zip'
@@ -935,7 +1018,8 @@ def download_folder_transfer(token):
     )
     response.headers['Cache-Control'] = 'no-store'
     response.headers['Referrer-Policy'] = 'no-referrer'
-    response.call_on_close(lambda: finish('cancelled'))
+    response.headers['Accept-Ranges'] = 'none'
+    response.call_on_close(close_unstarted_response)
     return response
 
 

--- a/docs/wiki/SFTP-File-Workspace-and-Transfers.md
+++ b/docs/wiki/SFTP-File-Workspace-and-Transfers.md
@@ -113,6 +113,13 @@ The body routes are:
 - `GET /api/transfers/<token>/download` for streamed file downloads;
 - `GET /api/transfers/<token>/folder-download` for bounded folder archives.
 
+Downloads intentionally do not implement HTTP byte ranges. A request carrying
+`Range` still receives the complete `200` response and `Accept-Ranges: none`.
+The server opens the remote file once before creating the response, obtains the
+security-relevant size from that same handle, and keeps that handle for the
+whole stream. Renaming or replacing the pathname while a response is active
+therefore cannot switch the stream to another object.
+
 Server-to-server work runs as a bounded cancellable background job. The
 transfer queue tracks progress, errors, cancellation, and conflict choices such
 as skip or overwrite.
@@ -175,6 +182,19 @@ host filesystem paths.
 Preview loads only bounded content. Tail mode limits requested line count. The
 editor refuses files above its size cap and saves through the resolved, owned
 file source.
+
+Preview, editor, download, archive, and server-to-server reads bind their byte
+limits to the already-open remote object. SFTP obtains size and type through
+handle `fstat`; SMB uses the SMB2 CREATE response and rejects directory or
+reparse-point handles. Observed bytes remain capped as a second guard if a file
+grows after it was opened. Path metadata is not reused to authorize bytes from
+a later open.
+
+For SFTP, the remote SSH account and server configuration define which paths
+are reachable; WebSSH does not add a virtual allowed-folder boundary. Deploy
+`internal-sftp` with a server-side chroot when a user must be confined to one
+subtree. Handle binding prevents a later pathname swap, but it is not a
+replacement for server-side filesystem confinement.
 
 Text saves carry the revision that was previewed and reject stale content.
 Atomic replacement is the default. If an SMB account cannot provide it, the

--- a/tests/integration/test_smb_integration.py
+++ b/tests/integration/test_smb_integration.py
@@ -88,8 +88,8 @@ def run_checks():
             for offset in range(0, len(payload), 65536):
                 remote_file.write(payload[offset:offset + 65536])
 
-        with backend.open_reader(source, '/round-trip.bin') as remote_file:
-            downloaded = b''.join(iter(lambda: remote_file.read(65536), b''))
+        with backend.open_reader(source, '/round-trip.bin') as lease:
+            downloaded = b''.join(iter(lambda: lease.reader.read(65536), b''))
         assert hashlib.sha256(downloaded).digest() == hashlib.sha256(payload).digest()
 
         unicode_stat, error = backend.get_file_stat(source, '/Überblick.txt')
@@ -113,12 +113,12 @@ def run_checks():
         )
         assert edit_outcome.success is True, edit_outcome
         assert edit_outcome.revision == hashlib.sha256(b'after').hexdigest()
-        with backend.open_reader(source, '/atomic-edit.txt') as remote_file:
-            assert remote_file.read() == b'after'
+        with backend.open_reader(source, '/atomic-edit.txt') as lease:
+            assert lease.reader.read() == b'after'
 
         protected_path = '/atomic-denied/replace-denied.txt'
-        with backend.open_reader(source, protected_path) as remote_file:
-            protected_original = remote_file.read()
+        with backend.open_reader(source, protected_path) as lease:
+            protected_original = lease.reader.read()
         protected_revision = hashlib.sha256(protected_original).hexdigest()
         protected_outcome = backend.write_file_text(
             source,
@@ -129,8 +129,8 @@ def run_checks():
             expected_revision=protected_revision,
         )
         assert protected_outcome.code == 'SMB_RECOVERABLE_REPLACE_REQUIRED'
-        with backend.open_reader(source, protected_path) as remote_file:
-            assert remote_file.read() == protected_original
+        with backend.open_reader(source, protected_path) as lease:
+            assert lease.reader.read() == protected_original
 
         recoverable_outcome = backend.write_file_text(
             source,
@@ -143,8 +143,8 @@ def run_checks():
         )
         assert recoverable_outcome.success is False
         assert recoverable_outcome.recovery_leaves == ()
-        with backend.open_reader(source, protected_path) as remote_file:
-            assert remote_file.read() == protected_original
+        with backend.open_reader(source, protected_path) as lease:
+            assert lease.reader.read() == protected_original
 
         legacy_outcome = backend.write_file_text(
             source,
@@ -156,8 +156,8 @@ def run_checks():
             expected_revision=protected_revision,
         )
         assert legacy_outcome.code == 'SMB_RECOVERABLE_REPLACE_REQUIRED'
-        with backend.open_reader(source, protected_path) as remote_file:
-            assert remote_file.read() == protected_original
+        with backend.open_reader(source, protected_path) as lease:
+            assert lease.reader.read() == protected_original
 
         assert backend.mkdir(source, '/recursive-source') == (True, None)
         assert backend.mkdir(source, '/recursive-source/nested') == (True, None)
@@ -192,8 +192,8 @@ def run_checks():
             None,
         )
         assert copy_result.bytes_transferred == len(payload)
-        with backend.open_reader(source, '/copied-from-remote.bin') as remote_file:
-            copied = b''.join(iter(lambda: remote_file.read(65536), b''))
+        with backend.open_reader(source, '/copied-from-remote.bin') as lease:
+            copied = b''.join(iter(lambda: lease.reader.read(65536), b''))
         assert hashlib.sha256(copied).digest() == hashlib.sha256(payload).digest()
 
         denied, error = backend.list_directory(source, '/denied')

--- a/tests/test_binary_transfer_preview.py
+++ b/tests/test_binary_transfer_preview.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import stat
 from types import SimpleNamespace
 
 
@@ -12,6 +13,13 @@ def test_preview_download_uses_the_capped_buffered_path(monkeypatch):
         def read(self, size):
             self.read_sizes.append(size)
             return b'preview' if len(self.read_sizes) == 1 else b''
+
+        def stat(self):
+            return SimpleNamespace(
+                st_size=7,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=1,
+            )
 
         def __enter__(self):
             return self
@@ -51,6 +59,13 @@ def test_preview_download_rejects_remote_growth_past_the_cap(monkeypatch):
         def read(self, _size):
             return next(self.chunks)
 
+        def stat(self):
+            return SimpleNamespace(
+                st_size=4,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=1,
+            )
+
         def __enter__(self):
             return self
 
@@ -77,3 +92,50 @@ def test_preview_download_rejects_remote_growth_past_the_cap(monkeypatch):
 
     assert data is None
     assert 'File too large for download' in error
+
+
+def test_preview_download_limit_uses_the_opened_object_metadata(monkeypatch):
+    """A replacement opened after path stat must not inherit the old size."""
+    from app import binary_transfer
+
+    class Replacement:
+        def __init__(self):
+            self.read_called = False
+
+        def stat(self):
+            return SimpleNamespace(
+                st_size=9,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=1,
+            )
+
+        def read(self, _size):
+            self.read_called = True
+            return b'replacement'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    replacement = Replacement()
+    sftp = SimpleNamespace(
+        stat=lambda _path: SimpleNamespace(st_size=1),
+        file=lambda *_args: replacement,
+    )
+
+    @contextmanager
+    def fake_session(_session_id):
+        yield sftp, 'session'
+
+    monkeypatch.setattr(binary_transfer.sftp_handler, 'sftp_session', fake_session)
+    monkeypatch.setattr(binary_transfer.sftp_handler, 'sanitize_path', lambda path: path)
+
+    data, error = binary_transfer.handle_binary_download(
+        'owned-session', '/allowed/link.txt', max_size=8,
+    )
+
+    assert data is None
+    assert 'File too large for download' in error
+    assert replacement.read_called is False

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -1,0 +1,75 @@
+import io
+
+import pytest
+
+
+def test_reader_lease_binds_validated_metadata_to_the_exact_reader():
+    """Dropping the opened reader from the lease recreates path TOCTOU."""
+    from app.file_backend import FileReaderLease
+
+    reader = io.BytesIO(b'bound-object')
+    lease = FileReaderLease(
+        reader=reader,
+        size=12,
+        mode=0o100600,
+        modified=123.5,
+        is_dir=False,
+        is_symlink=False,
+    )
+
+    assert lease.reader is reader
+    assert lease.size == 12
+    assert lease.mode == 0o100600
+    assert lease.modified == 123.5
+    assert lease.is_dir is False
+    assert lease.is_symlink is False
+
+
+@pytest.mark.parametrize('size', [True, -1, 1.5, '1'])
+def test_reader_lease_rejects_untrusted_sizes(size):
+    """Boolean, negative, or coerced sizes can bypass byte ceilings."""
+    from app.file_backend import FileReaderLease
+
+    with pytest.raises(ValueError, match='size'):
+        FileReaderLease(reader=io.BytesIO(), size=size)
+
+
+@pytest.mark.parametrize(
+    ('overrides', 'message'),
+    [
+        ({'is_dir': True}, 'directory'),
+        ({'is_symlink': True}, 'symbolic'),
+        ({'is_dir': 0}, 'is_dir'),
+        ({'is_symlink': 0}, 'is_symlink'),
+    ],
+)
+def test_reader_lease_rejects_non_regular_object_metadata(overrides, message):
+    """A reader lease must never bless a directory or link-like object."""
+    from app.file_backend import FileReaderLease
+
+    with pytest.raises(ValueError, match=message):
+        FileReaderLease(reader=io.BytesIO(), size=0, **overrides)
+
+
+def test_reader_lease_rejects_an_object_without_read():
+    """Metadata without its readable handle is not object binding."""
+    from app.file_backend import FileReaderLease
+
+    with pytest.raises(ValueError, match='reader'):
+        FileReaderLease(reader=object(), size=0)
+
+
+@pytest.mark.parametrize('mode', [True, -1, '600'])
+def test_reader_lease_rejects_invalid_modes(mode):
+    from app.file_backend import FileReaderLease
+
+    with pytest.raises(ValueError, match='mode'):
+        FileReaderLease(reader=io.BytesIO(), size=0, mode=mode)
+
+
+@pytest.mark.parametrize('modified', [True, -1, 'now'])
+def test_reader_lease_rejects_invalid_modified_values(modified):
+    from app.file_backend import FileReaderLease
+
+    with pytest.raises(ValueError, match='modified'):
+        FileReaderLease(reader=io.BytesIO(), size=0, modified=modified)

--- a/tests/test_remote_transfer.py
+++ b/tests/test_remote_transfer.py
@@ -6,6 +6,8 @@ import hashlib
 
 import pytest
 
+from app.file_backend import FileReaderLease
+
 
 class _BoundedReader(BytesIO):
     def __init__(self, payload):
@@ -33,6 +35,7 @@ class _Backend:
         self.readers = []
         self.commits = []
         self.created = []
+        self.writer_opens = 0
 
     def normalize_path(self, path):
         return path if isinstance(path, str) and path.startswith('/') else None
@@ -57,13 +60,14 @@ class _Backend:
         reader = _BoundedReader(self.files[path])
         self.readers.append(reader)
         with reader:
-            yield reader
+            yield FileReaderLease(reader=reader, size=len(self.files[path]))
 
     @contextmanager
     def open_atomic_writer(
         self, _source, path, *, replace, cancel_event, io_lane='control'
     ):
         assert io_lane == 'transfer'
+        self.writer_opens += 1
         writer = _PartialWriter()
         try:
             yield writer
@@ -136,6 +140,48 @@ def test_remote_copy_streams_through_one_atomic_commit(
     assert len(destination_backend.commits) == 1
     assert result.sha256 == hashlib.sha256(payload).hexdigest()
     assert max(source_backend.readers[0].read_sizes) == 31
+
+
+def test_remote_copy_rejects_opened_object_before_destination_writer():
+    """A small path stat must not authorize a larger substituted object."""
+    from app.remote_transfer import (
+        RemoteTransferLimitExceeded,
+        TransferBudget,
+        copy_remote_entry,
+    )
+
+    class StaleStatBackend(_Backend):
+        def stat(self, _source, path, *, follow_links=False):
+            assert follow_links is False
+            assert path == '/source.bin'
+            return {
+                'path': path,
+                'size': 1,
+                'is_dir': False,
+                'is_symlink': False,
+            }, None
+
+    source_backend = StaleStatBackend({'/source.bin': b'123456789'})
+    destination_backend = _Backend()
+
+    with pytest.raises(
+        RemoteTransferLimitExceeded,
+        match='Transfer size limit exceeded',
+    ):
+        copy_remote_entry(
+            _source('sftp', source_backend),
+            '/source.bin',
+            _source('smb', destination_backend),
+            '/target.bin',
+            conflict_policy='replace',
+            budget=TransferBudget(max_bytes=5, max_members=1),
+            cancel_event=Event(),
+            progress=None,
+            chunk_size=2,
+        )
+
+    assert destination_backend.writer_opens == 0
+    assert destination_backend.commits == []
 
 
 def test_limit_plus_one_never_commits_destination():
@@ -436,7 +482,11 @@ def test_opposite_direction_transfers_use_one_canonical_source_lock_order():
                     rendezvous.wait(timeout=0.2)
                 except BrokenBarrierError:
                     pass
-                yield _BoundedReader(payloads[source.handle_id])
+                reader = _BoundedReader(payloads[source.handle_id])
+                yield FileReaderLease(
+                    reader=reader,
+                    size=len(payloads[source.handle_id]),
+                )
 
         @contextmanager
         def open_atomic_writer(

--- a/tests/test_sftp_backend.py
+++ b/tests/test_sftp_backend.py
@@ -8,7 +8,7 @@ import pytest
 
 from app import sftp_handler
 from app import sftp_backend
-from app.file_backend import FileBackend, FileWriteOutcome
+from app.file_backend import FileBackend, FileReaderLease, FileWriteOutcome
 from app.file_sources import (
     FileCapability,
     FileSourceDescriptor,
@@ -215,6 +215,54 @@ def test_sftp_backend_normalizes_through_existing_sanitizer(monkeypatch):
     assert calls == ['/a/./b']
 
 
+def test_open_reader_uses_metadata_from_the_open_handle(monkeypatch):
+    """A path stat followed by open can be swapped to a different object."""
+    class RemoteFile(io.BytesIO):
+        def stat(self):
+            return SimpleNamespace(
+                st_size=13,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=123,
+            )
+
+    remote = RemoteFile(b'bound-content')
+
+    class RacingSFTP:
+        def stat(self, _path):
+            raise AssertionError('path stat must not authorize an opened reader')
+
+        def file(self, path, mode):
+            assert (path, mode) == ('/target.txt', 'rb')
+            return remote
+
+    install_sftp_session(monkeypatch, RacingSFTP())
+
+    with SFTPBackend().open_reader(source(), '/target.txt') as lease:
+        assert isinstance(lease, FileReaderLease)
+        assert lease.reader is remote
+        assert lease.size == 13
+        assert lease.modified == 123
+        assert lease.reader.read() == b'bound-content'
+
+
+def test_open_reader_fails_closed_without_handle_metadata(monkeypatch):
+    """Falling back to a pathname stat would reopen the original race."""
+    class NoFstatFile(io.BytesIO):
+        pass
+
+    install_sftp_session(
+        monkeypatch,
+        SimpleNamespace(file=lambda *_args: NoFstatFile(b'unsafe')),
+    )
+
+    with pytest.raises(
+        sftp_handler.SFTPOperationError,
+        match='metadata unavailable',
+    ):
+        with SFTPBackend().open_reader(source(), '/target.txt'):
+            pass
+
+
 class AtomicSFTP:
     def __init__(
         self,
@@ -266,13 +314,22 @@ def install_sftp_session(monkeypatch, sftp, calls=None):
 
 def test_transfer_reader_uses_a_separate_io_lane(monkeypatch):
     calls = []
-    sftp = AtomicSFTP()
+    class RemoteFile(io.BytesIO):
+        def stat(self):
+            return SimpleNamespace(
+                st_size=0,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=123,
+            )
+
+    sftp = SimpleNamespace(file=lambda *_args: RemoteFile())
     install_sftp_session(monkeypatch, sftp, calls)
 
     with SFTPBackend().open_reader(
         source(), '/source.txt', io_lane='transfer'
-    ) as reader:
-        assert reader.read() == b''
+    ) as lease:
+        assert lease.reader.read() == b''
+        assert lease.size == 0
 
     assert calls == [('session-a', 'transfer')]
 

--- a/tests/test_sftp_handler.py
+++ b/tests/test_sftp_handler.py
@@ -344,3 +344,87 @@ def test_preview_rejects_negative_read_before_opening_sftp(monkeypatch):
 
     assert result is None
     assert error == 'max_bytes must be a positive integer'
+
+
+def test_preview_limit_uses_fstat_from_the_open_object(monkeypatch):
+    """A rename between path stat and open must not bypass preview limits."""
+    import io
+    import stat
+    from contextlib import contextmanager
+    from types import SimpleNamespace
+
+    import app.sftp_handler as sftp_handler
+    import config
+
+    class Replacement(io.BytesIO):
+        def __init__(self):
+            super().__init__(b'replacement')
+            self.read_called = False
+
+        def stat(self):
+            return SimpleNamespace(
+                st_size=11,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=1,
+            )
+
+        def read(self, size=-1):
+            self.read_called = True
+            return super().read(size)
+
+    replacement = Replacement()
+    sftp = SimpleNamespace(
+        stat=lambda _path: SimpleNamespace(st_size=1),
+        file=lambda *_args: replacement,
+    )
+
+    @contextmanager
+    def fake_session(_session_id):
+        yield sftp, 'session'
+
+    monkeypatch.setattr(sftp_handler, 'sftp_session', fake_session)
+    monkeypatch.setattr(config, 'MAX_SUPPORTED_FILE_SIZE', 8)
+
+    result, error = sftp_handler.read_file_preview(
+        'session', '/allowed/link.txt', max_bytes=8
+    )
+
+    assert result is None
+    assert error == 'File too large (11 bytes). Maximum supported size is 8 bytes.'
+    assert replacement.read_called is False
+
+
+def test_editor_limit_uses_fstat_from_the_open_object(monkeypatch):
+    """Editor authorization must describe the object that supplies bytes."""
+    import io
+    import stat
+    from contextlib import contextmanager
+    from types import SimpleNamespace
+
+    import app.sftp_handler as sftp_handler
+
+    class Replacement(io.BytesIO):
+        def stat(self):
+            return SimpleNamespace(
+                st_size=9,
+                st_mode=stat.S_IFREG | 0o600,
+                st_mtime=1,
+            )
+
+    sftp = SimpleNamespace(
+        stat=lambda _path: SimpleNamespace(st_size=1),
+        file=lambda *_args: Replacement(b'123456789'),
+    )
+
+    @contextmanager
+    def fake_session(_session_id):
+        yield sftp, 'session'
+
+    monkeypatch.setattr(sftp_handler, 'sftp_session', fake_session)
+
+    result, error = sftp_handler.read_file_for_edit(
+        'session', '/allowed/link.txt', max_bytes=8
+    )
+
+    assert result is None
+    assert error == 'File too large to edit (0MB). Maximum: 0MB'

--- a/tests/test_smb_backend.py
+++ b/tests/test_smb_backend.py
@@ -12,7 +12,7 @@ from app.file_sources import (
     ResolvedFileSource,
     make_source_id,
 )
-from app.file_backend import FileWriteOutcome
+from app.file_backend import FileReaderLease, FileWriteOutcome
 from app.smb_backend import (
     FileConflict,
     NonAtomicOverwriteRequired,
@@ -73,6 +73,15 @@ class _Writable(BytesIO):
     def close(self):
         self.saved = self.getvalue()
         super().close()
+
+
+class _Readable(BytesIO):
+    def __init__(self, data, *, attributes=0, declared_size=None):
+        super().__init__(data)
+        self.fd = SimpleNamespace(
+            end_of_file=(len(data) if declared_size is None else declared_size),
+            file_attributes=attributes,
+        )
 
 
 class _PartialWritable(_Writable):
@@ -166,7 +175,7 @@ class _StatefulSMBSession(_Session):
             if mode == 'rb':
                 if path not in self.files:
                     raise FileNotFoundError(path)
-                return BytesIO(self.files[path])
+                return _Readable(self.files[path])
             if mode != 'xb':
                 raise AssertionError(f'unsafe editor mode: {mode}')
             if path in self.files:
@@ -690,10 +699,32 @@ def test_share_root_mutations_are_rejected_before_remote_io():
     assert session.calls == []
 
 
-def test_preview_rejects_growth_beyond_limit():
+def test_preview_uses_opened_size_when_path_size_is_stale():
     backend, source, session = _fixture()
     session.responses['stat'] = _Stat(size=3)
-    session.responses['open_file'] = BytesIO(b'abcd')
+    session.responses['open_file'] = _Readable(b'abcd')
+
+    result, error = backend.read_file_preview(
+        source,
+        '/growing.txt',
+        max_bytes=3,
+        offset=0,
+        tail_lines=None,
+    )
+
+    assert error is None
+    assert result['content'] == 'abc'
+    assert result['size'] == 4
+    assert result['truncated'] is True
+
+
+def test_preview_rejects_growth_after_the_handle_metadata_was_bound():
+    backend, source, session = _fixture()
+    session.responses['stat'] = _Stat(size=3)
+    session.responses['open_file'] = _Readable(
+        b'abcd',
+        declared_size=3,
+    )
 
     result, error = backend.read_file_preview(
         source,
@@ -710,7 +741,7 @@ def test_preview_rejects_growth_beyond_limit():
 def test_preview_truncates_a_file_that_was_already_over_the_limit():
     backend, source, session = _fixture()
     session.responses['stat'] = _Stat(size=6)
-    session.responses['open_file'] = BytesIO(b'abcdef')
+    session.responses['open_file'] = _Readable(b'abcdef')
 
     result, error = backend.read_file_preview(
         source,
@@ -728,7 +759,7 @@ def test_preview_truncates_a_file_that_was_already_over_the_limit():
 def test_open_reader_does_not_retry_when_caller_raises_attribute_error():
     backend, source, session = _fixture()
     session.responses['stat'] = _Stat(size=3)
-    session.responses['open_file'] = BytesIO(b'abc')
+    session.responses['open_file'] = _Readable(b'abc')
     yielded = 0
 
     with pytest.raises(AttributeError, match='caller failure'):
@@ -743,7 +774,7 @@ def test_transfer_lane_does_not_block_control_lane_navigation():
     backend, source, control_session = _fixture()
     transfer_session = _Session()
     transfer_session.responses['stat'] = _Stat(size=3)
-    transfer_session.responses['open_file'] = BytesIO(b'abc')
+    transfer_session.responses['open_file'] = _Readable(b'abc')
     control_session.responses['scandir'] = _Iterator([])
     actual = backend._pool().get_source(source.source_id, source.user_id)
     actual.control_session = control_session
@@ -789,13 +820,14 @@ def test_transfer_lane_does_not_block_control_lane_navigation():
 def test_read_paths_open_the_validated_object_without_following_reparse_points():
     backend, source, session = _fixture()
     session.responses['stat'] = _Stat(size=3)
-    session.responses['open_file'] = BytesIO(b'bad')
+    session.responses['open_file'] = _Readable(b'bad')
     session.responses['open_file_no_follow'] = (
-        lambda *_args, **_kwargs: BytesIO(b'abc')
+        lambda *_args, **_kwargs: _Readable(b'abc')
     )
 
-    with backend.open_reader(source, '/a.txt') as remote:
-        assert remote.read() == b'abc'
+    with backend.open_reader(source, '/a.txt') as lease:
+        assert isinstance(lease, FileReaderLease)
+        assert lease.reader.read() == b'abc'
 
     assert any(
         name == 'open_file_no_follow' and kwargs['mode'] == 'rb'
@@ -820,6 +852,33 @@ def test_read_paths_open_the_validated_object_without_following_reparse_points()
         name == 'open_file_no_follow' and kwargs['mode'] == 'rb'
         for name, _args, kwargs in session.calls
     )
+
+
+def test_open_reader_uses_size_and_attributes_from_the_open_handle():
+    """The SMB2 CREATE response, not a pathname stat, binds read policy."""
+    backend, source, session = _fixture()
+    session.responses['stat'] = _Stat(size=1)
+    opened = _Readable(b'replacement', declared_size=11)
+    session.responses['open_file'] = opened
+
+    with backend.open_reader(source, '/swapped.txt') as lease:
+        assert lease.reader is opened
+        assert lease.size == 11
+        assert lease.reader.read() == b'replacement'
+
+
+def test_open_reader_rejects_reparse_attribute_from_the_open_handle():
+    """A leaf swapped after component checks must still be rejected."""
+    backend, source, session = _fixture()
+    session.responses['stat'] = _Stat(size=1)
+    session.responses['open_file'] = _Readable(
+        b'link-target',
+        attributes=0x400,
+    )
+
+    with pytest.raises(SMBBackendError, match='File is not readable'):
+        with backend.open_reader(source, '/swapped.txt'):
+            pass
 
 
 class _MemberBudget:
@@ -924,7 +983,7 @@ def test_recursive_delete_is_postorder_and_rejects_reparse_points():
 def test_binary_preview_is_bounded_even_if_file_grows():
     backend, source, session = _fixture()
     session.responses['stat'] = _Stat(size=2)
-    session.responses['open_file'] = BytesIO(b'abc')
+    session.responses['open_file'] = _Readable(b'abc')
 
     value, error = backend.read_binary_preview(source, '/file.bin', max_size=2)
 

--- a/tests/test_transfer_cancellation.py
+++ b/tests/test_transfer_cancellation.py
@@ -24,6 +24,13 @@ class BoundedReader:
         self.offset += len(chunk)
         return chunk
 
+    def stat(self):
+        return SimpleNamespace(
+            st_mode=stat.S_IFREG | 0o600,
+            st_size=len(self.payload),
+            st_mtime=1,
+        )
+
     def __enter__(self):
         return self
 

--- a/tests/test_transfer_routes.py
+++ b/tests/test_transfer_routes.py
@@ -11,6 +11,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.file_backend import FileReaderLease
+
 
 class BoundedRequestStream:
     """A WSGI input stream that treats ``read()`` without a size as a bug."""
@@ -42,8 +44,11 @@ class BoundedRequestStream:
 
 
 class TrackingRemoteFile:
-    def __init__(self, payload=b''):
+    def __init__(self, payload=b'', *, declared_size=None):
         self.payload = payload
+        self.declared_size = (
+            len(payload) if declared_size is None else declared_size
+        )
         self.offset = 0
         self.read_sizes = []
         self.written = bytearray()
@@ -59,6 +64,13 @@ class TrackingRemoteFile:
 
     def write(self, chunk):
         self.written.extend(chunk)
+
+    def stat(self):
+        return SimpleNamespace(
+            st_size=self.declared_size,
+            st_mode=stat.S_IFREG | 0o600,
+            st_mtime=1,
+        )
 
     def close(self):
         self.closed = True
@@ -194,7 +206,7 @@ def test_smb_download_streams_only_through_resolved_backend(
             assert path == '/report.bin'
             assert io_lane == 'transfer'
             with remote:
-                yield remote
+                yield FileReaderLease(reader=remote, size=len(payload))
 
     resolved = SimpleNamespace(
         handle_id='smb-handle',
@@ -243,6 +255,117 @@ def test_smb_download_streams_only_through_resolved_backend(
         'target_host': 'nas.example',
         'share': 'Docs',
     }]
+
+
+def test_download_rejects_oversized_opened_object_before_first_byte(
+        app, client, monkeypatch, transfer_components):
+    """A stale small preflight must not authorize a larger opened object."""
+    transfer_routes, manager = transfer_components
+    remote = TrackingRemoteFile(b'123456789', declared_size=9)
+
+    class Backend:
+        def stat(self, *_args, **_kwargs):
+            raise AssertionError('path stat must not authorize the download')
+
+        @contextmanager
+        def open_reader(self, _source, _path, *, io_lane='control'):
+            assert io_lane == 'transfer'
+            with remote:
+                yield FileReaderLease(reader=remote, size=9)
+
+    resolved = SimpleNamespace(
+        handle_id='smb-handle',
+        backend=Backend(),
+        source_id='smb-quick:owned',
+        descriptor=SimpleNamespace(kind='smb', endpoint='nas.example/Docs'),
+    )
+    monkeypatch.setattr(
+        transfer_routes.file_service,
+        'resolve',
+        lambda *_args, **_kwargs: resolved,
+    )
+    monkeypatch.setattr(transfer_routes.config, 'MAX_DOWNLOAD_SIZE', 5)
+    user_id = _login(client, app, 'opened_download_limit_user')
+    record = manager.create(
+        user_id=user_id,
+        source_id='smb-quick:owned',
+        direction='download',
+        metadata={'remote_path': '/report.bin', 'filename': 'report.bin'},
+    )
+
+    response = client.get(f'/api/transfers/{record.token}/download')
+
+    assert response.status_code == 413
+    assert response.get_json() == {
+        'error_code': 'LIMIT_EXCEEDED',
+        'error': 'The transfer exceeds the configured limit.',
+        'retryable': False,
+        'limit_kind': 'download',
+        'limit_bytes': 5,
+        'actual_bytes': 9,
+    }
+    assert remote.read_sizes == []
+    assert remote.closed is True
+    assert manager._records == {}
+
+
+def test_download_explicitly_does_not_support_http_ranges(
+        app, client, monkeypatch, transfer_components):
+    transfer_routes, manager = transfer_components
+    payload = b'abcdef'
+    sftp = FakeSFTP(payload)
+
+    @contextmanager
+    def fake_session(_session_id):
+        yield sftp, 'session'
+
+    monkeypatch.setattr(transfer_routes.sftp_handler, 'sftp_session', fake_session)
+    user_id = _login(client, app, 'download_range_user')
+    token = _token(manager, user_id, 'download')
+
+    response = client.get(
+        f'/api/transfers/{token}/download',
+        headers={'Range': 'bytes=0-1'},
+    )
+
+    assert response.status_code == 200
+    assert response.headers['Accept-Ranges'] == 'none'
+    assert 'Content-Range' not in response.headers
+    assert response.data == payload
+
+
+def test_range_request_keeps_the_original_open_object_after_path_swap(
+        app, client, monkeypatch, transfer_components):
+    """Renaming the target mid-response must not cause a second path open."""
+    transfer_routes, manager = transfer_components
+    original_payload = b'a' * (app.config['CHUNK_SIZE'] + 17)
+    replacement_payload = b'not-the-opened-object'
+    sftp = FakeSFTP(original_payload)
+    original_reader = sftp.download_file
+
+    @contextmanager
+    def fake_session(_session_id):
+        yield sftp, 'session'
+
+    monkeypatch.setattr(transfer_routes.sftp_handler, 'sftp_session', fake_session)
+    user_id = _login(client, app, 'download_path_swap_user')
+    token = _token(manager, user_id, 'download')
+
+    response = client.get(
+        f'/api/transfers/{token}/download',
+        headers={'Range': 'bytes=0-1'},
+        buffered=False,
+    )
+    sftp.download_file = TrackingRemoteFile(replacement_payload)
+    body = b''.join(response.response)
+    response.close()
+
+    assert response.status_code == 200
+    assert response.headers['Accept-Ranges'] == 'none'
+    assert body == original_payload
+    assert sftp.opened == [('/remote/report.bin', 'rb')]
+    assert original_reader.closed is True
+    assert sftp.download_file.read_sizes == []
 
 
 def test_smb_upload_uses_atomic_backend_writer_and_bounded_request_reads(
@@ -509,7 +632,7 @@ def test_upload_http_socket_and_log_share_one_safe_failure_contract(
         ),
     ),
 )
-def test_download_preflight_keeps_typed_failure_across_http_and_socket(
+def test_download_open_keeps_typed_failure_across_http_and_socket(
     app,
     client,
     monkeypatch,
@@ -525,8 +648,10 @@ def test_download_preflight_keeps_typed_failure_across_http_and_socket(
     transfer_routes, manager = transfer_components
 
     class Backend:
-        def stat_or_raise(self, *_args, **_kwargs):
+        @contextmanager
+        def open_reader(self, *_args, **_kwargs):
             raise failure
+            yield
 
     resolved = SimpleNamespace(
         handle_id='smb-handle',
@@ -1330,11 +1455,11 @@ def test_unstarted_download_response_releases_record(
     assert manager._records == {}
 
 
-def test_download_preflight_limit_marks_request_done(
+def test_download_opened_handle_limit_marks_request_done(
         app, client, monkeypatch, transfer_components):
     transfer_routes, manager = transfer_components
     sftp = FakeSFTP()
-    sftp.reported_size = app.config['MAX_DOWNLOAD_SIZE'] + 1
+    sftp.download_file.declared_size = app.config['MAX_DOWNLOAD_SIZE'] + 1
 
     @contextmanager
     def fake_session(_session_id):
@@ -1358,7 +1483,7 @@ def test_download_preflight_limit_marks_request_done(
         'retryable': False,
         'limit_kind': 'download',
         'limit_bytes': app.config['MAX_DOWNLOAD_SIZE'],
-        'actual_bytes': sftp.reported_size,
+        'actual_bytes': sftp.download_file.declared_size,
     }
     assert record.request_done_event.is_set()
     assert manager._records == {}
@@ -1578,7 +1703,7 @@ def test_smb_folder_download_builds_bounded_local_zip_via_backend(
             assert path == '/reports/report.txt'
             assert io_lane == 'transfer'
             with TrackingRemoteFile(payload) as remote:
-                yield remote
+                yield FileReaderLease(reader=remote, size=len(payload))
 
     resolved = SimpleNamespace(
         handle_id='smb-handle', backend=Backend(), source_id='smb-quick:owned',
@@ -1672,7 +1797,7 @@ def test_folder_download_preflight_reports_smb_permission_failure(
     assert 'private' not in repr(response.get_json())
 
 
-def test_folder_download_propagates_limit_after_first_chunk(
+def test_folder_download_rejects_oversized_opened_archive_before_first_chunk(
         app, client, monkeypatch, transfer_components):
     transfer_routes, manager = transfer_components
     payload = b'abcdef'
@@ -1723,17 +1848,12 @@ def test_folder_download_propagates_limit_after_first_chunk(
         },
     )
 
-    response = client.get(
-        f'/api/transfers/{record.token}/folder-download',
-        buffered=False,
-    )
-    stream = iter(response.response)
+    response = client.get(f'/api/transfers/{record.token}/folder-download')
 
-    assert next(stream) == b'abc'
-    with pytest.raises(transfer_routes.sftp_handler.TransferSizeExceeded):
-        next(stream)
-    response.close()
-
+    assert response.status_code == 413
+    assert response.get_json()['error_code'] == 'LIMIT_EXCEEDED'
+    assert sftp.download_file.read_sizes == []
+    assert sftp.download_file.closed is True
     assert record.request_done_event.is_set()
     assert manager._records == {}
 


### PR DESCRIPTION
## Summary

- introduce a protocol-neutral reader lease that keeps remote metadata bound to the exact SFTP or SMB handle supplying bytes
- use SFTP handle stat and SMB2 CREATE metadata, reject invalid or non-readable opened objects, and preserve separate transfer I/O lanes
- open downloads before response construction, disable byte ranges, enforce declared and observed byte limits, and close handles on every response outcome
- apply the same binding to previews, editor reads, archive members, remote ZIP streams, and server-to-server copies

## Security boundaries

- WebSSH does not add a virtual allowed-folder root for SFTP; deployments that require subtree confinement must use the remote account and server-side chroot
- supported SMB targets must continue to disable symlink and wide-link traversal; final read handles are also opened without following reparse points and validated from CREATE metadata
- RBAC and role-based connection visibility are intentionally not part of this change

## Validation

- `pytest tests/test_binary_transfer_preview.py tests/test_file_backend.py tests/test_remote_transfer.py tests/test_sftp_backend.py tests/test_sftp_handler.py tests/test_smb_backend.py tests/test_transfer_cancellation.py tests/test_transfer_routes.py -q` — 221 passed
- `pytest tests -q` — 2,213 passed, 33 skipped
- `python scripts/run_integration_tests.py` — 27 passed against disposable OpenSSH targets
- `python scripts/run_smb_integration_tests.py` — SMB 3.1.1 integration checks passed
- security diff review — 0 findings across 7 changed production modules