### PR TITLE
Stabilize mobile Settings Center E2E readiness

### DIFF
--- a/tests/e2e/account-menu.spec.js
+++ b/tests/e2e/account-menu.spec.js
@@ -87,6 +87,7 @@ test('account menu and settings stay inside a mobile viewport', async ({ page })
 
     await page.locator('#accountSettingsBtn').click();
     await expect(page).toHaveURL(/\/settings#preferences$/);
+    await expect(page.locator('[data-account-panel="preferences"]')).not.toHaveClass(/\bhidden\b/);
     await expect(page.locator('#scrollbackInput')).toBeVisible();
     await expect(page.locator('#confirmSessionCloseInput')).toBeVisible();
     const layout = await page.evaluate(() => ({


### PR DESCRIPTION
## Summary
- wait for the Preferences panel to be activated by the Settings Center navigation before measuring mobile layout
- avoid treating unstyled, pre-initialization markup as the rendered page
- keep production UI and layout behavior unchanged

## Root cause
The failed post-merge run measured document width while the Settings Center CSS and JavaScript were still loading. Visibility checks could pass before the hidden CSS rule was available, so the test observed the intrinsic width of inactive administration markup.

## Verification
- affected mobile test repeated 10 times: 10 passed
- affected test with a simulated 500 ms stylesheet delay: passed
- complete account-menu.spec.js: 3 passed