### PR TITLE
ci: consolidate and parallelize the test suite

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,7 @@ jobs:
 
   build-and-push:
     needs: security-scan
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -37,7 +38,6 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,11 +68,13 @@ jobs:
             VCS_REF=${{ github.sha }}
           sbom: true
           provenance: mode=max
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=security-amd64
+            type=gha,scope=security-arm64
+            type=gha,scope=publish
+          cache-to: type=gha,mode=max,scope=publish
 
       - name: Verify published image and record immutable identity
-        if: github.event_name != 'pull_request'
         shell: bash
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
@@ -89,7 +91,6 @@ jobs:
             > image-release.json
 
       - name: Upload immutable image identity
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-release-${{ github.sha }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -111,3 +111,17 @@ jobs:
           path: trivy-results-arm64.json
           if-no-files-found: error
           retention-days: 14
+
+  image-security:
+    needs: [image-security-amd64, image-security-arm64]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Require all architecture scans
+        env:
+          AMD64_RESULT: ${{ needs.image-security-amd64.result }}
+          ARM64_RESULT: ${{ needs.image-security-arm64.result }}
+        run: |
+          test "$AMD64_RESULT" = success
+          test "$ARM64_RESULT" = success

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,15 +10,13 @@ permissions:
   contents: read
 
 jobs:
-  image-security:
+  image-security-amd64:
+    name: Image security (AMD64)
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -31,18 +29,8 @@ jobs:
           load: true
           pull: true
           tags: webssh-security:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build ARM64 scan candidate
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          platforms: linux/arm64
-          pull: true
-          outputs: type=docker,dest=/tmp/webssh-arm64.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=security-amd64
+          cache-to: type=gha,mode=max,scope=security-amd64
 
       - name: Generate SPDX JSON SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -68,6 +56,39 @@ jobs:
           scanners: vuln
           trivyignores: .trivyignore.yaml
 
+      - name: Upload AMD64 Trivy result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-amd64-${{ github.sha }}
+          path: trivy-results-amd64.json
+          if-no-files-found: error
+          retention-days: 14
+
+  image-security-arm64:
+    name: Image security (ARM64)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Build ARM64 scan candidate
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          platforms: linux/arm64
+          pull: true
+          outputs: type=docker,dest=/tmp/webssh-arm64.tar
+          cache-from: type=gha,scope=security-arm64
+          cache-to: type=gha,mode=max,scope=security-arm64
+
       - name: Scan ARM64 fixable high and critical vulnerabilities
         if: ${{ always() }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -82,11 +103,11 @@ jobs:
           scanners: vuln
           trivyignores: .trivyignore.yaml
 
-      - name: Upload Trivy result
+      - name: Upload ARM64 Trivy result
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: trivy-${{ github.sha }}
-          path: trivy-results-*.json
+          name: trivy-arm64-${{ github.sha }}
+          path: trivy-results-arm64.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Run disposable encrypted SMB integration tests
         run: python scripts/run_smb_integration_tests.py
 
-  browser-e2e:
+  browser-e2e-shards:
     needs: dispatch-integrity
     name: browser-e2e (${{ matrix.shard }}/2)
     runs-on: ubuntu-24.04
@@ -282,6 +282,19 @@ jobs:
           path: test-results/
           if-no-files-found: ignore
           retention-days: 7
+
+  browser-e2e:
+    needs: browser-e2e-shards
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Require all browser shards
+        env:
+          SHARD_RESULT: ${{ needs.browser-e2e-shards.result }}
+        run: test "$SHARD_RESULT" = success
 
   container-threading-smoke:
     needs: dispatch-integrity

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,19 +72,6 @@ jobs:
             check_name: pytest
           - python_version: '3.11'
             check_name: pytest (Python 3.11 minimum)
-    env:
-      TEST_REDIS_URL: redis://localhost:6379/15
-    services:
-      redis:
-        image: redis:7-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -109,7 +96,13 @@ jobs:
           python -m pip install --require-hashes -r requirements-test.txt
 
       - name: Run tests
-        run: pytest tests/ -v
+        run: >-
+          pytest tests/
+          --ignore=tests/integration
+          -q
+          -n 2
+          --dist=loadscope
+          --durations=30
 
   redis-rate-limiter:
     needs: dispatch-integrity
@@ -161,7 +154,10 @@ jobs:
           python -m pip install --require-hashes -r requirements-test.txt
 
       - name: Run Redis rate limiter tests
-        run: pytest tests/test_rate_limiter.py -v
+        run: >-
+          pytest
+          tests/test_rate_limiter.py::test_real_redis_does_not_store_denied_requests
+          -q
 
   ssh-integration:
     needs: dispatch-integrity
@@ -215,9 +211,22 @@ jobs:
 
   browser-e2e:
     needs: dispatch-integrity
+    name: browser-e2e (${{ matrix.shard }}/2)
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            e2e_port: 4173
+            run_static_checks: true
+          - shard: 2
+            e2e_port: 4174
+            run_static_checks: false
+    env:
+      WEBSSH_E2E_PORT: ${{ matrix.e2e_port }}
 
     steps:
       - name: Checkout repository
@@ -252,22 +261,24 @@ jobs:
         run: npm ci
 
       - name: Check vendored frontend assets
+        if: matrix.run_static_checks
         run: npm run vendor:check
 
       - name: Run JavaScript unit tests
+        if: matrix.run_static_checks
         run: npm run test:js
 
       - name: Install locked Playwright Chromium
         run: npx playwright install --with-deps chromium
 
       - name: Run required local browser gate
-        run: npm run test:e2e
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/2
 
       - name: Upload browser failure evidence
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: browser-e2e-failure
+          name: browser-e2e-${{ matrix.shard }}-failure
           path: test-results/
           if-no-files-found: ignore
           retention-days: 7

--- a/docs/wiki/Development-and-Testing.md
+++ b/docs/wiki/Development-and-Testing.md
@@ -38,10 +38,15 @@ Do not hand-edit generated lock files. A dependency change must update the input
 Run the suite with:
 
 ```powershell
-.\.venv\Scripts\python.exe -m pytest tests -q
+.\.venv\Scripts\python.exe -m pytest tests --ignore=tests/integration -q -n 2 --dist=loadscope
 ```
 
-The maintained gates execute tests on Python 3.11 and 3.14, exercise Redis 7/8 rate limiting, and include disposable OpenSSH integration. Targeted tests are useful while developing, but they do not replace the relevant full gate before release.
+The pytest harness uses a reduced bcrypt work factor to keep authentication-heavy
+tests fast. An isolated subprocess contract verifies that normal application
+processes retain bcrypt's production work factor. The maintained gates execute
+tests on Python 3.11 and 3.14, exercise Redis 7/8 rate limiting, and include
+disposable OpenSSH integration. Targeted tests are useful while developing, but
+they do not replace the relevant full gate before release.
 
 ## Frontend dependencies
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,8 @@ const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
 
 module.exports = {
     testDir: './tests/e2e',
-    fullyParallel: false,
+    // Test-level sharding keeps both isolated CI servers evenly loaded.
+    fullyParallel: true,
     workers: 1,
     forbidOnly: true,
     retries: process.env.CI ? 1 : 0,

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -1,3 +1,4 @@
 # Direct test dependency. Runtime constraints are included from requirements.in.
 -r requirements.in
 pytest==9.1.1
+pytest-xdist==3.8.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -434,6 +434,10 @@ dnspython==2.8.0 \
     --hash=sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af \
     --hash=sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f
     # via -r requirements.in
+execnet==2.1.2 \
+    --hash=sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd \
+    --hash=sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
+    # via pytest-xdist
 flask==3.1.3 \
     --hash=sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb \
     --hash=sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c
@@ -743,6 +747,12 @@ pyspnego==0.12.1 \
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
     --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
+    # via
+    #   -r requirements-test.in
+    #   pytest-xdist
+pytest-xdist==3.8.0 \
+    --hash=sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88 \
+    --hash=sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1
     # via -r requirements-test.in
 python-dotenv==1.2.3 \
     --hash=sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9 \

--- a/scripts/dependabot_vendor.py
+++ b/scripts/dependabot_vendor.py
@@ -126,7 +126,10 @@ def validate(event, pull_request, files, jobs):
     job_items = jobs.get('jobs')
     _require(isinstance(job_items, list), 'workflow jobs have an invalid shape')
     failed_vendor_check = any(
-        job.get('name') == 'browser-e2e'
+        re.fullmatch(
+            r'browser-e2e(?: \([1-9][0-9]*/[1-9][0-9]*\))?',
+            str(job.get('name', '')),
+        )
         and job.get('conclusion') == 'failure'
         and any(
             step.get('name') == 'Check vendored frontend assets'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,25 @@ import tempfile
 from pathlib import Path
 from urllib.parse import urlsplit
 
+import bcrypt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, rsa
+
+_PRODUCTION_BCRYPT_GENSALT = bcrypt.gensalt
+_TEST_BCRYPT_ROUNDS = 4
+
+
+def _fast_test_gensalt(rounds=12, prefix=b'2b'):
+    """Keep password behavior realistic without paying production cost per test."""
+    del rounds
+    return _PRODUCTION_BCRYPT_GENSALT(
+        rounds=_TEST_BCRYPT_ROUNDS,
+        prefix=prefix,
+    )
+
+
+bcrypt.gensalt = _fast_test_gensalt
 
 _SESSION_DATA_DIRECTORY = tempfile.TemporaryDirectory(
     prefix='webssh-pytest-session-',
@@ -64,6 +80,7 @@ for _name, _value in _TEST_ENVIRONMENT.items():
 
 def pytest_unconfigure(config):
     del config
+    bcrypt.gensalt = _PRODUCTION_BCRYPT_GENSALT
     for name, original in _ORIGINAL_TEST_ENVIRONMENT.items():
         if original is None:
             os.environ.pop(name, None)

--- a/tests/e2e/product-captures.spec.js
+++ b/tests/e2e/product-captures.spec.js
@@ -647,10 +647,36 @@ test('captures the seeded key management surface at Full HD scale', async ({ pag
 
     expect(page.viewportSize()).toEqual(DESKTOP_VIEWPORT);
 
+    await page.evaluate(() => {
+        window.__captureKeyListRequests = 0;
+        window.__captureKeyListResponses = 0;
+        window.__captureKeyListOriginalEmit = window.socket.emit.bind(window.socket);
+        window.socket.emit = function captureKeyListRequests(event, ...args) {
+            if (event === 'list_keys') window.__captureKeyListRequests += 1;
+            return window.__captureKeyListOriginalEmit(event, ...args);
+        };
+        window.__captureKeyListResponseHandler = () => {
+            window.__captureKeyListResponses += 1;
+        };
+        window.socket.on('keys_list', window.__captureKeyListResponseHandler);
+    });
     await openKeyManagement(page);
-    await expect.poll(() => page.evaluate(() => (
-        window.ProfileManager.keys[0]?.name || ''
-    ))).toBe('E2E usable key');
+    await expect.poll(() => page.evaluate(() => ({
+        loaded: window.__captureKeyListRequests > 0
+            && window.__captureKeyListResponses === window.__captureKeyListRequests,
+        name: window.ProfileManager.keys[0]?.name || '',
+    }))).toEqual({
+        loaded: true,
+        name: 'E2E usable key',
+    });
+    await page.evaluate(() => {
+        window.socket.off('keys_list', window.__captureKeyListResponseHandler);
+        window.socket.emit = window.__captureKeyListOriginalEmit;
+        delete window.__captureKeyListOriginalEmit;
+        delete window.__captureKeyListResponseHandler;
+        delete window.__captureKeyListRequests;
+        delete window.__captureKeyListResponses;
+    });
     await sanitizeSeededCatalog(page);
     await expect(page.locator('#keyManagementTitle')).toHaveText('Manage SSH Keys');
     await expect(page.locator('#keysList')).toContainText('Operations Ed25519');

--- a/tests/e2e/theme-system.spec.js
+++ b/tests/e2e/theme-system.spec.js
@@ -39,7 +39,11 @@ async function openThemeSettings(page) {
 }
 
 async function selectTheme(page, selector, themeId) {
+    const alreadySelected = await selector.inputValue() === themeId;
     await selector.selectOption(themeId);
+    if (alreadySelected) {
+        await selector.dispatchEvent('change');
+    }
     await expect(page.locator('#settingsPreferenceStatus')).toHaveText('Theme saved.');
     await expect(selector).toBeEnabled();
     await expect(page.locator('body')).toHaveAttribute('data-theme', themeId);

--- a/tests/e2e/theme-system.spec.js
+++ b/tests/e2e/theme-system.spec.js
@@ -34,17 +34,30 @@ async function openThemeSettings(page) {
     await page.getByRole('button', { name: 'Account menu' }).click();
     await page.getByRole('link', { name: 'Settings' }).click();
     await expect(page).toHaveURL(/\/settings#preferences$/);
+    await page.waitForLoadState('load');
     await expect(page.getByRole('heading', { name: 'Preferences' })).toBeVisible();
     await page.evaluate(() => document.fonts.ready);
+    await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).fontFamily))
+        .toContain('Inter');
 }
 
 async function selectTheme(page, selector, themeId) {
+    const status = page.locator('#settingsPreferenceStatus');
+    await expect(selector).toBeEnabled();
     const alreadySelected = await selector.inputValue() === themeId;
+    await status.evaluate(element => {
+        element.textContent = '';
+    });
+    const preferenceResponse = page.waitForResponse(response => (
+        response.request().method() === 'POST'
+        && new URL(response.url()).pathname.endsWith('/api/account/preferences')
+    ));
     await selector.selectOption(themeId);
     if (alreadySelected) {
         await selector.dispatchEvent('change');
     }
-    await expect(page.locator('#settingsPreferenceStatus')).toHaveText('Theme saved.');
+    expect((await preferenceResponse).ok()).toBe(true);
+    await expect(status).toHaveText('Theme saved.');
     await expect(selector).toBeEnabled();
     await expect(page.locator('body')).toHaveAttribute('data-theme', themeId);
     await expect.poll(() => page.evaluate(() => localStorage.getItem('websshTheme')))

--- a/tests/e2e/theme-system.spec.js
+++ b/tests/e2e/theme-system.spec.js
@@ -38,6 +38,15 @@ async function openThemeSettings(page) {
     await page.evaluate(() => document.fonts.ready);
 }
 
+async function selectTheme(page, selector, themeId) {
+    await selector.selectOption(themeId);
+    await expect(page.locator('#settingsPreferenceStatus')).toHaveText('Theme saved.');
+    await expect(selector).toBeEnabled();
+    await expect(page.locator('body')).toHaveAttribute('data-theme', themeId);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('websshTheme')))
+        .toBe(themeId);
+}
+
 async function readThemeState(page) {
     return page.evaluate(() => {
         const bodyStyle = getComputedStyle(document.body);
@@ -192,8 +201,7 @@ test('all themes share one typography system without moving the Settings Center'
     ]);
 
     for (const themeId of THEME_IDS) {
-        await selector.selectOption(themeId);
-        await expect(page.locator('body')).toHaveAttribute('data-theme', themeId);
+        await selectTheme(page, selector, themeId);
         const state = await readThemeState(page);
         expect(state.fontFamily).toBe(baseline.fontFamily);
         expectStableGeometry(state.geometry, baseline.geometry);
@@ -203,7 +211,11 @@ test('all themes share one typography system without moving the Settings Center'
 test('Paper Ops uses a tinted Blueprint Steel canvas instead of white surfaces', async ({ page }) => {
     await login(page);
     await openThemeSettings(page);
-    await page.getByRole('combobox', { name: 'Theme' }).selectOption('paper');
+    await selectTheme(
+        page,
+        page.getByRole('combobox', { name: 'Theme' }),
+        'paper',
+    );
 
     const state = await readThemeState(page);
     expect(state.colors.secondaryLuminance).toBeLessThan(0.9);
@@ -221,7 +233,7 @@ test('professional themes use restrained local backgrounds', async ({ page }) =>
     const selector = page.getByRole('combobox', { name: 'Theme' });
 
     for (const [themeId, assetName] of Object.entries(PROFESSIONAL_THEME_BACKGROUNDS)) {
-        await selector.selectOption(themeId);
+        await selectTheme(page, selector, themeId);
         const state = await readThemeState(page);
         expect(state.background.image).toContain(assetName);
         expect(state.background.opacity).toBeGreaterThanOrEqual(0.04);
@@ -236,9 +248,11 @@ test('professional themes use restrained local backgrounds', async ({ page }) =>
 test('the last selected theme styles the next login screen', async ({ page }) => {
     await login(page);
     await openThemeSettings(page);
-    await page.getByRole('combobox', { name: 'Theme' }).selectOption('paper');
-    await expect.poll(() => page.evaluate(() => localStorage.getItem('websshTheme')))
-        .toBe('paper');
+    await selectTheme(
+        page,
+        page.getByRole('combobox', { name: 'Theme' }),
+        'paper',
+    );
     await page.getByRole('link', { name: 'Back to Terminal' }).click();
     const logoutStatus = await page.evaluate(async () => {
         const csrf = document.querySelector('meta[name="csrf-token"]').content;
@@ -288,7 +302,7 @@ test('fun themes use local decorative backgrounds that cannot intercept input', 
     const selector = page.getByRole('combobox', { name: 'Theme' });
 
     for (const [themeId, assetName] of Object.entries(FUN_THEME_BACKGROUNDS)) {
-        await selector.selectOption(themeId);
+        await selectTheme(page, selector, themeId);
         const state = await readThemeState(page);
         expect(state.background.image).toContain(assetName);
         expect(state.background.opacity).toBeGreaterThanOrEqual(0.08);
@@ -306,7 +320,7 @@ test('muted copy stays readable and Matrix keeps success distinct from its ident
     const selector = page.getByRole('combobox', { name: 'Theme' });
 
     for (const themeId of THEME_IDS) {
-        await selector.selectOption(themeId);
+        await selectTheme(page, selector, themeId);
         const state = await readThemeState(page);
         expect(state.colors.mutedContrast).toBeGreaterThanOrEqual(4.5);
         if (themeId === 'emerald-matrix') {

--- a/tests/test_dependabot_vendor.py
+++ b/tests/test_dependabot_vendor.py
@@ -117,6 +117,16 @@ def test_valid_dependabot_npm_run_emits_sanitized_push_coordinates(tmp_path):
     ]
 
 
+def test_valid_sharded_browser_job_is_accepted(tmp_path):
+    def mutate(_event, _pull_request, _files, jobs):
+        jobs['jobs'][0]['name'] = 'browser-e2e (1/2)'
+
+    result, output = _run_validator(tmp_path, mutate)
+
+    assert result.returncode == 0, result.stderr
+    assert output.exists()
+
+
 def test_gate_rejects_pr_code_outside_manifests_and_generated_vendor(tmp_path):
     def add_untrusted_script(_event, pull_request, files, _jobs):
         files.append({'filename': 'scripts/vendor.js', 'status': 'modified'})

--- a/tests/test_dependency_policy.py
+++ b/tests/test_dependency_policy.py
@@ -245,7 +245,7 @@ def test_python_runtime_contract_stays_synchronized():
     ]
     assert "python-version: ${{ matrix.python_version }}" in pytest_job
 
-    for job_name in ("ssh-integration", "browser-e2e"):
+    for job_name in ("ssh-integration", "browser-e2e-shards"):
         assert (
             f"python-version: '{PRODUCTION_PYTHON}'"
             in workflow_job(workflow, job_name)

--- a/tests/test_password_hashing_policy.py
+++ b/tests/test_password_hashing_policy.py
@@ -1,0 +1,46 @@
+"""Contracts for fast test hashing and production bcrypt strength."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _bcrypt_rounds(password_hash):
+    return int(password_hash.split('$')[2])
+
+
+def test_pytest_password_hashing_uses_the_fast_work_factor():
+    from app.models import User
+
+    user = User(username='pytest-hash-policy')
+    user.set_password('test-password')
+
+    assert _bcrypt_rounds(user.password_hash) == 4
+    assert user.check_password('test-password') is True
+
+
+def test_production_password_hashing_keeps_the_default_work_factor():
+    """The pytest-only patch must never weaken a normal application process."""
+    probe = subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            (
+                'from app.models import User; '
+                "user = User(username='production-hash-policy'); "
+                "user.set_password('test-password'); "
+                "assert user.check_password('test-password'); "
+                "print(user.password_hash.split('$')[2])"
+            ),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.splitlines()[-1] == '12'

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -164,7 +164,7 @@ def test_container_build_inputs_and_ci_services_are_digest_pinned():
 
     tests_workflow = (WORKFLOWS / 'tests.yml').read_text(encoding='utf-8')
     redis_references = re.findall(r'redis:[78]-alpine[^\s#]*', tests_workflow)
-    assert len(redis_references) >= 3
+    assert len(redis_references) == 2
     assert all(IMAGE_DIGEST.search(reference) for reference in redis_references)
 
 
@@ -184,6 +184,8 @@ def test_security_workflow_gates_publish_and_preserves_scan_evidence():
     assert re.search(r'permissions:\s*\n\s+contents:\s+read\b', security)
     assert not re.search(r'^\s+\w[\w-]*:\s+write\b', security, re.MULTILINE)
     assert 'docker/setup-qemu-action@' in security
+    assert 'image-security-amd64:' in security
+    assert 'image-security-arm64:' in security
     assert re.search(r'platforms:\s*linux/amd64\b', security)
     assert re.search(r'platforms:\s*linux/arm64\b', security)
     assert (
@@ -216,6 +218,12 @@ def test_security_workflow_gates_publish_and_preserves_scan_evidence():
     )
     assert re.search(
         r'build-and-push:.*?\n\s+needs:\s+security-scan\b',
+        publish,
+        re.DOTALL,
+    )
+    assert re.search(
+        r'build-and-push:.*?\n\s+needs:\s+security-scan\s*\n'
+        r"\s+if:\s+github\.event_name\s+!=\s+'pull_request'",
         publish,
         re.DOTALL,
     )
@@ -472,3 +480,20 @@ def test_browser_ci_runs_javascript_units_before_playwright():
     browser_step = browser_job.index('run: npm run test:e2e')
 
     assert unit_step < browser_step
+
+
+def test_slow_test_gates_are_sharded_without_duplicate_redis_unit_runs():
+    workflow = (WORKFLOWS / 'tests.yml').read_text(encoding='utf-8')
+    playwright = (ROOT / 'playwright.config.js').read_text(encoding='utf-8')
+
+    assert '--ignore=tests/integration' in workflow
+    assert '-n 2' in workflow
+    assert '--dist=loadscope' in workflow
+    assert '--durations=30' in workflow
+    assert workflow.count(
+        'tests/test_rate_limiter.py::'
+        'test_real_redis_does_not_store_denied_requests'
+    ) == 1
+    assert 'name: browser-e2e (${{ matrix.shard }}/2)' in workflow
+    assert 'npm run test:e2e -- --shard=${{ matrix.shard }}/2' in workflow
+    assert 'fullyParallel: true' in playwright

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -186,6 +186,13 @@ def test_security_workflow_gates_publish_and_preserves_scan_evidence():
     assert 'docker/setup-qemu-action@' in security
     assert 'image-security-amd64:' in security
     assert 'image-security-arm64:' in security
+    assert re.search(
+        r'image-security:\s*\n\s+needs:\s*'
+        r'\[image-security-amd64, image-security-arm64\]',
+        security,
+    )
+    assert 'test "$AMD64_RESULT" = success' in security
+    assert 'test "$ARM64_RESULT" = success' in security
     assert re.search(r'platforms:\s*linux/amd64\b', security)
     assert re.search(r'platforms:\s*linux/arm64\b', security)
     assert (
@@ -471,8 +478,8 @@ def test_workflows_use_an_explicit_runner_release():
 
 def test_browser_ci_runs_javascript_units_before_playwright():
     workflow = (WORKFLOWS / 'tests.yml').read_text(encoding='utf-8')
-    browser_job = workflow.split('  browser-e2e:', 1)[1].split(
-        '\n  container-threading-smoke:',
+    browser_job = workflow.split('  browser-e2e-shards:', 1)[1].split(
+        '\n  browser-e2e:',
         1,
     )[0]
 
@@ -496,4 +503,9 @@ def test_slow_test_gates_are_sharded_without_duplicate_redis_unit_runs():
     ) == 1
     assert 'name: browser-e2e (${{ matrix.shard }}/2)' in workflow
     assert 'npm run test:e2e -- --shard=${{ matrix.shard }}/2' in workflow
+    assert re.search(
+        r'\n  browser-e2e:\s*\n\s+needs:\s+browser-e2e-shards\b',
+        workflow,
+    )
+    assert 'test "$SHARD_RESULT" = success' in workflow
     assert 'fullyParallel: true' in playwright


### PR DESCRIPTION
## Summary

- reduce authentication-heavy pytest runtime with a pytest-only bcrypt work factor while preserving a subprocess contract for the production cost
- run the Python suite with two load-scope workers, keep disposable integrations in their dedicated jobs, and execute only the real Redis probe against Redis 7 and 8
- split Playwright into two isolated, test-level shards while running vendor and JavaScript checks once
- run AMD64 and ARM64 image security jobs in parallel, share their architecture caches with publishing, and skip the redundant non-publishing multi-architecture build on pull requests
- preserve Dependabot vendor recovery and add CI policy contracts for the consolidated layout

## Validation

- `2278 passed, 2 skipped` in `157.03s` with a fresh environment installed from the hash lock
- Playwright shard 1: `50 passed` in `2.7m`
- Playwright shard 2: `50 passed` in `2.8m`
- 34 JavaScript test files passed
- 10 vendored frontend assets verified
- 37 focused hashing, supply-chain, and Dependabot policy tests passed after the final workflow cleanup
- `requirements-test.txt` reproduced byte-for-byte with the CI-pinned uv 0.12.3
- all workflow YAML parsed successfully and `git diff --check` passed

## Expected impact

- local Python wall time decreased from 8:12 to 2:37 without removing functional coverage
- the slower browser shard completes in about 2:48 instead of the current 6:32 Playwright step
- pull requests no longer repeat the multi-architecture image build after both scan candidates have already been built

Production bcrypt behavior is unchanged. The isolated production contract performs a real hash and verification and asserts the current cost factor of 12.
