### PR TITLE
Fix Android IME rollover and stabilize deferred theme E2E

### DIFF
--- a/static/js/terminal-manager.js
+++ b/static/js/terminal-manager.js
@@ -47,7 +47,17 @@ const TerminalManager = {
             return () => {};
         }
 
-        const resetStaleInput = () => {
+        const eventSurface = terminal.element || textarea;
+        const targetsTextarea = event => (
+            eventSurface === textarea || event.target === textarea
+        );
+        let compositionActive = false;
+        let recentTextInput = null;
+
+        const resetStaleInput = event => {
+            if (!targetsTextarea(event)) return;
+            compositionActive = true;
+            recentTextInput = null;
             // Some Android IMEs replace xterm's accumulated helper value when a
             // composition starts. Starting from that stale offset truncates the
             // same number of characters from the committed terminal input.
@@ -55,10 +65,75 @@ const TerminalManager = {
             textarea.setSelectionRange?.(0, 0);
         };
 
-        // Capture runs before xterm records the composition's start offset.
-        textarea.addEventListener('compositionstart', resetStaleInput, true);
+        const finishComposition = event => {
+            if (!targetsTextarea(event)) return;
+            compositionActive = false;
+            recentTextInput = null;
+        };
+
+        const rememberTextInput = event => {
+            if (
+                !targetsTextarea(event)
+                || compositionActive
+                || event.isComposing
+                || event.inputType !== 'insertText'
+                || typeof event.data !== 'string'
+                || event.data.length === 0
+            ) {
+                return;
+            }
+            recentTextInput = {
+                data: event.data,
+                timeStamp: Number(event.timeStamp),
+            };
+        };
+
+        const suppressDuplicateImeFallback = event => {
+            if (!targetsTextarea(event)) return;
+            const keyCode = Number(event.keyCode || event.which);
+            if (
+                keyCode !== 229
+                || compositionActive
+                || event.isComposing
+                || event.ctrlKey
+                || event.metaKey
+                || event.altKey
+            ) {
+                return;
+            }
+
+            const key = typeof event.key === 'string' ? event.key : '';
+            const printableKey = Array.from(key).length === 1;
+            const keyTime = Number(event.timeStamp);
+            const inputDelay = keyTime - recentTextInput?.timeStamp;
+            const followsTextInput = (
+                Number.isFinite(inputDelay)
+                && inputDelay >= 0
+                && inputDelay <= 50
+                && ['', 'Unidentified', 'Process'].includes(key)
+            );
+            if (!printableKey && !followsTextInput) return;
+
+            // Android IMEs can deliver insertText before a printable keydown 229
+            // without any composition events. xterm has already accepted that
+            // input, so its deferred textarea-diff fallback would duplicate it.
+            // Do not prevent the browser default: a keydown-first IME still needs
+            // to produce its subsequent input event.
+            recentTextInput = null;
+            event.stopImmediatePropagation?.();
+        };
+
+        // Capture on xterm's parent runs before xterm's own capture listeners on
+        // the helper textarea. This matters for keydown as well as composition.
+        eventSurface.addEventListener('compositionstart', resetStaleInput, true);
+        eventSurface.addEventListener('compositionend', finishComposition, true);
+        eventSurface.addEventListener('input', rememberTextInput, true);
+        eventSurface.addEventListener('keydown', suppressDuplicateImeFallback, true);
         return () => {
-            textarea.removeEventListener('compositionstart', resetStaleInput, true);
+            eventSurface.removeEventListener('compositionstart', resetStaleInput, true);
+            eventSurface.removeEventListener('compositionend', finishComposition, true);
+            eventSurface.removeEventListener('input', rememberTextInput, true);
+            eventSurface.removeEventListener('keydown', suppressDuplicateImeFallback, true);
         };
     },
 

--- a/tests/e2e/session-workspace.spec.js
+++ b/tests/e2e/session-workspace.spec.js
@@ -399,6 +399,58 @@ test('Android IME composition sends the complete value without its stale prefix'
     await assertNoExternalRequests(page);
 });
 
+test('Android IME input-before-keydown rollover is forwarded exactly once', async ({ page }) => {
+    await login(page);
+    await seedLinuxSession(page);
+    await page.evaluate(() => {
+        const terminalKey = TerminalManager.sessionTerminals['workspace-linux'][0];
+        const terminal = TerminalManager.terminals[terminalKey];
+        const textarea = terminal.textarea;
+        window.__androidCompositionDispose = TerminalManager.setupAndroidCompositionGuard(
+            terminal,
+            true,
+        );
+
+        for (const character of '12345') {
+            textarea.value += character;
+            textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+            textarea.dispatchEvent(new InputEvent('input', {
+                bubbles: true,
+                composed: true,
+                data: character,
+                inputType: 'insertText',
+            }));
+            const keydown = new KeyboardEvent('keydown', {
+                bubbles: true,
+                cancelable: true,
+                key: 'Unidentified',
+            });
+            Object.defineProperty(keydown, 'keyCode', {value: 229});
+            textarea.dispatchEvent(keydown);
+            const keyup = new KeyboardEvent('keyup', {
+                bubbles: true,
+                key: character,
+            });
+            Object.defineProperty(keyup, 'keyCode', {
+                value: character.charCodeAt(0),
+            });
+            textarea.dispatchEvent(keyup);
+        }
+    });
+
+    await expect.poll(() => page.evaluate(() => window.__workspaceEvents
+        .filter(event => event.event === 'ssh_input')
+        .map(event => event.payload.data)
+        .join(''))).toBe('12345');
+    await page.waitForTimeout(50);
+    expect(await page.evaluate(() => window.__workspaceEvents
+        .filter(event => event.event === 'ssh_input')
+        .map(event => event.payload.data)
+        .join(''))).toBe('12345');
+    await page.evaluate(() => window.__androidCompositionDispose());
+    await assertNoExternalRequests(page);
+});
+
 test('tmux resync ignores replayed OSC 52 and accepts a live clipboard selection', async ({ page }) => {
     await login(page);
     await seedLinuxSession(page, {

--- a/tests/e2e/theme-system.spec.js
+++ b/tests/e2e/theme-system.spec.js
@@ -283,6 +283,7 @@ test('the last selected theme styles the next login screen', async ({ page }) =>
     await page.goto('/login');
     await expect(page).toHaveURL(/\/login/);
     await expect(page.locator('body')).toHaveAttribute('data-theme', 'paper');
+    await expect(page.locator('body')).toHaveAttribute('data-theme-background-ready', '');
 
     const authTheme = await page.evaluate(() => ({
         backdropImage: getComputedStyle(document.body, '::before').backgroundImage,

--- a/tests/js/terminal-manager-layout.test.js
+++ b/tests/js/terminal-manager-layout.test.js
@@ -70,6 +70,87 @@ test('Android compositions discard stale helper input before xterm records the o
     assert.equal(listeners.size, 0);
 });
 
+test('Android IME fallback does not reprocess text delivered before keydown 229', () => {
+    const listeners = new Map();
+    const textarea = {
+        value: '',
+        addEventListener(name, listener, capture = false) {
+            listeners.set(`${name}:${capture}`, listener);
+        },
+        removeEventListener(name, listener, capture = false) {
+            const key = `${name}:${capture}`;
+            if (listeners.get(key) === listener) listeners.delete(key);
+        },
+    };
+    const dispose = TerminalManager.setupAndroidCompositionGuard({
+        textarea,
+        options: {screenReaderMode: false},
+    }, true);
+    let stopped = 0;
+
+    listeners.get('input:true')({
+        data: '1',
+        inputType: 'insertText',
+        isComposing: false,
+        timeStamp: 100,
+    });
+    listeners.get('keydown:true')({
+        key: 'Unidentified',
+        keyCode: 229,
+        isComposing: false,
+        timeStamp: 101,
+        stopImmediatePropagation() { stopped += 1; },
+    });
+
+    assert.equal(stopped, 1);
+    dispose();
+    assert.equal(listeners.size, 0);
+});
+
+test('Android IME guard leaves control keys and active compositions to xterm', () => {
+    const listeners = new Map();
+    const textarea = {
+        value: '',
+        addEventListener(name, listener, capture = false) {
+            listeners.set(`${name}:${capture}`, listener);
+        },
+        removeEventListener(name, listener, capture = false) {
+            const key = `${name}:${capture}`;
+            if (listeners.get(key) === listener) listeners.delete(key);
+        },
+        setSelectionRange() {},
+    };
+    const dispose = TerminalManager.setupAndroidCompositionGuard({
+        textarea,
+        options: {screenReaderMode: false},
+    }, true);
+    let stopped = 0;
+    const dispatchKeydown = overrides => listeners.get('keydown:true')({
+        keyCode: 229,
+        isComposing: false,
+        timeStamp: 200,
+        stopImmediatePropagation() { stopped += 1; },
+        ...overrides,
+    });
+
+    listeners.get('input:true')({
+        data: 'x',
+        inputType: 'insertText',
+        isComposing: false,
+        timeStamp: 199,
+    });
+    dispatchKeydown({key: 'Backspace'});
+    dispatchKeydown({key: 'c', ctrlKey: true});
+    listeners.get('compositionstart:true')();
+    dispatchKeydown({key: 'a', isComposing: true});
+    listeners.get('compositionend:true')();
+    dispatchKeydown({key: 'a'});
+
+    assert.equal(stopped, 1);
+    dispose();
+    assert.equal(listeners.size, 0);
+});
+
 test('Android composition guard preserves screen-reader helper input', () => {
     let listenerAdded = false;
     const textarea = {


### PR DESCRIPTION
## Summary

- wait for the deferred auth-theme background readiness signal before inspecting computed styles
- preserve the intentional idle-time background loading behavior
- handle Android IME input-before-keydown rollover without replaying text through xterm
- keep normal composition, Backspace, modified shortcuts, and screen-reader input on their existing paths

## Root causes

### Deferred theme assertion

The test waited for the stored paper theme but immediately inspected the deferred background image. On a busy runner, `requestIdleCallback` had not yet added `data-theme-background-ready`, so the assertion saw the intended temporary `none` value. The failure trace showed the background request succeeding immediately after the assertion failed.

### Android IME rollover

Some Android IMEs can emit an `insertText` input event before a `keydown` with key code 229 and without composition events. xterm then schedules its own textarea-diff fallback and can replay stale text, producing duplicated or truncated terminal input. The guard now observes that ordering before xterm capture handling and suppresses only the paired fallback keydown.

## Testing

- all JavaScript tests: 40 passed
- complete `theme-system.spec.js`: 6 passed
- Android composition and input-before-keydown browser regressions: 2 passed
- terminal selection and 360px mobile workspace browser regressions: 2 passed
- ESLint on all changed JavaScript and E2E files
- `git diff --check`

## Validation boundary

The Android regression is covered through the real xterm browser integration in Chromium. It has not yet been verified on a physical OnePlus Pad 3 running Android 16 and Brave.

Failure reference: https://github.com/bifrost0x/webssh/actions/runs/34197698324

Fixes #210