### PR TITLE
Fix same-pane file moves and contextual transfer controls

### DIFF
--- a/docs/wiki/SFTP-File-Workspace-and-Transfers.md
+++ b/docs/wiki/SFTP-File-Workspace-and-Transfers.md
@@ -80,7 +80,8 @@ Supported operations include:
 - create directory;
 - rename;
 - move files or folders on the same source by dragging them onto a destination
-  folder in the current pane or into the other pane;
+  folder in the current File Workspace pane, the embedded active-session SFTP
+  browser, or the other pane;
 - delete;
 - drag-and-drop file and folder upload;
 - single and batch download;

--- a/static/js/sftp-file-manager.js
+++ b/static/js/sftp-file-manager.js
@@ -872,11 +872,15 @@ class SFTPFileManager {
             : this.t('fm.transfer', 'Transfer');
         const icon = button.querySelector?.('.material-icons');
         const text = button.querySelector?.('.btn-text');
-        if (icon) icon.textContent = moving ? 'drive_file_move' : 'swap_horiz';
+        if (icon) {
+            icon.textContent = direction === 'RightToLeft'
+                ? 'arrow_back'
+                : direction === 'LeftToRight' ? 'arrow_forward'
+                    : moving ? 'drive_file_move' : 'swap_horiz';
+        }
         if (text) text.textContent = label;
         button.classList?.toggle?.('is-move', moving);
         button.dataset.operation = available ? operation : 'unavailable';
-        if (direction) button.hidden = moving;
         if (direction) {
             const key = moving
                 ? `fm.workspace.move${direction}`
@@ -902,8 +906,19 @@ class SFTPFileManager {
         const activeOperation = this.workspaceOperationBetweenPanes(
             this.activePane, targetPane,
         );
-        const transferAvailable = activeOperation !== 'unavailable'
+        const activeTransferAvailable = activeOperation !== 'unavailable'
             && selectedCount > 0;
+        const transferSourcePane = selectedCount > 0
+            ? this.activePane
+            : (this.panes[targetPane]?.selected?.size || 0) > 0
+                ? targetPane : this.activePane;
+        const transferTargetPane = transferSourcePane === 'left' ? 'right' : 'left';
+        const transferSelectedCount = this.panes[transferSourcePane]?.selected?.size || 0;
+        const transferOperation = this.workspaceOperationBetweenPanes(
+            transferSourcePane, transferTargetPane,
+        );
+        const transferAvailable = transferOperation !== 'unavailable'
+            && transferSelectedCount > 0;
         const setDisabled = (id, disabled) => {
             const element = document.getElementById(id);
             if (element) element.disabled = disabled;
@@ -914,29 +929,20 @@ class SFTPFileManager {
         setDisabled('fmPreview', !this.sourceCan(state, 'preview') || !selectedFile || selectedFile.is_dir);
         setDisabled('fmRename', !this.sourceCan(state, 'rename') || selectedCount !== 1);
         setDisabled('fmDelete', !this.sourceCan(state, 'delete') || selectedCount === 0);
-        setDisabled('fmTransfer', !transferAvailable);
-        const rightOperation = this.workspaceOperationBetweenPanes('left', 'right');
-        const leftOperation = this.workspaceOperationBetweenPanes('right', 'left');
-        setDisabled('fmTransferRight', !(
-            rightOperation !== 'unavailable'
-            && this.panes.left.selected.size > 0
-        ));
-        setDisabled('fmTransferLeft', !(
-            leftOperation !== 'unavailable'
-            && this.panes.right.selected.size > 0
-        ));
+        setDisabled('fmTransfer', !activeTransferAvailable);
         this.updateWorkspaceOperationButton(
             document.getElementById('fmTransfer'), activeOperation,
         );
+        const betweenButton = document.getElementById('fmTransferBetween');
+        if (betweenButton) {
+            betweenButton.disabled = !transferAvailable;
+            betweenButton.hidden = !transferAvailable;
+            betweenButton.dataset.sourcePane = transferSourcePane;
+        }
         this.updateWorkspaceOperationButton(
-            document.getElementById('fmTransferRight'),
-            rightOperation,
-            'LeftToRight',
-        );
-        this.updateWorkspaceOperationButton(
-            document.getElementById('fmTransferLeft'),
-            leftOperation,
-            'RightToLeft',
+            betweenButton,
+            transferOperation,
+            transferSourcePane === 'left' ? 'LeftToRight' : 'RightToLeft',
         );
         ['left', 'right'].forEach(pane => {
             const paneState = this.panes[pane];
@@ -965,32 +971,12 @@ class SFTPFileManager {
         });
         const hint = document.getElementById('fmTransferHint');
         if (hint) {
-            const leftOperation = this.workspaceOperationBetweenPanes('left', 'right');
-            const rightOperation = this.workspaceOperationBetweenPanes('right', 'left');
-            const leftSelection = leftOperation !== 'unavailable'
-                ? this.panes.left.selected.size : 0;
-            const rightSelection = rightOperation !== 'unavailable'
-                ? this.panes.right.selected.size : 0;
-            const transferSelection = Math.max(leftSelection, rightSelection);
-            const selectedOperation = leftSelection >= rightSelection
-                ? leftOperation : rightOperation;
-            const moveOnly = leftOperation === 'move' && rightOperation === 'move';
-            hint.textContent = moveOnly
-                ? this.t(
-                    'fm.workspace.dragToMove',
-                    'Drag items onto a folder to move them',
-                )
-                : transferSelection > 0
+            hint.textContent = transferAvailable
                 ? `${this.t(
-                    selectedOperation === 'move' ? 'fm.move' : 'fm.transfer',
-                    selectedOperation === 'move' ? 'Move' : 'Transfer',
-                )} ${transferSelection} ${this.t('fm.selected', 'selected')}`
-                : selectedOperation === 'move'
-                    ? this.t(
-                        'fm.workspace.dragToMove',
-                        'Drag items onto a folder to move them',
-                    )
-                    : this.t('fm.workspace.selectFiles', 'Select files');
+                    transferOperation === 'move' ? 'fm.move' : 'fm.transfer',
+                    transferOperation === 'move' ? 'Move' : 'Transfer',
+                )} ${transferSelectedCount} ${this.t('fm.selected', 'selected')}`
+                : this.t('fm.workspace.selectFiles', 'Select files');
         }
     }
 
@@ -1171,12 +1157,8 @@ class SFTPFileManager {
 
                         <div class="fm-transfer-rail" aria-label="Transfer between panes" data-i18n-aria-label="fm.workspace.transferBetween">
                             <span class="fm-transfer-hint" id="fmTransferHint" aria-live="polite">Select files</span>
-                            <button type="button" class="fm-transfer-direction" id="fmTransferRight" aria-label="Transfer left to right" title="Transfer left to right">
+                            <button type="button" class="fm-transfer-direction" id="fmTransferBetween" aria-label="Transfer left to right" title="Transfer left to right" hidden>
                                 <span class="material-icons" aria-hidden="true">arrow_forward</span>
-                                <span class="btn-text" data-i18n="fm.transfer">Transfer</span>
-                            </button>
-                            <button type="button" class="fm-transfer-direction" id="fmTransferLeft" aria-label="Transfer right to left" title="Transfer right to left">
-                                <span class="material-icons" aria-hidden="true">arrow_back</span>
                                 <span class="btn-text" data-i18n="fm.transfer">Transfer</span>
                             </button>
                         </div>
@@ -1480,12 +1462,10 @@ class SFTPFileManager {
         document.querySelectorAll('[data-source-target]').forEach(button => {
             button.addEventListener('click', () => this.openSourceLauncher(button.dataset.sourceTarget));
         });
-        document.getElementById('fmTransferRight').addEventListener('click', () => {
-            this.setActivePane('left');
-            this.executeTransfer();
-        });
-        document.getElementById('fmTransferLeft').addEventListener('click', () => {
-            this.setActivePane('right');
+        document.getElementById('fmTransferBetween').addEventListener('click', event => {
+            const sourcePane = event.currentTarget.dataset.sourcePane;
+            if (!['left', 'right'].includes(sourcePane)) return;
+            this.setActivePane(sourcePane);
             this.executeTransfer();
         });
         document.querySelector('.fm-panes').addEventListener('click', event => {
@@ -3726,6 +3706,18 @@ class SFTPFileManager {
         return !this.draggedItems.some(item => item?.name === directory.name);
     }
 
+    canStartSamePaneMove(pane) {
+        const state = this.panes?.[pane];
+        return Boolean(
+            this.getPaneSourceId(state)
+            && !state.loading
+            && !state.error
+            && typeof state.path === 'string'
+            && this.sourceCan(state, 'rename')
+            && this.sourceCan(state, 'write'),
+        );
+    }
+
     setupDirectoryDropTarget(element, pane, index) {
         element.addEventListener('dragover', event => {
             if (!this.canDropDraggedItemsOnDirectory(pane, index)) return;
@@ -3777,9 +3769,13 @@ class SFTPFileManager {
         this.draggedItems = Array.from(state.selected).map(i => state.files[i]).filter(f => f);
         const targetPane = pane === 'left' ? 'right' : 'left';
         const operation = this.workspaceOperationBetweenPanes(pane, targetPane);
-        e.dataTransfer.effectAllowed = operation === 'move'
-            ? 'move'
-            : operation === 'copy' ? 'copy' : 'none';
+        const samePaneMove = this.draggedItems.length > 0
+            && this.canStartSamePaneMove(pane);
+        e.dataTransfer.effectAllowed = samePaneMove && operation === 'copy'
+            ? 'copyMove'
+            : samePaneMove || operation === 'move'
+                ? 'move'
+                : operation === 'copy' ? 'copy' : 'none';
         e.dataTransfer.setData('text/plain', this.draggedItems.map(f => f.name).join(', '));
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1393,7 +1393,7 @@
     <script src="{{ url_for('static', filename='js/file-transfer.js') }}?v=3"></script>
     <script src="{{ url_for('static', filename='js/file-workspace-state.js') }}?v=4"></script>
     <script src="{{ url_for('static', filename='js/smb-source-dialog.js') }}?v=5"></script>
-    <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=31"></script>
+    <script src="{{ url_for('static', filename='js/sftp-file-manager.js') }}?v=32"></script>
     <script src="{{ url_for('static', filename='js/connection-history.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/primary-workspace-controller.js') }}?v=1"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}?v=26"></script>

--- a/tests/e2e/file-workspace.spec.js
+++ b/tests/e2e/file-workspace.spec.js
@@ -161,9 +161,11 @@ test('source-first workspace preserves panes and exposes only functional SFTP ac
         manager.renderPane('left');
         manager.renderPane('right');
     });
-    await expect(page.locator('#fmTransferRight')).toBeEnabled();
+    await expect(page.locator('#fmTransferBetween')).toBeVisible();
+    await expect(page.locator('#fmTransferBetween')).toBeEnabled();
+    await expect(page.locator('.fm-transfer-rail .fm-transfer-direction')).toHaveCount(1);
     await expect(page.locator('#fmTransferHint')).toContainText('1 selected');
-    await page.locator('#fmTransferRight').click();
+    await page.locator('#fmTransferBetween').click();
     await expect.poll(() => page.evaluate(() => (
         window.__fileWorkspaceEvents.some(item => item.event === 'transfer_server_to_server')
     ))).toBe(true);
@@ -342,26 +344,9 @@ test('same-pane drag moves the selection into a folder without a Move toolbar ac
     });
 
     await expect(page.locator('[data-pane-action="move"]')).toHaveCount(0);
-    const highlighted = await page.evaluate(() => {
-        const source = document.querySelector('#fmLeftList .fm-file-item[data-index="0"]');
-        const target = document.querySelector('#fmLeftList .fm-file-item[data-index="1"]');
-        const dataTransfer = new DataTransfer();
-        source.dispatchEvent(new DragEvent('dragstart', {
-            bubbles: true, cancelable: true, dataTransfer,
-        }));
-        target.dispatchEvent(new DragEvent('dragover', {
-            bubbles: true, cancelable: true, dataTransfer,
-        }));
-        const active = target.classList.contains('fm-directory-drop-target');
-        target.dispatchEvent(new DragEvent('drop', {
-            bubbles: true, cancelable: true, dataTransfer,
-        }));
-        source.dispatchEvent(new DragEvent('dragend', {
-            bubbles: true, cancelable: true, dataTransfer,
-        }));
-        return active;
-    });
-    expect(highlighted).toBe(true);
+    const source = page.locator('#fmLeftList .fm-file-item[data-index="0"]');
+    const target = page.locator('#fmLeftList .fm-file-item[data-index="1"]');
+    await source.dragTo(target);
     await expect.poll(() => page.evaluate(() => (
         window.__fileWorkspaceEvents.find(item => item.event === 'rename_file')?.payload
     ))).toMatchObject({

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -254,6 +254,17 @@ async function seedLinuxSession(page, options = {}) {
                     });
                     return window.socket;
                 }
+                if (event === 'rename_file') {
+                    const acknowledgement = rest.find(value => typeof value === 'function');
+                    acknowledgement?.({
+                        success: true,
+                        source_id: payload.source_id,
+                        old_path: payload.old_path,
+                        new_path: payload.new_path,
+                        request_id: payload.request_id,
+                    });
+                    return window.socket;
+                }
                 if (['ssh_input', 'ssh_resize'].includes(event)) return window.socket;
             }
             return originalEmit(event, payload, ...rest);
@@ -477,6 +488,29 @@ test('single-session workspace keeps terminal primary with on-demand Files, Diag
     await expect(filesTab).toBeEnabled();
     await expect(filesTab).toHaveAttribute('aria-selected', 'false');
     await expect(page.locator('#sessionFilesPanel')).toBeHidden();
+    await assertNoExternalRequests(page);
+});
+
+test('embedded Workspace SFTP moves a file by dropping it onto a sibling folder', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page);
+
+    await expect(page.locator('#sessionFilesPanel')).toBeVisible();
+    await expect(page.locator('[data-pane-action="move"]')).toHaveCount(0);
+    await expect(page.locator('#fmTransferBetween')).toBeHidden();
+
+    const source = page.locator('#fmLeftList .fm-file-item[data-index="1"]');
+    const target = page.locator('#fmLeftList .fm-file-item[data-index="0"]');
+    await source.dragTo(target);
+
+    await expect.poll(() => page.evaluate(() => (
+        window.__workspaceEvents.find(event => event.event === 'rename_file')?.payload
+    ))).toMatchObject({
+        source_id: 'sftp-session:workspace-linux',
+        old_path: '/srv/webssh/current/compose.yaml',
+        new_path: '/srv/webssh/current/releases/compose.yaml',
+    });
+    await expect(page.locator('.fm-directory-drop-target')).toHaveCount(0);
     await assertNoExternalRequests(page);
 });
 

--- a/tests/js/sftp-transfer-queue.test.js
+++ b/tests/js/sftp-transfer-queue.test.js
@@ -1439,7 +1439,7 @@ test('workspace operation distinguishes same-source move from cross-source copy'
     assert.equal(manager.canTransferBetweenPanes('left', 'right'), true);
 });
 
-test('same-source move hides the directional action and gives a drag hint', () => {
+test('one contextual inter-pane action follows the active selection', () => {
     const previousDocument = global.document;
     const hint = { textContent: '' };
     const icon = { textContent: '' };
@@ -1447,6 +1447,8 @@ test('same-source move hides the directional action and gives a drag hint', () =
     const button = {
         dataset: {},
         title: '',
+        disabled: true,
+        hidden: true,
         classList: classList(),
         querySelector(selector) {
             return selector === '.material-icons' ? icon : text;
@@ -1455,7 +1457,9 @@ test('same-source move hides the directional action and gives a drag hint', () =
     };
     global.document = {
         getElementById(id) {
-            return id === 'fmTransferHint' ? hint : null;
+            if (id === 'fmTransferHint') return hint;
+            if (id === 'fmTransferBetween') return button;
+            return null;
         },
         querySelectorAll() { return []; },
         querySelector() { return null; },
@@ -1479,22 +1483,33 @@ test('same-source move hides the directional action and gives a drag hint', () =
     );
     Object.assign(manager, {
         displayMode: 'modal',
+        activePane: 'right',
         t(_key, fallback) { return fallback; },
     });
 
     try {
-        manager.updateWorkspaceOperationButton(button, 'move', 'LeftToRight');
         manager.updateWorkspaceActions();
 
-        assert.equal(icon.textContent, 'drive_file_move');
+        assert.equal(icon.textContent, 'arrow_forward');
         assert.equal(text.textContent, 'Move');
         assert.equal(button.title, 'Move left to right');
-        assert.equal(button.hidden, true);
-        assert.equal(hint.textContent, 'Drag items onto a folder to move them');
+        assert.equal(button.hidden, false);
+        assert.equal(button.disabled, false);
+        assert.equal(button.dataset.sourcePane, 'left');
+        assert.equal(hint.textContent, 'Move 1 selected');
 
         manager.panes.left.selected.clear();
         manager.updateWorkspaceActions();
-        assert.equal(hint.textContent, 'Drag items onto a folder to move them');
+        assert.equal(button.hidden, true);
+        assert.equal(button.disabled, true);
+        assert.equal(hint.textContent, 'Select files');
+
+        manager.panes.right.files = [{ name: 'archive.txt', is_dir: false }];
+        manager.panes.right.selected.add(0);
+        manager.updateWorkspaceActions();
+        assert.equal(icon.textContent, 'arrow_back');
+        assert.equal(button.hidden, false);
+        assert.equal(button.dataset.sourcePane, 'right');
     } finally {
         global.document = previousDocument;
     }
@@ -1734,6 +1749,32 @@ test('same-source drag advertises a move instead of a copy', () => {
 
     manager.handleDragStart({ dataTransfer }, 'left', 0);
 
+    assert.equal(dataTransfer.effectAllowed, 'move');
+});
+
+test('embedded same-pane drag advertises a move without a second pane', () => {
+    const manager = Object.create(SFTPFileManager.prototype);
+    manager.initializeWorkspaceState();
+    const item = { name: 'report.txt', is_dir: false };
+    manager.panes.left = filePane(manager, 'sftp-session:embedded', {
+        path: '/source',
+        files: [item, { name: 'archive', is_dir: true }],
+        selected: new Set([0]),
+    });
+    manager.panes.right = manager.createEmptyPaneState();
+    Object.assign(manager, {
+        displayMode: 'embedded',
+        draggedItems: [],
+        dragSource: null,
+    });
+    const dataTransfer = {
+        effectAllowed: '',
+        setData() {},
+    };
+
+    manager.handleDragStart({ dataTransfer }, 'left', 0);
+
+    assert.equal(manager.workspace.layout, 'single');
     assert.equal(dataTransfer.effectAllowed, 'move');
 });
 

--- a/tests/test_file_manager_source_ui.py
+++ b/tests/test_file_manager_source_ui.py
@@ -71,6 +71,10 @@ def test_file_manager_exposes_folder_drop_move_and_concise_smb_help():
     assert 'data-pane-action="move"' not in source
     assert 'setupDirectoryDropTarget(item, pane, index)' in source
     assert 'moveSelectedToDirectory(pane, targetIndex, selectedItems)' in source
+    assert source.count('id="fmTransferBetween"') == 1
+    assert 'id="fmTransferRight"' not in source
+    assert 'id="fmTransferLeft"' not in source
+    assert 'canStartSamePaneMove(pane)' in source
     assert 'SFTP-File-Workspace-and-Transfers' in template
     assert 'target="_blank" rel="noopener noreferrer"' in template
     assert 'For Active Directory or TrueNAS, try DNS domain' not in template

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -44,7 +44,7 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
         "filename='js/session-manager.js'": '?v=12',
         "filename='js/terminal-manager.js'": '?v=10',
         "filename='js/smb-source-dialog.js'": '?v=5',
-        "filename='js/sftp-file-manager.js'": '?v=31',
+        "filename='js/sftp-file-manager.js'": '?v=32',
         "filename='js/jump-host-manager.js'": '?v=4',
         "filename='js/command-library.js'": '?v=4',
         "filename='js/command-set-manager.js'": '?v=6',


### PR DESCRIPTION
## Summary

- Enable drag-and-drop moves into folders within the same File Manager pane and the embedded Workspace SFTP browser.
- Replace the duplicate directional controls with one contextual inter-pane Move/Transfer button that is shown only for a valid selection and operation.
- Keep embedded Workspace SFTP free of a Move toolbar action or target-browser workflow, and document the drag behavior.

This implements the remaining file-management UI feedback from [Discussion #99](https://github.com/bifrost0x/webssh/discussions/99).

## Testing

- JavaScript test suite: 33 passed
- Focused Python UI/template suite: 38 passed
- Targeted Playwright file-workspace and embedded Workspace SFTP scenarios: 3 passed
- ESLint on the changed JavaScript and E2E files
- `git diff --check`