### PR TITLE
Restore scrolling in the embedded mobile File Manager

### DIFF
--- a/static/css/webssh-2.css
+++ b/static/css/webssh-2.css
@@ -1496,7 +1496,7 @@ body:has(.auth-container) {
 
     .workspace.layout-tablet .session-files-panel,
     .workspace.layout-mobile .session-files-panel {
-        display: block !important;
+        display: flex !important;
         position: absolute;
         top: 0;
         right: 0;
@@ -1504,6 +1504,7 @@ body:has(.auth-container) {
         z-index: 35;
         width: min(480px, 100%);
         max-width: 100%;
+        flex-direction: column;
         border-left: 1px solid var(--ws2-border);
         background: var(--ws2-surface);
         box-shadow: -18px 0 42px rgb(0 0 0 / 34%);

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}?v=9">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=30">
 </head>
 <body data-theme="{{ theme|default('glass') }}">
     <header class="header">

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=30">
 </head>
 <body data-theme="{{ theme }}">
     <div class="auth-shell">

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/sftp-file-manager.css') }}?v=20">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/session-workspace.css') }}?v=9">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=30">
 </head>
 <body data-theme="{{ theme|default('glass') }}" data-confirm-session-close="{{ 'true' if confirm_session_close else 'false' }}" data-disconnect-session-action="{{ disconnect_session_action }}" data-connection-history-scope="{{ connection_history_scope }}">
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}?v=3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=30">
 </head>
 <body data-theme="glass" data-use-theme-preference>
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}?v=2">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=30">
 </head>
 <body data-theme="glass" data-use-theme-preference>
     <script src="{{ url_for('static', filename='js/theme-preference.js') }}?v=1"></script>

--- a/templates/security.html
+++ b/templates/security.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/material-icons/material-icons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=24">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}?v=9">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=29">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/webssh-2.css') }}?v=30">
 </head>
 <body data-theme="{{ theme|default('glass') }}" data-ldap-managed="{{ 'true' if ldap_managed else 'false' }}" data-recovery-mode="{{ 'true' if recovery_mode else 'false' }}" data-account-mfa-enabled="{{ 'true' if account_mfa_enabled else 'false' }}" data-recovery-enabled="{{ 'true' if recovery_codes_enabled else 'false' }}" data-confirm-session-close="{{ 'true' if confirm_session_close else 'false' }}" data-disconnect-session-action="{{ disconnect_session_action }}">
     <header class="header">

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -547,6 +547,73 @@ test('360px mobile workspace keeps tools available and preserves context across 
     await sftpDock.click();
     await expect(page.locator('#sessionFilesPanel')).toBeVisible();
     await expect(sftpDock).toHaveClass(/active/);
+
+    await page.evaluate(() => {
+        const manager = window.sftpFileManager;
+        Object.assign(manager.panes.left, {
+            loading: false,
+            pendingDirectoryRequestId: null,
+            pendingDirectoryPath: null,
+            files: [
+                { name: 'releases', is_dir: true, size: 0 },
+                ...Array.from({ length: 30 }, (_, index) => ({
+                    name: `mobile-report-${String(index).padStart(2, '0')}.txt`,
+                    is_dir: false,
+                    size: 12 + index,
+                })),
+            ],
+        });
+        manager.updatePathInput('left', manager.panes.left.path);
+        manager.renderPane('left');
+    });
+
+    const embeddedList = page.locator('#sessionFilesPanel #fmLeftList');
+    const embeddedFile = embeddedList.locator('.fm-file-item[data-index="1"]');
+    await embeddedFile.click();
+    await expect(embeddedFile).toHaveClass(/selected/);
+
+    const embeddedScrollLayout = await page.evaluate(() => {
+        const panel = document.getElementById('sessionFilesPanel');
+        const mount = document.getElementById('sessionFilesMount');
+        const list = document.getElementById('fmLeftList');
+        return {
+            panelDisplay: getComputedStyle(panel).display,
+            panelHeight: panel.clientHeight,
+            mountHeight: mount.clientHeight,
+            listClientHeight: list.clientHeight,
+            listScrollHeight: list.scrollHeight,
+        };
+    });
+    expect(embeddedScrollLayout.listScrollHeight).toBeGreaterThan(
+        embeddedScrollLayout.listClientHeight,
+    );
+
+    const embeddedListBox = await embeddedList.boundingBox();
+    const touchClient = await page.context().newCDPSession(page);
+    const touchX = embeddedListBox.x + (embeddedListBox.width / 2);
+    const touchStartY = embeddedListBox.y + Math.min(embeddedListBox.height - 24, 300);
+    await touchClient.send('Input.dispatchTouchEvent', {
+        type: 'touchStart',
+        touchPoints: [{ x: touchX, y: touchStartY }],
+    });
+    await touchClient.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: touchX + 20, y: touchStartY - 2 }],
+    });
+    await touchClient.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: touchX + 18, y: touchStartY - 160 }],
+    });
+    await touchClient.send('Input.dispatchTouchEvent', {
+        type: 'touchEnd',
+        touchPoints: [],
+    });
+    await expect.poll(() => embeddedList.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
+    expect(embeddedScrollLayout.panelDisplay).toBe('flex');
+    expect(embeddedScrollLayout.mountHeight).toBeLessThanOrEqual(
+        embeddedScrollLayout.panelHeight,
+    );
+
     await metricsDock.click();
     await expect(page.locator('#sessionDiagnosticsOverlay')).toBeVisible();
     await expect(metricsDock).toHaveClass(/active/);

--- a/tests/test_webssh2_shell.py
+++ b/tests/test_webssh2_shell.py
@@ -118,7 +118,7 @@ def test_every_user_facing_page_uses_current_shared_asset_versions(app, client):
         response = client.get(path)
         assert response.status_code == 200
         assert b'css/style.css?v=24' in response.data
-        assert b'css/webssh-2.css?v=29' in response.data
+        assert b'css/webssh-2.css?v=30' in response.data
         assert b'js/i18n.js?v=42' in response.data
 
     client.post("/logout")
@@ -126,7 +126,7 @@ def test_every_user_facing_page_uses_current_shared_asset_versions(app, client):
         response = client.get(path)
         assert response.status_code == 200
         assert b'css/style.css?v=24' in response.data
-        assert b'css/webssh-2.css?v=29' in response.data
+        assert b'css/webssh-2.css?v=30' in response.data
         assert b'js/i18n.js?v=42' in response.data
 
 


### PR DESCRIPTION
## Summary
- keep mobile and tablet embedded SFTP panels as flex columns so the file mount can shrink
- restore a bounded native scroll container behind the mobile SFTP dock
- add a 360 px regression that selects a file and scrolls a 31-item embedded listing with a realistic touch gesture
- bump the shared workspace stylesheet cache version

## Root cause
The earlier touch regression covered the modal File Manager. The real mobile SFTP dock mounts the File Manager inside the session files panel. A more specific mobile rule changed that panel to block layout, overriding its flex layout. The file list therefore expanded to its full content height behind an overflow-clipped parent and had no scroll range.

## Validation
- reproduced on merged main: list clientHeight and scrollHeight were both 1360 px
- targeted embedded mobile regression: 1 passed
- File Manager and session workspace Playwright tests: 22 passed
- tests/test_webssh2_shell.py: 21 passed
- git diff --check