### PR TITLE
fix: allow queuing transfers during active copies

### DIFF
--- a/static/js/sftp-file-manager.js
+++ b/static/js/sftp-file-manager.js
@@ -3869,10 +3869,12 @@ class SFTPFileManager {
         const targetSourceId = this.getPaneSourceId(target);
         const sourceSnapshot = { source: { ...source.source } };
         const targetSnapshot = { source: { ...target.source } };
+        const batchId = this.nextRequestId('queue', 'remote-transfer-batch');
         for (const item of selectedItems) {
             this.queueTransfer({
                 id: this.nextRequestId('queue', 'remote-transfer'),
                 type: 's2s-queued',
+                batchId,
                 filename: item.name,
                 sourcePath: this.joinPath(source.path, item.name),
                 targetPath: this.joinPath(target.path, item.name),
@@ -3887,21 +3889,27 @@ class SFTPFileManager {
     }
 
     async drainQueuedServerTransfers() {
-        if (this.transferExecutionInProgress) return 'queued';
+        if (this.transferExecutionInProgress || this.isTransferring) return 'queued';
         this.transferExecutionInProgress = true;
         this.conflictAction = null;
         this.applyToAll = false;
+        let currentBatchId = null;
         this.updateWorkspaceActions();
         try {
             while (true) {
-                const pending = this.transferQueue.find(transfer => (
-                    transfer.type === 's2s-queued'
-                    && transfer.status === 'pending'
-                ));
+                const pending = this.transferQueue.find(
+                    transfer => transfer.status === 'pending'
+                );
                 if (!pending) return 'complete';
+                if (pending.type !== 's2s-queued') return 'queued';
+                if (pending.batchId !== currentBatchId) {
+                    currentBatchId = pending.batchId;
+                    this.conflictAction = null;
+                    this.applyToAll = false;
+                }
                 pending.starting = true;
                 this.renderTransferQueue();
-                await this.transferSSHtoSSH(
+                const outcome = await this.transferSSHtoSSH(
                     pending.sourcePath,
                     pending.sourcePane,
                     pending.targetPath,
@@ -3911,10 +3919,22 @@ class SFTPFileManager {
                     pending,
                 );
                 delete pending.starting;
+                if (outcome === 'batch-cancelled') {
+                    for (const transfer of this.transferQueue) {
+                        if (
+                            transfer.type === 's2s-queued'
+                            && transfer.status === 'pending'
+                            && transfer.batchId === pending.batchId
+                        ) {
+                            this.finalizeTransferById(transfer.id, 'cancelled');
+                        }
+                    }
+                }
             }
         } finally {
             this.transferExecutionInProgress = false;
             this.updateWorkspaceActions();
+            void this.processTransferQueue();
         }
     }
 
@@ -4257,6 +4277,29 @@ class SFTPFileManager {
             });
             if (action === 'replace') {
                 this.activeTransfers.delete(transferId);
+                if (queuedTransfer) {
+                    queuedTransfer.id = this.nextRequestId(
+                        'queue', 'remote-transfer'
+                    );
+                    queuedTransfer.type = 's2s-queued';
+                    queuedTransfer.status = 'pending';
+                    queuedTransfer.progress = 0;
+                    delete queuedTransfer.error;
+                    delete queuedTransfer.errorCode;
+                    delete queuedTransfer.retryable;
+                    this.retainTransferSources(sourceIds);
+                    queuedTransfer.starting = true;
+                    this.renderTransferQueue();
+                    return this.transferSSHtoSSH(
+                        sourcePath,
+                        sourcePane,
+                        targetPath,
+                        targetPane,
+                        item,
+                        'replace',
+                        queuedTransfer,
+                    );
+                }
                 this.transferQueue = this.transferQueue.filter(
                     transfer => transfer.id !== transferId
                 );
@@ -4275,7 +4318,9 @@ class SFTPFileManager {
             completedTransfer.errorCode = null;
             completedTransfer.retryable = false;
             this.renderTransferQueue();
-            return completedTransfer.status;
+            return action === 'cancel' && queuedTransfer?.batchId
+                ? 'batch-cancelled'
+                : completedTransfer.status;
         }
         return status;
     }
@@ -4624,16 +4669,17 @@ class SFTPFileManager {
         transfer.progress = 0;
         this.transferQueue.push(transfer);
         this.renderTransferQueue();
-        this.processTransferQueue();
+        if (transfer.type !== 's2s-queued') this.processTransferQueue();
     }
 
     async processTransferQueue() {
-        if (this.isTransferring) return;
+        if (this.isTransferring || this.transferExecutionInProgress) return;
 
-        const pending = this.transferQueue.find(t => (
-            t.status === 'pending' && t.type !== 's2s-queued'
-        ));
+        const pending = this.transferQueue.find(t => t.status === 'pending');
         if (!pending) return;
+        if (pending.type === 's2s-queued') {
+            return this.drainQueuedServerTransfers();
+        }
 
         this.isTransferring = true;
         pending.status = 'active';
@@ -4923,8 +4969,10 @@ class SFTPFileManager {
             this.resolveS2STerminal(transfer.id, status);
         }
         if (wasActive) {
-            this.isTransferring = false;
-            setTimeout(() => this.processTransferQueue(), 100);
+            this.isTransferring = this.activeTransfers.size > 0;
+            if (!this.isTransferring && !this.transferExecutionInProgress) {
+                setTimeout(() => this.processTransferQueue(), 100);
+            }
         }
         this.renderTransferQueue();
         this.flushPendingQuickDisconnects();

--- a/static/js/sftp-file-manager.js
+++ b/static/js/sftp-file-manager.js
@@ -912,9 +912,9 @@ class SFTPFileManager {
         const activeOperation = this.workspaceOperationBetweenPanes(
             this.activePane, targetPane,
         );
-        const activeTransferAvailable = !operationLocked
-            && activeOperation !== 'unavailable'
+        const activeTransferAvailable = activeOperation !== 'unavailable'
             && selectedCount > 0;
+        const activeTransferBlocked = operationLocked && activeOperation !== 'copy';
         const transferSourcePane = selectedCount > 0
             ? this.activePane
             : (this.panes[targetPane]?.selected?.size || 0) > 0
@@ -924,9 +924,9 @@ class SFTPFileManager {
         const transferOperation = this.workspaceOperationBetweenPanes(
             transferSourcePane, transferTargetPane,
         );
-        const transferAvailable = !operationLocked
-            && transferOperation !== 'unavailable'
+        const transferAvailable = transferOperation !== 'unavailable'
             && transferSelectedCount > 0;
+        const transferBlocked = operationLocked && transferOperation !== 'copy';
         const setDisabled = (id, disabled) => {
             const element = document.getElementById(id);
             if (element) element.disabled = disabled;
@@ -938,14 +938,14 @@ class SFTPFileManager {
         setDisabled('fmRename', operationLocked || !this.sourceCan(state, 'rename') || selectedCount !== 1);
         setDisabled('fmMove', !this.canOpenMovePickerForState(state));
         setDisabled('fmDelete', operationLocked || !this.sourceCan(state, 'delete') || selectedCount === 0);
-        setDisabled('fmTransfer', !activeTransferAvailable);
+        setDisabled('fmTransfer', activeTransferBlocked || !activeTransferAvailable);
         this.updateWorkspaceOperationButton(
             document.getElementById('fmTransfer'), activeOperation,
         );
         const betweenButton = document.getElementById('fmTransferBetween');
         if (betweenButton) {
-            betweenButton.disabled = !transferAvailable;
-            betweenButton.hidden = !transferAvailable;
+            betweenButton.disabled = transferBlocked || !transferAvailable;
+            betweenButton.hidden = transferBlocked || !transferAvailable;
             betweenButton.dataset.sourcePane = transferSourcePane;
         }
         this.updateWorkspaceOperationButton(
@@ -3819,7 +3819,6 @@ class SFTPFileManager {
     }
 
     async executeTransfer() {
-        if (this.transferExecutionInProgress) return;
         const sourcePane = this.activePane;
         const targetPane = sourcePane === 'left' ? 'right' : 'left';
 
@@ -3866,26 +3865,56 @@ class SFTPFileManager {
         }
 
         this.showNotification(`${this.t('fm.startingTransfer', 'Starting transfer of')} ${selectedItems.length} ${this.t('fm.items', 'item(s)')}...`, 'info');
+        const sourceId = this.getPaneSourceId(source);
+        const targetSourceId = this.getPaneSourceId(target);
+        const sourceSnapshot = { source: { ...source.source } };
+        const targetSnapshot = { source: { ...target.source } };
+        for (const item of selectedItems) {
+            this.queueTransfer({
+                id: this.nextRequestId('queue', 'remote-transfer'),
+                type: 's2s-queued',
+                filename: item.name,
+                sourcePath: this.joinPath(source.path, item.name),
+                targetPath: this.joinPath(target.path, item.name),
+                size: item.size || 0,
+                sourceIds: [sourceId, targetSourceId],
+                sourcePane: sourceSnapshot,
+                targetPane: targetSnapshot,
+                item: { ...item },
+            });
+        }
+        return this.drainQueuedServerTransfers();
+    }
+
+    async drainQueuedServerTransfers() {
+        if (this.transferExecutionInProgress) return 'queued';
         this.transferExecutionInProgress = true;
         this.conflictAction = null;
         this.applyToAll = false;
-
+        this.updateWorkspaceActions();
         try {
-            for (const item of selectedItems) {
-                const sourcePath = source.path === '/' ? '/' + item.name : source.path + '/' + item.name;
-                const targetPath = target.path === '/' ? '/' + item.name : target.path + '/' + item.name;
-
-                const outcome = await this.transferSSHtoSSH(
-                    sourcePath,
-                    source,
-                    targetPath,
-                    target,
-                    item,
+            while (true) {
+                const pending = this.transferQueue.find(transfer => (
+                    transfer.type === 's2s-queued'
+                    && transfer.status === 'pending'
+                ));
+                if (!pending) return 'complete';
+                pending.starting = true;
+                this.renderTransferQueue();
+                await this.transferSSHtoSSH(
+                    pending.sourcePath,
+                    pending.sourcePane,
+                    pending.targetPath,
+                    pending.targetPane,
+                    pending.item,
+                    'error',
+                    pending,
                 );
-                if (outcome === 'cancelled') break;
+                delete pending.starting;
             }
         } finally {
             this.transferExecutionInProgress = false;
+            this.updateWorkspaceActions();
         }
     }
 
@@ -4090,6 +4119,7 @@ class SFTPFileManager {
         targetPane,
         item,
         conflictPolicy = 'error',
+        queuedTransfer = null,
     ) {
         const sourceId = this.getPaneSourceId(sourcePane);
         const targetSourceId = this.getPaneSourceId(targetPane);
@@ -4105,21 +4135,28 @@ class SFTPFileManager {
                 'remote_transfer', item.size,
             );
             if (preflight) {
+                const message = this.transferFailureMessage(
+                    'LIMIT_EXCEEDED',
+                    'The transfer exceeds the configured limit.',
+                    preflight,
+                );
                 this.showNotification(
-                    `${this.t('fm.transferFailed', 'Transfer failed')}: ${
-                        this.transferFailureMessage(
-                            'LIMIT_EXCEEDED',
-                            'The transfer exceeds the configured limit.',
-                            preflight,
-                        )
-                    }`,
+                    `${this.t('fm.transferFailed', 'Transfer failed')}: ${message}`,
                     'error',
                 );
+                if (queuedTransfer) {
+                    this.finalizeTransferById(
+                        queuedTransfer.id,
+                        'error',
+                        message,
+                        'LIMIT_EXCEEDED',
+                    );
+                }
                 return 'error';
             }
         }
 
-        this.retainTransferSources(sourceIds);
+        if (!queuedTransfer) this.retainTransferSources(sourceIds);
         const requestId = this.nextRequestId('workspace', 'remote-transfer');
         this.pendingS2SRequests ||= new Map();
         this.pendingS2SRequests.set(requestId, {
@@ -4141,13 +4178,23 @@ class SFTPFileManager {
         if (!acknowledgement || !acknowledgement.success
                 || !this.matchesS2SResponse(acknowledgement)) {
             this.pendingS2SRequests.delete(requestId);
-            this.releaseTransferSources(sourceIds);
-            this.flushPendingQuickDisconnects();
             const message = this.transferFailureMessage(
                 acknowledgement?.error_code,
                 acknowledgement?.error,
                 acknowledgement,
             );
+            if (queuedTransfer) {
+                this.finalizeTransferById(
+                    queuedTransfer.id,
+                    'error',
+                    message,
+                    acknowledgement?.error_code,
+                    acknowledgement?.retryable,
+                );
+            } else {
+                this.releaseTransferSources(sourceIds);
+                this.flushPendingQuickDisconnects();
+            }
             this.showNotification(
                 `${this.t('fm.transferFailed', 'Transfer failed')}: ${message}`,
                 'error',
@@ -4158,17 +4205,29 @@ class SFTPFileManager {
         const terminal = this.waitForS2STerminal(transferId);
         this.pendingS2SRequests.delete(requestId);
 
-        this.queueTransfer({
-            id: transferId,
-            type: 's2s',
-            filename: item.name,
-            sourcePath: sourcePath,
-            targetPath: targetPath,
-            size: item.size || 0,
-            sourceIds,
-            requestId,
-            sourcesRetained: true,
-        });
+        if (queuedTransfer) {
+            this.activeTransfers.delete(queuedTransfer.id);
+            queuedTransfer.id = transferId;
+            queuedTransfer.type = 's2s';
+            queuedTransfer.requestId = requestId;
+            queuedTransfer.status = 'active';
+            delete queuedTransfer.starting;
+            this.activeTransfers.set(transferId, queuedTransfer);
+            this.isTransferring = true;
+            this.renderTransferQueue();
+        } else {
+            this.queueTransfer({
+                id: transferId,
+                type: 's2s',
+                filename: item.name,
+                sourcePath: sourcePath,
+                targetPath: targetPath,
+                size: item.size || 0,
+                sourceIds,
+                requestId,
+                sourcesRetained: true,
+            });
+        }
         const earlyTerminal = this.s2sEarlyTerminals?.get(transferId);
         if (earlyTerminal) {
             this.s2sEarlyTerminals.delete(transferId);
@@ -4179,6 +4238,10 @@ class SFTPFileManager {
                 earlyTerminal.errorCode,
                 earlyTerminal.retryable,
             );
+        }
+        if (queuedTransfer?.cancelRequested
+                && queuedTransfer.status === 'active') {
+            this.requestS2SCancellation(queuedTransfer);
         }
         const status = await terminal;
         const completedTransfer = this.transferQueue?.find(
@@ -4567,7 +4630,9 @@ class SFTPFileManager {
     async processTransferQueue() {
         if (this.isTransferring) return;
 
-        const pending = this.transferQueue.find(t => t.status === 'pending');
+        const pending = this.transferQueue.find(t => (
+            t.status === 'pending' && t.type !== 's2s-queued'
+        ));
         if (!pending) return;
 
         this.isTransferring = true;
@@ -4788,32 +4853,46 @@ class SFTPFileManager {
     cancelQueuedTransfer(transferId) {
         const transfer = this.transferQueue.find(t => String(t.id) === transferId);
         if (!transfer || !['pending', 'active'].includes(transfer.status)) return;
+        if (transfer.type === 's2s-queued') {
+            if (transfer.starting) {
+                transfer.cancelRequested = true;
+                transfer.status = 'cancelling';
+                this.renderTransferQueue();
+            } else {
+                this.finalizeTransferById(transfer.id, 'cancelled');
+            }
+            return;
+        }
         if (transfer.type === 's2s') {
-            transfer.cancelWasActive = transfer.status === 'active';
-            transfer.status = 'cancelling';
-            this.renderTransferQueue();
-            this.socket.emit('cancel_transfer', {
-                transfer_id: transfer.id
-            }, acknowledgement => {
-                if (
-                    acknowledgement?.success === true
-                    && acknowledgement.state === 'cancelled'
-                ) {
-                    this.cancelTransferById(transfer.id);
-                } else if (acknowledgement?.state === 'unavailable') {
-                    this.failTransferById(
-                        transfer.id,
-                        this.t(
-                            'fm.cancelUnavailable',
-                            'Cancellation could not be confirmed. Refresh the destination before retrying.',
-                        ),
-                        'TRANSFER_UNAVAILABLE',
-                    );
-                }
-            });
+            this.requestS2SCancellation(transfer);
             return;
         }
         this.getTransferClient().cancelTransfer(transfer.id);
+    }
+
+    requestS2SCancellation(transfer) {
+        transfer.cancelWasActive = transfer.status === 'active';
+        transfer.status = 'cancelling';
+        this.renderTransferQueue();
+        this.socket.emit('cancel_transfer', {
+            transfer_id: transfer.id
+        }, acknowledgement => {
+            if (
+                acknowledgement?.success === true
+                && acknowledgement.state === 'cancelled'
+            ) {
+                this.cancelTransferById(transfer.id);
+            } else if (acknowledgement?.state === 'unavailable') {
+                this.failTransferById(
+                    transfer.id,
+                    this.t(
+                        'fm.cancelUnavailable',
+                        'Cancellation could not be confirmed. Refresh the destination before retrying.',
+                    ),
+                    'TRANSFER_UNAVAILABLE',
+                );
+            }
+        });
     }
 
     finalizeTransferById(

--- a/tests/e2e/file-workspace.spec.js
+++ b/tests/e2e/file-workspace.spec.js
@@ -187,6 +187,16 @@ test('source-first workspace preserves panes and exposes only functional SFTP ac
     await expect.poll(() => page.evaluate(() => (
         window.__fileWorkspaceEvents.some(item => item.event === 'transfer_server_to_server')
     ))).toBe(true);
+    await expect.poll(() => page.evaluate(() => (
+        window.sftpFileManager.transferExecutionInProgress
+    ))).toBe(true);
+    await expect(page.locator('#fmTransferBetween')).toBeVisible();
+    await expect(page.locator('#fmTransferBetween')).toBeEnabled();
+
+    await page.locator('#fmTransferBetween').click();
+    await expect.poll(() => page.evaluate(() => (
+        window.sftpFileManager.transferQueue.map(transfer => transfer.status)
+    ))).toEqual(['active', 'pending']);
 
     await page.locator('#fmLayoutSingle').click();
     await expect(page.locator('#sftpFileManager')).toHaveClass(/fm-workspace-single/);

--- a/tests/js/sftp-transfer-queue.test.js
+++ b/tests/js/sftp-transfer-queue.test.js
@@ -1515,6 +1515,65 @@ test('one contextual inter-pane action follows the active selection', () => {
     }
 });
 
+test('cross-source transfer actions remain available while another copy is active', () => {
+    const previousDocument = global.document;
+    const elements = new Map();
+    const makeButton = () => ({
+        dataset: {},
+        title: '',
+        disabled: false,
+        hidden: false,
+        classList: classList(),
+        querySelector() { return null; },
+        setAttribute() {},
+    });
+    const transfer = makeButton();
+    const between = makeButton();
+    const newFolder = makeButton();
+    elements.set('fmTransfer', transfer);
+    elements.set('fmTransferBetween', between);
+    elements.set('fmNewFolder', newFolder);
+    global.document = {
+        getElementById(id) { return elements.get(id) || null; },
+        querySelectorAll() { return []; },
+        querySelector() { return null; },
+    };
+    const manager = Object.create(SFTPFileManager.prototype);
+    manager.initializeWorkspaceState();
+    manager.workspace.setLayout('split');
+    manager.panes.left = filePane(manager, 'sftp-session:source', {
+        path: '/source',
+        files: [{ name: 'queued.txt', is_dir: false }],
+        selected: new Set([0]),
+    });
+    manager.panes.right = filePane(manager, 'smb-quick:target', {
+        path: '/target',
+    });
+    manager.workspace.openTab(
+        'left', manager.panes.left.source, manager.panes.left,
+    );
+    manager.workspace.openTab(
+        'right', manager.panes.right.source, manager.panes.right,
+    );
+    Object.assign(manager, {
+        displayMode: 'modal',
+        activePane: 'left',
+        transferExecutionInProgress: true,
+        t(_key, fallback) { return fallback; },
+    });
+
+    try {
+        manager.updateWorkspaceActions();
+
+        assert.equal(transfer.disabled, false);
+        assert.equal(between.hidden, false);
+        assert.equal(between.disabled, false);
+        assert.equal(newFolder.disabled, true);
+    } finally {
+        global.document = previousDocument;
+    }
+});
+
 test('source launcher identifies the existing connection that enables Move', () => {
     const manager = Object.create(SFTPFileManager.prototype);
     manager.initializeWorkspaceState();
@@ -3114,7 +3173,7 @@ test('server copies queue the server-owned cancellable transfer id', async () =>
     await terminal;
 });
 
-test('three selected server copies start only after the previous transfer is terminal', async () => {
+test('new server copies join the visible queue and start after earlier work is terminal', async () => {
     const requests = [];
     const flushAsync = () => new Promise(resolve => setImmediate(resolve));
     const manager = Object.create(SFTPFileManager.prototype);
@@ -3128,6 +3187,7 @@ test('three selected server copies start only after the previous transfer is ter
                     { name: 'first.bin', is_dir: false, size: 1 },
                     { name: 'second.bin', is_dir: false, size: 2 },
                     { name: 'third.bin', is_dir: false, size: 3 },
+                    { name: 'fourth.bin', is_dir: false, size: 4 },
                 ],
                 selected: new Set([0, 1, 2]),
             },
@@ -3169,11 +3229,13 @@ test('three selected server copies start only after the previous transfer is ter
     const execution = manager.executeTransfer();
     await flushAsync();
     assert.deepEqual(requests.map(request => request.sourcePath), ['/source/first.bin']);
-    let duplicateSettled = false;
-    manager.executeTransfer().then(() => { duplicateSettled = true; });
-    await flushAsync();
-    assert.equal(duplicateSettled, true);
+    manager.panes.left.selected = new Set([3]);
+    const queued = await manager.executeTransfer();
+    assert.equal(queued, 'queued');
     assert.deepEqual(requests.map(request => request.sourcePath), ['/source/first.bin']);
+    assert.deepEqual(manager.transferQueue.map(transfer => transfer.status), [
+        'active', 'pending', 'pending', 'pending',
+    ]);
 
     manager.completeS2STransfer({ transfer_id: 'server-1' });
     await flushAsync();
@@ -3193,15 +3255,50 @@ test('three selected server copies start only after the previous transfer is ter
     ]);
 
     manager.cancelTransferById('server-3');
+    await flushAsync();
+    assert.deepEqual(requests.map(request => request.sourcePath), [
+        '/source/first.bin', '/source/second.bin', '/source/third.bin',
+        '/source/fourth.bin',
+    ]);
+
+    manager.completeS2STransfer({ transfer_id: 'server-4' });
     await execution;
     assert.deepEqual(manager.transferQueue.map(transfer => transfer.status), [
-        'complete', 'error', 'cancelled',
+        'complete', 'error', 'cancelled', 'complete',
     ]);
     assert.equal(manager.transferQueue[1].errorCode, 'PERMISSION_DENIED');
     assert.equal(
         manager.transferQueue[1].error,
         'Permission denied for this file operation.',
     );
+});
+
+test('cancelling a pending server copy never emits a server cancellation', () => {
+    const emitted = [];
+    const released = [];
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        transferQueue: [{
+            id: 'queued-copy-1',
+            type: 's2s-queued',
+            status: 'pending',
+            sourceIds: ['sftp-session:source', 'smb-quick:target'],
+        }],
+        activeTransfers: new Map(),
+        socket: { emit(...args) { emitted.push(args); } },
+        releaseTransferSources(sourceIds) { released.push(sourceIds); },
+        recordUploadTerminal() {},
+        renderTransferQueue() {},
+        flushPendingQuickDisconnects() {},
+    });
+
+    manager.cancelQueuedTransfer('queued-copy-1');
+
+    assert.equal(manager.transferQueue[0].status, 'cancelled');
+    assert.deepEqual(released, [[
+        'sftp-session:source', 'smb-quick:target',
+    ]]);
+    assert.deepEqual(emitted, []);
 });
 
 test('server copy retries a conflict only after explicit replace consent', async () => {

--- a/tests/js/sftp-transfer-queue.test.js
+++ b/tests/js/sftp-transfer-queue.test.js
@@ -3273,6 +3273,162 @@ test('new server copies join the visible queue and start after earlier work is t
     );
 });
 
+test('server copy conflict cancellation reports a batch cancellation', async () => {
+    const queuedTransfer = {
+        id: 'queued-copy',
+        type: 's2s-queued',
+        status: 'pending',
+        batchId: 'batch-a',
+        sourceIds: ['sftp-session:source', 'sftp-session:target'],
+    };
+    let manager;
+    manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        transferQueue: [queuedTransfer],
+        activeTransfers: new Map(),
+        isTransferring: false,
+        pendingS2SRequests: new Map(),
+        s2sEarlyTerminals: new Map(),
+        s2sTerminalWaiters: new Map(),
+        requestSequence: 0,
+        socket: {
+            emit(event, payload, acknowledgement) {
+                assert.equal(event, 'transfer_server_to_server');
+                const context = {
+                    transfer_id: 'server-copy',
+                    source_id: payload.source_id,
+                    destination_source_id: payload.destination_source_id,
+                    request_id: payload.request_id,
+                };
+                manager.failS2STransfer({
+                    ...context,
+                    error: 'A file or folder already exists at the destination.',
+                    error_code: 'CONFLICT',
+                    retryable: false,
+                });
+                acknowledgement({ success: true, ...context });
+            },
+        },
+        recordUploadTerminal() {},
+        releaseTransferSources() {},
+        flushPendingQuickDisconnects() {},
+        renderTransferQueue() {},
+        processTransferQueue() {},
+        showNotification() {},
+        resolveUploadConflict() { return Promise.resolve('cancel'); },
+        t(_key, fallback) { return fallback; },
+    });
+
+    const result = await manager.transferSSHtoSSH(
+        '/source/report.txt',
+        filePane(manager, 'sftp-session:source'),
+        '/target/report.txt',
+        filePane(manager, 'sftp-session:target'),
+        { name: 'report.txt', is_dir: false, size: 10 },
+        'error',
+        queuedTransfer,
+    );
+
+    assert.equal(result, 'batch-cancelled');
+    assert.equal(queuedTransfer.status, 'cancelled');
+});
+
+test('batch cancellation skips its remaining server copies but preserves later batches', async () => {
+    const started = [];
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        transferQueue: [
+            {
+                id: 'batch-a-1', type: 's2s-queued', status: 'pending',
+                batchId: 'batch-a', sourceIds: [],
+            },
+            {
+                id: 'batch-a-2', type: 's2s-queued', status: 'pending',
+                batchId: 'batch-a', sourceIds: [],
+            },
+            {
+                id: 'batch-b-1', type: 's2s-queued', status: 'pending',
+                batchId: 'batch-b', sourceIds: [],
+            },
+        ],
+        activeTransfers: new Map(),
+        isTransferring: false,
+        transferExecutionInProgress: false,
+        async transferSSHtoSSH(_sourcePath, _sourcePane, _targetPath, _targetPane, _item, _policy, transfer) {
+            started.push(transfer.id);
+            transfer.status = transfer.id === 'batch-a-1' ? 'cancelled' : 'complete';
+            return transfer.id === 'batch-a-1' ? 'batch-cancelled' : 'complete';
+        },
+        recordUploadTerminal() {},
+        releaseTransferSources() {},
+        flushPendingQuickDisconnects() {},
+        renderTransferQueue() {},
+        updateWorkspaceActions() {},
+        processTransferQueue() {},
+    });
+
+    await manager.drainQueuedServerTransfers();
+
+    assert.deepEqual(started, ['batch-a-1', 'batch-b-1']);
+    assert.deepEqual(
+        manager.transferQueue.map(transfer => transfer.status),
+        ['cancelled', 'cancelled', 'complete'],
+    );
+});
+
+test('queued server copies wait for the current transfer queue owner', async () => {
+    let starts = 0;
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        transferQueue: [{
+            id: 'queued-copy', type: 's2s-queued', status: 'pending',
+            batchId: 'batch-a', sourceIds: [],
+        }],
+        activeTransfers: new Map([['upload-1', { id: 'upload-1' }]]),
+        isTransferring: true,
+        transferExecutionInProgress: false,
+        async transferSSHtoSSH() {
+            starts++;
+            this.transferQueue[0].status = 'complete';
+            return 'complete';
+        },
+        renderTransferQueue() {},
+        updateWorkspaceActions() {},
+    });
+
+    const result = await manager.drainQueuedServerTransfers();
+
+    assert.equal(result, 'queued');
+    assert.equal(starts, 0);
+    assert.equal(manager.transferQueue[0].status, 'pending');
+    assert.equal(manager.isTransferring, true);
+});
+
+test('finishing one active transfer keeps the queue owned by another active transfer', () => {
+    const manager = Object.create(SFTPFileManager.prototype);
+    Object.assign(manager, {
+        transferQueue: [
+            { id: 'upload-1', type: 'upload', status: 'active', sourceIds: [] },
+            { id: 'download-1', type: 'download', status: 'active', sourceIds: [] },
+        ],
+        activeTransfers: new Map([
+            ['upload-1', { id: 'upload-1' }],
+            ['download-1', { id: 'download-1' }],
+        ]),
+        isTransferring: true,
+        recordUploadTerminal() {},
+        releaseTransferSources() {},
+        flushPendingQuickDisconnects() {},
+        renderTransferQueue() {},
+        processTransferQueue() {},
+    });
+
+    manager.finalizeTransferById('upload-1', 'complete');
+
+    assert.equal(manager.isTransferring, true);
+    assert.equal(manager.activeTransfers.has('download-1'), true);
+});
+
 test('cancelling a pending server copy never emits a server cancellation', () => {
     const emitted = [];
     const released = [];


### PR DESCRIPTION
## Summary
- keep cross-source copy actions available while another server copy is active
- enqueue selected items immediately so pending work is visible and starts sequentially
- serialize server copies with upload/download queue owners and preserve source lifetimes
- limit conflict-dialog cancellation to the affected batch while preserving later batches

Fixes #184

## Validation
- `node --test tests/js/*.test.js` (373 passed)
- `npm run lint:js`
- `npm run vendor:check`
- Firefox regression scenario for the File Manager transfer queue (1 passed)
- File Workspace E2E suite in Chromium (8 passed)