### PR TITLE
Restore native touch scrolling in the mobile File Manager

### DIFF
--- a/static/css/sftp-file-manager.css
+++ b/static/css/sftp-file-manager.css
@@ -394,7 +394,7 @@
     overflow-x: hidden;
     padding: 8px;
     overscroll-behavior: contain;
-    touch-action: pan-y;
+    touch-action: auto;
     -webkit-overflow-scrolling: touch;
 }
 
@@ -409,7 +409,7 @@
     transition: all 0.15s ease;
     user-select: none;
     border: 1px solid transparent;
-    touch-action: pan-y;
+    touch-action: auto;
     -webkit-tap-highlight-color: transparent;
 }
 

--- a/static/css/sftp-file-manager.css
+++ b/static/css/sftp-file-manager.css
@@ -394,7 +394,7 @@
     overflow-x: hidden;
     padding: 8px;
     overscroll-behavior: contain;
-    touch-action: auto;
+    touch-action: manipulation;
     -webkit-overflow-scrolling: touch;
 }
 
@@ -409,7 +409,7 @@
     transition: all 0.15s ease;
     user-select: none;
     border: 1px solid transparent;
-    touch-action: auto;
+    touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
 
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}?v=19">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}?v=20">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=9">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
 </head>

--- a/tests/e2e/file-workspace.spec.js
+++ b/tests/e2e/file-workspace.spec.js
@@ -498,7 +498,7 @@ test.describe('mobile touch File Manager', () => {
             touchPoints: [],
         });
         await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
-        expect(scrollLayout.listTouchAction).toBe('auto');
+        expect(scrollLayout.listTouchAction).toBe('manipulation');
 
         const longPressFile = page.locator('#fmLeftList .fm-file-item[data-index="15"]');
         await longPressFile.scrollIntoViewIfNeeded();

--- a/tests/e2e/file-workspace.spec.js
+++ b/tests/e2e/file-workspace.spec.js
@@ -452,6 +452,21 @@ test.describe('mobile touch File Manager', () => {
             manager.renderPane('left');
         });
         const file = page.locator('#fmLeftList .fm-file-item[data-index="1"]');
+        const scrollLayout = await page.evaluate(() => {
+            const modalBody = document.querySelector('#sftpFileManager .modal-body');
+            const listElement = document.getElementById('fmLeftList');
+            return {
+                modalBodyOverflowY: getComputedStyle(modalBody).overflowY,
+                listOverflowY: getComputedStyle(listElement).overflowY,
+                listTouchAction: getComputedStyle(listElement).touchAction,
+                listClientHeight: listElement.clientHeight,
+                listScrollHeight: listElement.scrollHeight,
+            };
+        });
+        expect(scrollLayout.modalBodyOverflowY).toBe('hidden');
+        expect(scrollLayout.listOverflowY).toBe('auto');
+        expect(scrollLayout.listScrollHeight).toBeGreaterThan(scrollLayout.listClientHeight);
+
         await file.tap();
         await expect(file).toHaveClass(/selected/);
         await file.locator('.fm-file-checkbox').tap();
@@ -468,13 +483,22 @@ test.describe('mobile touch File Manager', () => {
         });
         await client.send('Input.dispatchTouchEvent', {
             type: 'touchMove',
-            touchPoints: [{ x, y: startY - 180 }],
+            touchPoints: [{ x: x + 24, y: startY - 2 }],
+        });
+        await client.send('Input.dispatchTouchEvent', {
+            type: 'touchMove',
+            touchPoints: [{ x: x + 22, y: startY - 90 }],
+        });
+        await client.send('Input.dispatchTouchEvent', {
+            type: 'touchMove',
+            touchPoints: [{ x: x + 18, y: startY - 180 }],
         });
         await client.send('Input.dispatchTouchEvent', {
             type: 'touchEnd',
             touchPoints: [],
         });
         await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
+        expect(scrollLayout.listTouchAction).toBe('auto');
 
         const longPressFile = page.locator('#fmLeftList .fm-file-item[data-index="15"]');
         await longPressFile.scrollIntoViewIfNeeded();

--- a/tests/test_profile_launcher_ui.py
+++ b/tests/test_profile_launcher_ui.py
@@ -33,7 +33,7 @@ def test_merged_profile_frontend_assets_have_distinct_cache_versions():
     template = read('templates/index.html')
     expected_versions = {
         "filename='css/style.css'": '?v=24',
-        "filename='css/sftp-file-manager.css'": '?v=19',
+        "filename='css/sftp-file-manager.css'": '?v=20',
         "filename='js/i18n.js'": '?v=42',
         "filename='js/command-workspace.js'": '?v=3',
         "filename='js/command-palette-utils.js'": '?v=1',


### PR DESCRIPTION
## Summary

- let the browser handle native File Manager pan gestures instead of axis-locking them to `pan-y`
- use `touch-action: manipulation` so diagonal gesture starts scroll while double-tap zoom stays suppressed
- preserve the existing tap, long-press, selection, and desktop drag-and-drop behavior
- exercise a realistic touch swipe that begins slightly sideways before moving vertically
- bump the File Manager stylesheet cache version

## Root cause

The touch regression test added in #177 used a perfectly vertical single-move gesture. With `touch-action: pan-y`, browsers may reject the complete pan when a real finger starts slightly horizontally, leaving the file list at `scrollTop` 0.

## Validation

- reproduced on merged main: realistic diagonal-start touch gesture failed with `scrollTop` 0
- fixed regression test: passed with `touch-action: manipulation`
- JavaScript test files: 35/35 passed
- focused Python/template tests: 37 passed
- File Manager and session workspace Playwright journeys: 22 passed
- ESLint passed
- `git diff --check` passed
