### PR TITLE
fix(security): retry queued SSH input backpressure

### DIFF
--- a/static/js/ssh-input.js
+++ b/static/js/ssh-input.js
@@ -48,8 +48,8 @@
         root.showNotification?.(message || 'SSH input could not be sent', 'error');
     }
 
-    async function transmit(sessionId, chunks) {
-        if (chunks.length === 1) {
+    async function transmit(sessionId, chunks, acknowledgeSingle = false) {
+        if (chunks.length === 1 && !acknowledgeSingle) {
             root.socket.emit('ssh_input', {session_id: sessionId, data: chunks[0]});
             return true;
         }
@@ -100,7 +100,9 @@
         }
 
         const queued = pending
-            ? pending.catch(() => false).then(() => transmit(sessionId, chunks))
+            ? pending.catch(() => false).then(
+                () => transmit(sessionId, chunks, true),
+            )
             : transmit(sessionId, chunks);
         sessionQueues.set(sessionId, queued);
         queued.finally(() => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1407,7 +1407,7 @@
     <script src="{{ url_for('static', filename='js/command-workspace.js') }}?v=3"></script>
 
     <script src="{{ url_for('static', filename='js/terminal-manager.js') }}?v=12"></script>
-    <script src="{{ url_for('static', filename='js/ssh-input.js') }}?v=1"></script>
+    <script src="{{ url_for('static', filename='js/ssh-input.js') }}?v=2"></script>
     <script src="{{ url_for('static', filename='js/session-manager.js') }}?v=12"></script>
     <script src="{{ url_for('static', filename='js/workspace-layout-controller.js') }}?v=7"></script>
     <script src="{{ url_for('static', filename='js/mobile-app-shell.js') }}?v=7"></script>

--- a/tests/js/ssh-input.test.js
+++ b/tests/js/ssh-input.test.js
@@ -104,6 +104,37 @@ test('concurrent typing waits behind a backpressured paste for one session', asy
     assert.equal(delivered.join(''), `${paste}k`);
 });
 
+test('queued single-chunk input retries backpressure after a paste', async () => {
+    const delivered = [];
+    let queuedAttempts = 0;
+    const transport = loadSSHInput({
+        emit(_event, payload, acknowledgement) {
+            if (payload.data === 'k') {
+                queuedAttempts += 1;
+                if (queuedAttempts === 1) {
+                    acknowledgement?.({
+                        success: false,
+                        code: 'ssh_input_backpressure',
+                        retry_after_ms: 1,
+                    });
+                    return;
+                }
+            }
+            delivered.push(payload.data);
+            acknowledgement?.({success: true});
+        },
+    });
+    const paste = 'x'.repeat(70 * 1024);
+
+    const pasteResult = transport.send('session-1', paste);
+    const typingResult = transport.send('session-1', 'k');
+
+    assert.equal(await pasteResult, true);
+    assert.equal(await typingResult, true);
+    assert.equal(queuedAttempts, 2);
+    assert.equal(delivered.join(''), `${paste}k`);
+});
+
 test('client chunks at the effective server limit below 64 KiB', () => {
     const transport = loadSSHInput({emit() {}}, 4 * 1024);
     const chunks = transport.byteChunks('x'.repeat(10 * 1024));


### PR DESCRIPTION
## Summary

- retry an acknowledged single SSH input chunk when it was queued behind a large paste
- preserve the low-latency fire-and-forget path for normal, unqueued typing
- bump the SSH input asset cache version so deployed browsers receive the fix
- cover renewed backpressure on the queued single-chunk path with a regression test

## Context

This follows up on #175 and addresses the post-merge review finding that a keystroke queued behind a rate-limited paste could be dropped if the token bucket was still empty.

## Validation

- `node --test tests/js/*.test.js` — 35 passed
- `python -m pytest -q tests/test_ssh_input.py` — 6 passed
- `python -m pytest -q tests/test_profile_launcher_ui.py tests/test_key_management_ui.py` — 38 passed
- `git diff --check`
