### PR TITLE
Fix terminal uploads, note persistence feedback, and GUI regressions

### DIFF
--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -3067,27 +3067,26 @@ def handle_get_notepad(current_user=None):
 @socketio.on('save_notepad')
 @socket_login_required
 def handle_save_notepad(data, current_user=None):
-    """Persist the notepad text for the current user."""
+    """Acknowledge notepad writes only after persistence succeeds."""
+    def failed(message):
+        payload = {'success': False, 'error': message}
+        emit('error', payload)
+        return payload
+
     try:
-        text = data.get('text', '')
+        text = data.get('text') if isinstance(data, dict) else None
         if not isinstance(text, str):
-            payload = {
-                'success': False,
-                'error': 'Invalid notepad content',
-            }
-            emit('error', payload)
-            return payload
+            return failed('Invalid notepad content')
         if len(text) > 100000:
-            emit('error', {'error': 'Notepad content too large (max 100KB)'})
-            return
-        success = save_user_settings(current_user.id, {'notepad': text})
-        if not success:
-            emit('error', {'error': 'Failed to save notepad'})
+            return failed('Notepad content too large (max 100000 characters)')
+        if not save_user_settings(current_user.id, {'notepad': text}):
+            return failed('Failed to save notepad')
+        return {'success': True}
     except StorageCorruptionError as error:
         return _emit_storage_error(error, current_user)
     except Exception as e:
         log_error("Failed to save notepad", error=str(e))
-        emit('error', {'error': 'Failed to save notepad'})
+        return failed('Failed to save notepad')
 
 @socketio.on('list_commands')
 @socket_login_required

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -346,6 +346,7 @@
 
 .admin-tabs {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 2px;
     margin: 0;
     overflow: visible;
@@ -1212,4 +1213,13 @@
         margin-top: 6px;
         box-shadow: none;
     }
+}
+
+/* Navigation labels must fit the sidebar in every language. */
+.settings-center-navigation .admin-tab > span:last-child {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+.settings-center-navigation .admin-nav-group {
+    flex-wrap: wrap;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6261,3 +6261,10 @@ body.keyboard-open.notepad-focused .notepad-panel {
     background-repeat: no-repeat;
     background-size: auto, cover;
 }
+
+.notepad-save-status.offline,
+.notepad-save-status.failed,
+.notepad-save-status.tooLarge {
+    opacity: 1;
+    color: var(--error-color, #f87171);
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -34,13 +34,15 @@
     window.addEventListener('beforeunload', (event) => {
         if (socketProtocolReloadPending) {
             socketProtocolReloadPending = false;
-            return;
+            if (!window.notepadController?.hasUnsaved()) return;
         }
         const activeSessions = Object.values(SessionManager.sessions).filter(
             session => session.connected
         );
-        if (activeSessions.length > 0) {
-            const message = window.i18n
+        if (activeSessions.length > 0 || window.notepadController?.hasUnsaved()) {
+            const message = window.notepadController?.hasUnsaved()
+                ? window.i18n?.t('notes.unsaved') || 'Your notes have not been saved.'
+                : window.i18n
                 ? window.i18n.t(
                     'session.closeWarning',
                     'You have active SSH sessions. They will be closed.',
@@ -1251,6 +1253,7 @@
             }
             socketProtocolMismatch.markCompatible();
             window.socket.emit('get_notepad');
+            window.notepadController?.reconnect();
         }
     });
 
@@ -1516,7 +1519,11 @@
         if (!notepad) {
             return;
         }
-        notepad.value = (data && data.notepad) ? data.notepad : '';
+        if (window.notepadController) {
+            window.notepadController.receive(data?.notepad || '');
+        } else {
+            notepad.value = data?.notepad || '';
+        }
     });
 
     let currentConnectRequestId = null;
@@ -1927,57 +1934,54 @@
         const keyHint = document.getElementById('keyHint');
         const profileHint = document.getElementById('profileHint');
 
-        const hostnamePattern = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
-        const ipPattern = /^(\d{1,3}\.){3}\d{1,3}$/;
-        const usernamePattern = /^[a-zA-Z0-9_-]{1,32}$/;
-
-        hostInput.addEventListener('input', () => {
-            const value = hostInput.value.trim();
-            const isValid = value && (hostnamePattern.test(value) || ipPattern.test(value));
-            setFieldState(hostInput, hostHint, isValid ? 'Valid host' : 'Hostname or IP required', isValid);
-        });
-
-        portInput.addEventListener('input', () => {
-            const value = parseInt(portInput.value, 10);
-            const isValid = value >= 1 && value <= 65535;
-            setFieldState(portInput, portHint, isValid ? 'Valid port' : 'Port 1-65535', isValid);
-        });
-
-        userInput.addEventListener('input', () => {
-            const value = userInput.value.trim();
-            const isValid = usernamePattern.test(value);
-            setFieldState(userInput, userHint, isValid ? 'Valid username' : '1-32 chars, a-z 0-9 _ -', isValid);
+        const validation = window.ConnectionValidation;
+        const hint = (input, element, valid, key) => {
+            setFieldState(input, element, valid ? '' : i18n.t(key), valid);
+        };
+        const validateHost = () => hint(hostInput, hostHint,
+            validation.isValidHost(hostInput.value), 'validation.host');
+        const validatePort = () => hint(portInput, portHint,
+            validation.isValidPort(portInput.value), 'validation.port');
+        const validateUser = () => hint(userInput, userHint,
+            validation.isValidUsername(userInput.value), 'validation.username');
+        hostInput.addEventListener('input', validateHost);
+        portInput.addEventListener('input', validatePort);
+        userInput.addEventListener('input', validateUser);
+        window.addEventListener('languageChanged', () => {
+            if (hostHint.textContent) validateHost();
+            if (portHint.textContent) validatePort();
+            if (userHint.textContent) validateUser();
         });
 
         if (passwordInput) {
             passwordInput.addEventListener('input', () => {
                 const value = passwordInput.value;
                 const isValid = value.length > 0;
-                setFieldState(passwordInput, passHint, isValid ? 'Ready' : 'Password required', isValid);
+                setFieldState(passwordInput, passHint, isValid ? '' : i18n.t('connection.passwordRequired'), isValid);
             });
         }
 
         if (keySelect) {
             keySelect.addEventListener('change', () => {
                 const value = keySelect.value;
-                setFieldState(keySelect, keyHint, value ? 'Key selected' : 'Select a key', Boolean(value));
+                setFieldState(keySelect, keyHint, value ? '' : i18n.t('connection.selectSSHKey'), Boolean(value));
             });
         }
 
         if (profileNameInput) {
             profileNameInput.addEventListener('input', () => {
                 const value = profileNameInput.value.trim();
-                setFieldState(profileNameInput, profileHint, value ? 'Saved name' : '', value ? true : null);
+                setFieldState(profileNameInput, profileHint, '', value ? true : null);
             });
         }
 
         if (authTypeSelect) {
             authTypeSelect.addEventListener('change', () => {
                 if (authTypeSelect.value === 'password' && passwordInput) {
-                    setFieldState(passwordInput, passHint, passwordInput.value ? 'Ready' : 'Password required', Boolean(passwordInput.value));
+                    setFieldState(passwordInput, passHint, passwordInput.value ? '' : i18n.t('connection.passwordRequired'), Boolean(passwordInput.value));
                 }
                 if (authTypeSelect.value === 'key' && keySelect) {
-                    setFieldState(keySelect, keyHint, keySelect.value ? 'Key selected' : 'Select a key', Boolean(keySelect.value));
+                    setFieldState(keySelect, keyHint, keySelect.value ? '' : i18n.t('connection.selectSSHKey'), Boolean(keySelect.value));
                 }
             });
         }
@@ -2126,146 +2130,27 @@
 
     function setupNotepad() {
         const notepad = document.getElementById('sessionNotepad');
-        const saveStatus = document.getElementById('notepadSaveStatus');
-        if (!notepad) {
-            return;
-        }
-
-        const updateSaveStatus = (status) => {
-            if (!saveStatus) return;
-            if (status === 'saving') {
-                saveStatus.textContent = 'Saving...';
-                saveStatus.className = 'notepad-save-status saving';
-            } else if (status === 'saved') {
-                saveStatus.textContent = 'Saved';
-                saveStatus.className = 'notepad-save-status saved';
-                setTimeout(() => {
-                    saveStatus.className = 'notepad-save-status';
-                    saveStatus.textContent = '';
-                }, 2000);
-            }
-        };
-
+        const status = document.getElementById('notepadSaveStatus');
+        if (!notepad || !window.NotepadController) return;
+        window.notepadController = window.NotepadController.create({
+            socket: window.socket,
+            read: () => notepad.value,
+            write: value => { notepad.value = value; },
+            status: state => {
+                if (!status) return;
+                status.textContent = window.i18n.t(`notes.${state}`);
+                status.className = `notepad-save-status ${state}`;
+                status.setAttribute('role', state === 'failed' ? 'alert' : 'status');
+            },
+        });
+        notepad.addEventListener('input', () => window.notepadController.changed());
         notepad.addEventListener('focus', () => {
             if (document.body.classList.contains('keyboard-open')) {
                 document.body.classList.add('notepad-focused');
             }
         });
-        notepad.addEventListener('blur', () => {
-            document.body.classList.remove('notepad-focused');
-        });
-
-        let timer;
-        notepad.addEventListener('input', () => {
-            clearTimeout(timer);
-            const value = notepad.value;
-            updateSaveStatus('saving');
-            timer = setTimeout(() => {
-                if (window.socket) {
-                    window.socket.emit('save_notepad', { text: value });
-                    updateSaveStatus('saved');
-                }
-            }, 300);
-        });
-    }
-
-    function setupDropUpload() {
-        const overlay = document.getElementById('dropOverlay');
-        const form = document.getElementById('dropUploadForm');
-        const fileNameInput = document.getElementById('dropUploadFileName');
-        const pathInput = document.getElementById('dropUploadPath');
-        const modal = document.getElementById('dropUploadModal');
-        let pendingFile = null;
-
-        if (!overlay || !form || !modal) {
-            return;
-        }
-
-        const showOverlay = () => overlay.classList.remove('hidden');
-        const hideOverlay = () => overlay.classList.add('hidden');
-
-        document.addEventListener('dragover', (e) => {
-            if (e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')) {
-                e.preventDefault();
-                showOverlay();
-            }
-        });
-
-        document.addEventListener('dragleave', (e) => {
-            if (e.target === document.documentElement) {
-                hideOverlay();
-            }
-        });
-
-        document.addEventListener('dragend', () => {
-            hideOverlay();
-        });
-
-        document.addEventListener('drop', (e) => {
-            e.preventDefault();
-            hideOverlay();
-
-            const active = SessionManager.getWorkspaceSession?.()
-                || SessionManager.getActiveSession();
-            if (!active) {
-                showNotification('No active session for upload', 'warning');
-                return;
-            }
-
-            const file = e.dataTransfer.files && e.dataTransfer.files[0];
-            if (!file) {
-                return;
-            }
-            pendingFile = file;
-            fileNameInput.value = file.name;
-            pathInput.value = `./${file.name}`;
-
-            if (window.ModalManager) {
-                window.ModalManager.open(modal);
-            } else {
-                modal.classList.add('show');
-            }
-        });
-
-        form.addEventListener('submit', (e) => {
-            e.preventDefault();
-            const active = SessionManager.getWorkspaceSession?.()
-                || SessionManager.getActiveSession();
-            if (!active || !pendingFile) {
-                showNotification('No active session for upload', 'warning');
-                return;
-            }
-            const remotePath = pathInput.value.trim();
-            if (!remotePath) {
-                showNotification('Remote path required', 'error');
-                return;
-            }
-            FileTransferManager.uploadFile(active.id, pendingFile, remotePath);
-            pendingFile = null;
-            if (window.ModalManager) {
-                window.ModalManager.close(modal);
-            } else {
-                modal.classList.remove('show');
-            }
-        });
-
-        document.getElementById('cancelDropUploadBtn').addEventListener('click', () => {
-            pendingFile = null;
-            if (window.ModalManager) {
-                window.ModalManager.close(modal);
-            } else {
-                modal.classList.remove('show');
-            }
-        });
-
-        document.getElementById('closeDropUploadModal').addEventListener('click', () => {
-            pendingFile = null;
-            if (window.ModalManager) {
-                window.ModalManager.close(modal);
-            } else {
-                modal.classList.remove('show');
-            }
-        });
+        notepad.addEventListener('blur', () => document.body.classList.remove('notepad-focused'));
+        window.addEventListener('languageChanged', () => window.notepadController.render());
     }
 
     function setupShortcutsModal() {
@@ -3040,7 +2925,6 @@
         setupConnectionValidation();
         setupPasswordToggles();
         setupClipboardActions();
-        setupDropUpload();
         setupSplitControls();
         setupNotepad();
         TerminalSearch.init();

--- a/static/js/connection-validation.js
+++ b/static/js/connection-validation.js
@@ -1,0 +1,35 @@
+(function(root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.ConnectionValidation = api;
+}(typeof window !== 'undefined' ? window : null, function() {
+    'use strict';
+    function isValidHost(host) {
+        let value = String(host || '').trim();
+        if (value.startsWith('[') && value.endsWith(']')) value = value.slice(1, -1);
+        value = value.replace(/\.+$/, '');
+        if (!value) return false;
+        if (value.includes(':')) {
+            // Use the browser's IPv6 parser instead of an incomplete IPv6 regex.
+            const [address, zone, ...extra] = value.split('%');
+            if (extra.length || (zone !== undefined && (!zone || /\s/.test(zone)))) return false;
+            try {
+                return new URL(`http://[${address}]/`).hostname.startsWith('[');
+            } catch { return false; }
+        }
+        if (/[^\x00-\x7f]/.test(value)) {
+            if (/[\s/@:#?\\]/.test(value)) return false;
+            try { value = new URL(`http://${value}/`).hostname; } catch { return false; }
+        }
+        return value.length <= 253 && value.split('.').every(label => (
+            /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(label)
+        ));
+    }
+    function isValidUsername(value) {
+        return /^[a-zA-Z0-9_.-]{1,32}$/.test(String(value || '').trim());
+    }
+    function isValidPort(value) {
+        return /^\d+$/.test(String(value)) && Number(value) >= 1 && Number(value) <= 65535;
+    }
+    return {isValidHost, isValidUsername, isValidPort};
+}));

--- a/static/js/drag-drop-manager.js
+++ b/static/js/drag-drop-manager.js
@@ -1,12 +1,14 @@
 
 class DragDropManager {
-  constructor() {
+  constructor({sessionManager} = {}) {
+    this.sessionManager = sessionManager;
     this.overlay = null;
     this.dropZones = new Set();
     this.isDragging = false;
     this.dragCounter = 0;
     this.transferClient = null;
-    this.defaultSessionId = null;
+    this.pendingDrop = null;
+    this.directoryRequestSequence = 0;
 
     this.handleDragEnter = this.handleDragEnter.bind(this);
     this.handleDragOver = this.handleDragOver.bind(this);
@@ -17,6 +19,7 @@ class DragDropManager {
   init() {
     this.createOverlay();
     this.attachGlobalListeners();
+    this.setupUploadDialog();
 
     if (window.socket && window.BinaryTransferClient) {
       this.transferClient = window.BinaryTransferClient.forSocket(window.socket);
@@ -99,14 +102,6 @@ class DragDropManager {
   }
 
   attachGlobalListeners() {
-    document.addEventListener('dragover', (e) => {
-      e.preventDefault();
-    });
-
-    document.addEventListener('drop', (e) => {
-      e.preventDefault();
-    });
-
     document.addEventListener('dragenter', this.handleDragEnter);
     document.addEventListener('dragleave', this.handleDragLeave);
     document.addEventListener('dragover', this.handleDragOver);
@@ -163,137 +158,136 @@ class DragDropManager {
     }
   }
 
-  async handleDrop(e) {
-    if (!this.isFileDrag(e)) return;
+  t(key, fallback) {
+    return window.i18n?.t(key, fallback) || fallback;
+  }
 
+  setupUploadDialog() {
+    const modal = document.getElementById('dropUploadModal');
+    const close = () => {
+      this.pendingDrop = null;
+      window.ModalManager.close(modal);
+    };
+    document.getElementById('cancelDropUploadBtn')?.addEventListener('click', close);
+    document.getElementById('closeDropUploadModal')?.addEventListener('click', close);
+    document.getElementById('dropUploadForm')?.addEventListener('submit', async event => {
+      event.preventDefault();
+      const pending = this.pendingDrop;
+      const path = document.getElementById('dropUploadPath').value.trim();
+      if (!pending || !path) return;
+      close();
+      try {
+        this.assertConnected(pending.session);
+        await this.processEntries(pending.entries, pending.session, path);
+      } catch (error) {
+        window.showNotification?.(error.message, 'error');
+      }
+    });
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && modal?.classList.contains('show')) this.pendingDrop = null;
+    });
+    modal?.addEventListener('click', event => {
+      if (event.target === modal) this.pendingDrop = null;
+    });
+  }
+
+  handleDrop(e) {
+    if (!this.isFileDrag(e)) return;
     e.preventDefault();
     e.stopPropagation();
-
-    this.dragCounter = 0;
     this.hideOverlay();
-
-    const items = e.dataTransfer?.items;
-    const files = e.dataTransfer?.files;
-
     const session = this.getActiveSession();
+    if (!session) return this.showQuickConnectDialog();
 
-    if (!session) {
-      this.showQuickConnectDialog();
-      return;
-    }
+    // Read DataTransfer while the drop event is active; browsers protect it later.
+    const items = Array.from(e.dataTransfer?.items || []).filter(item => item.kind === 'file');
+    const entries = items.length ? items.map(item => {
+      const entry = item.webkitGetAsEntry?.();
+      return entry ? {entry} : {file: item.getAsFile?.()};
+    }).filter(item => item.entry || item.file)
+      : Array.from(e.dataTransfer?.files || [], file => ({file}));
+    if (!entries.length) return;
+    this.pendingDrop = {session: {...session}, entries};
+    document.getElementById('dropUploadFileName').value = entries
+      .map(item => (item.entry || item.file).name).join(', ');
+    document.getElementById('dropUploadPath').value = '.';
+    document.getElementById('dropUploadTarget').textContent =
+      `${session.username}@${session.host}:${session.port || 22}`;
+    window.ModalManager.open(document.getElementById('dropUploadModal'));
+  }
 
-    if (items) {
-      await this.processDataTransferItems(items, session);
-    } else if (files) {
-      this.processFiles(Array.from(files), session);
+  assertConnected(session) {
+    if (!window.socket?.connected || !(this.sessionManager || window.SessionManager)?.getSession(session.id)?.connected) {
+      throw new Error(this.t('fm.noActiveSession', 'No active SSH session'));
     }
   }
 
-  async processDataTransferItems(items, session) {
-    const entries = Array.from(items)
-      .filter(item => item.kind === 'file')
-      .map(item => item.webkitGetAsEntry());
+  joinPath(base, name) {
+    return `${base.replace(/\/+$/, '')}/${name}`;
+  }
 
-    for (const entry of entries) {
-      if (entry.isFile) {
-        entry.file(file => this.uploadFile(file, session));
-      } else if (entry.isDirectory) {
-        await this.uploadDirectory(entry, session);
+  async processEntries(entries, session, basePath) {
+    for (const {entry, file} of entries) {
+      if (entry?.isDirectory) {
+        await this.uploadDirectory(entry, session, basePath);
+      } else {
+        const upload = file || await new Promise((resolve, reject) => entry.file(resolve, reject));
+        this.uploadFileToPath(upload, this.joinPath(basePath, upload.name), session);
       }
     }
   }
 
-  processFiles(files, session) {
-    files.forEach(file => this.uploadFile(file, session));
-  }
-
-  async uploadDirectory(directoryEntry, session, basePath = null) {
-    if (!this.transferClient) return;
-
-    const currentPath = basePath || this.getCurrentPath() || '/';
-    const dirPath = `${currentPath}/${directoryEntry.name}`;
-
-    if (window.socket) {
-      const sourceId = session.fileSource?.sourceId || `sftp-session:${session.id}`;
-      window.socket.emit('create_directory', {
-        source_id: sourceId,
-        remote_path: dirPath,
-        request_id: `terminal-drop:create-directory:${Date.now()}:${this.dragCounter}`
-      });
-    }
-
-    const reader = directoryEntry.createReader();
-    const entries = await new Promise((resolve, reject) => {
-      reader.readEntries(resolve, reject);
+  createDirectory(path, session) {
+    this.assertConnected(session);
+    const socket = window.socket;
+    const sourceId = session.fileSource?.sourceId || `sftp-session:${session.id}`;
+    const requestId = `terminal-drop:mkdir:${Date.now()}:${++this.directoryRequestSequence}`;
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(timer);
+        socket.off('directory_created', created);
+        socket.off('error', failed);
+        socket.off('disconnect', disconnected);
+      };
+      const finish = error => {
+        cleanup();
+        if (error) reject(error); else resolve();
+      };
+      const matches = data => data?.request_id === requestId && data?.source_id === sourceId;
+      const created = data => { if (matches(data)) finish(); };
+      const failed = data => { if (matches(data)) finish(new Error(data.error)); };
+      const disconnected = () => finish(new Error(this.t('fm.noActiveSession', 'No active SSH session')));
+      const timer = setTimeout(() => finish(new Error(this.t('dropUpload.timeout', 'Creating the destination folder timed out.'))), 15000);
+      socket.on('directory_created', created);
+      socket.on('error', failed);
+      socket.on('disconnect', disconnected);
+      socket.emit('create_directory', {source_id: sourceId, remote_path: path, request_id: requestId});
     });
-
-    for (const entry of entries) {
-      if (entry.isFile) {
-        entry.file(file => {
-          const filePath = `${dirPath}/${file.name}`;
-          this.uploadFileToPath(file, filePath, session);
-        });
-      } else if (entry.isDirectory) {
-        await this.uploadDirectory(entry, session, dirPath);
-      }
-    }
   }
 
-  maxFileSize = 100 * 1024 * 1024;
-
-  validateFile(file) {
-    if (file.size > this.maxFileSize) {
-      return `File "${file.name}" too large (${(file.size / 1024 / 1024).toFixed(2)}MB). Max size: ${this.maxFileSize / 1024 / 1024}MB`;
+  async uploadDirectory(directoryEntry, session, basePath) {
+    const dirPath = this.joinPath(basePath, directoryEntry.name);
+    await this.createDirectory(dirPath, session);
+    const reader = directoryEntry.createReader();
+    while (true) {
+      const entries = await new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+      if (!entries.length) break;
+      await this.processEntries(entries.map(entry => ({entry})), session, dirPath);
     }
-    if (file.size === 0) {
-      return `File "${file.name}" is empty and cannot be uploaded.`;
-    }
-    return null;
-  }
-
-  uploadFile(file, session) {
-    const error = this.validateFile(file);
-    if (error) {
-      if (window.showNotification) {
-        window.showNotification(error, 'error');
-      }
-      return;
-    }
-
-    const currentPath = this.getCurrentPath() || '/';
-    const remotePath = `${currentPath}/${file.name}`;
-    this.uploadFileToPath(file, remotePath, session);
   }
 
   uploadFileToPath(file, remotePath, session) {
-    if (!this.transferClient) {
-      console.error('Transfer client not initialized');
-      return;
-    }
-
+    this.assertConnected(session);
     const sourceId = session.fileSource?.sourceId || `sftp-session:${session.id}`;
-    this.transferClient.uploadFile(file, remotePath, sourceId);
-
-    if (window.showNotification) {
-      window.showNotification(`Uploading ${file.name}...`, 'info');
-    }
+    FileTransferManager.uploadFile(sourceId, file, remotePath);
   }
 
   getActiveSession() {
-    if (window.SessionManager) {
-      const sessions = window.SessionManager.getAllSessions();
-      const connected = sessions.filter(s => s.connected);
-
-      if (connected.length > 0) {
-        return connected[0];
-      }
-    }
-
-    return null;
-  }
-
-  getCurrentPath() {
-    return '/';
+    const manager = this.sessionManager || window.SessionManager;
+    const id = typeof manager?.getWorkspaceSession === 'function'
+      ? manager.getWorkspaceSession() : manager?.getActiveSession();
+    const session = id ? manager.getSession(id) : null;
+    return session?.connected ? session : null;
   }
 
   showQuickConnectDialog() {
@@ -331,8 +325,7 @@ class DragDropManager {
 
     if (hint) {
       if (session) {
-        const path = this.getCurrentPath() || '/';
-        hint.textContent = `Uploading to ${session.username}@${session.host}:${path}`;
+        hint.textContent = `${session.username}@${session.host} — ${this.t('dropUpload.chooseFolder', 'Choose a destination folder after dropping.')}`;
       } else {
         hint.textContent = 'Connect to a server first';
       }
@@ -370,7 +363,7 @@ class DragDropManager {
 
 if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', () => {
-    window.dragDropManager = new DragDropManager();
+    window.dragDropManager = new DragDropManager({sessionManager: SessionManager});
     window.dragDropManager.init();
   });
 }

--- a/static/js/i18n.js
+++ b/static/js/i18n.js
@@ -1,6 +1,19 @@
 
 const translations = {
     en: {
+        'notes.unsaved': "Your notes have not been saved.",
+        'notes.saving': "Saving…",
+        'notes.saved': "Saved",
+        'notes.failed': "Not saved. Edit to retry.",
+        'notes.offline': "Offline — not saved",
+        'notes.tooLarge': "Not saved: maximum 100,000 characters.",
+        'validation.host': "Enter a hostname or IPv4/IPv6 address.",
+        'validation.port': "Enter a whole port number from 1 to 65535.",
+        'validation.username': "Use 1–32 letters, digits, underscores, hyphens or dots.",
+        'dropUpload.folder': "Destination folder",
+        'dropUpload.folderHint': "Relative paths start in the SFTP home directory, not the terminal working directory.",
+        'dropUpload.timeout': "Creating the destination folder timed out.",
+        'dropUpload.chooseFolder': "Choose a destination folder after dropping.",
         'app.title': 'Web SSH Terminal',
         'app.subtitle': 'Modern Terminal Access',
 
@@ -1296,6 +1309,19 @@ const translations = {
 
 
     vi: {
+        'notes.unsaved': "Ghi chú của bạn chưa được lưu.",
+        'notes.saving': "Đang lưu…",
+        'notes.saved': "Đã lưu",
+        'notes.failed': "Chưa lưu. Chỉnh sửa để thử lại.",
+        'notes.offline': "Ngoại tuyến — chưa lưu",
+        'notes.tooLarge': "Chưa lưu: tối đa 100.000 ký tự.",
+        'validation.host': "Nhập tên máy chủ hoặc địa chỉ IPv4/IPv6.",
+        'validation.port': "Nhập số cổng nguyên từ 1 đến 65535.",
+        'validation.username': "Dùng 1–32 chữ cái, chữ số, dấu gạch dưới, gạch nối hoặc dấu chấm.",
+        'dropUpload.folder': "Thư mục đích",
+        'dropUpload.folderHint': "Đường dẫn tương đối bắt đầu tại thư mục nhà SFTP, không phải thư mục làm việc của terminal.",
+        'dropUpload.timeout': "Hết thời gian tạo thư mục đích.",
+        'dropUpload.chooseFolder': "Chọn thư mục đích sau khi thả.",
         'app.title': 'Web SSH Terminal',
         'app.subtitle': 'Truy cập terminal hiện đại',
 
@@ -2590,6 +2616,19 @@ const translations = {
     },
 
     de: {
+        'notes.unsaved': "Deine Notizen wurden noch nicht gespeichert.",
+        'notes.saving': "Wird gespeichert…",
+        'notes.saved': "Gespeichert",
+        'notes.failed': "Nicht gespeichert. Zum Wiederholen bearbeiten.",
+        'notes.offline': "Offline — nicht gespeichert",
+        'notes.tooLarge': "Nicht gespeichert: maximal 100.000 Zeichen.",
+        'validation.host': "Hostname oder IPv4-/IPv6-Adresse eingeben.",
+        'validation.port': "Eine ganze Portnummer zwischen 1 und 65535 eingeben.",
+        'validation.username': "1–32 Buchstaben, Ziffern, Unterstriche, Bindestriche oder Punkte verwenden.",
+        'dropUpload.folder': "Zielordner",
+        'dropUpload.folderHint': "Relative Pfade beginnen im SFTP-Heimatverzeichnis, nicht im Arbeitsverzeichnis des Terminals.",
+        'dropUpload.timeout': "Zeitüberschreitung beim Erstellen des Zielordners.",
+        'dropUpload.chooseFolder': "Nach dem Ablegen einen Zielordner auswählen.",
         'app.title': 'Web SSH Terminal',
         'app.subtitle': 'Moderner Terminal-Zugang',
 
@@ -3883,6 +3922,19 @@ const translations = {
     },
 
     fr: {
+        'notes.unsaved': "Vos notes n’ont pas été enregistrées.",
+        'notes.saving': "Enregistrement…",
+        'notes.saved': "Enregistré",
+        'notes.failed': "Non enregistré. Modifiez pour réessayer.",
+        'notes.offline': "Hors ligne — non enregistré",
+        'notes.tooLarge': "Non enregistré : 100 000 caractères maximum.",
+        'validation.host': "Saisissez un nom d’hôte ou une adresse IPv4/IPv6.",
+        'validation.port': "Saisissez un numéro de port entier de 1 à 65535.",
+        'validation.username': "Utilisez 1 à 32 lettres, chiffres, traits de soulignement, tirets ou points.",
+        'dropUpload.folder': "Dossier de destination",
+        'dropUpload.folderHint': "Les chemins relatifs partent du dossier personnel SFTP, pas du répertoire de travail du terminal.",
+        'dropUpload.timeout': "Délai dépassé pour la création du dossier de destination.",
+        'dropUpload.chooseFolder': "Choisissez un dossier de destination après le dépôt.",
         'app.title': 'Terminal SSH Web',
         'app.subtitle': 'Accès Terminal Moderne',
 
@@ -5176,6 +5228,19 @@ const translations = {
     },
 
     es: {
+        'notes.unsaved': "Sus notas no se han guardado.",
+        'notes.saving': "Guardando…",
+        'notes.saved': "Guardado",
+        'notes.failed': "No guardado. Edite para reintentar.",
+        'notes.offline': "Sin conexión — no guardado",
+        'notes.tooLarge': "No guardado: máximo 100.000 caracteres.",
+        'validation.host': "Introduzca un nombre de host o una dirección IPv4/IPv6.",
+        'validation.port': "Introduzca un número de puerto entero entre 1 y 65535.",
+        'validation.username': "Use entre 1 y 32 letras, dígitos, guiones bajos, guiones o puntos.",
+        'dropUpload.folder': "Carpeta de destino",
+        'dropUpload.folderHint': "Las rutas relativas parten del directorio personal SFTP, no del directorio de trabajo del terminal.",
+        'dropUpload.timeout': "Se agotó el tiempo para crear la carpeta de destino.",
+        'dropUpload.chooseFolder': "Elija una carpeta de destino después de soltar.",
         'app.title': 'Terminal SSH Web',
         'app.subtitle': 'Acceso Terminal Moderno',
 
@@ -6469,6 +6534,19 @@ const translations = {
     },
 
     zh: {
+        'notes.unsaved': "你的笔记尚未保存。",
+        'notes.saving': "正在保存…",
+        'notes.saved': "已保存",
+        'notes.failed': "未保存。编辑以重试。",
+        'notes.offline': "离线 — 未保存",
+        'notes.tooLarge': "未保存：最多 100,000 个字符。",
+        'validation.host': "请输入主机名或 IPv4/IPv6 地址。",
+        'validation.port': "请输入 1 到 65535 之间的整数端口号。",
+        'validation.username': "使用 1–32 个字母、数字、下划线、连字符或点。",
+        'dropUpload.folder': "目标文件夹",
+        'dropUpload.folderHint': "相对路径从 SFTP 主目录开始，而不是终端的工作目录。",
+        'dropUpload.timeout': "创建目标文件夹超时。",
+        'dropUpload.chooseFolder': "拖放后选择目标文件夹。",
         'app.title': 'Web SSH 终端',
         'app.subtitle': '现代化终端访问',
 

--- a/static/js/notepad-controller.js
+++ b/static/js/notepad-controller.js
@@ -1,0 +1,74 @@
+(function(root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.NotepadController = api;
+}(typeof window !== 'undefined' ? window : null, function() {
+    'use strict';
+
+    function create(options) {
+        const {socket, read, write, status} = options;
+        const schedule = options.setTimeout || setTimeout;
+        const cancel = options.clearTimeout || clearTimeout;
+        let dirty = false;
+        let edited = false;
+        let revision = 0;
+        let timer;
+        let pending = null;
+        let state = 'saved';
+
+        function show(next) {
+            state = next;
+            status(state);
+        }
+        function save() {
+            cancel(timer);
+            if (!dirty || pending) return;
+            if (!socket.connected) return show('offline');
+            const text = read();
+            // Match Python's Unicode character count, including astral characters.
+            if (Array.from(text).length > 100000) return show('tooLarge');
+            const attempt = {revision};
+            pending = attempt;
+            show('saving');
+            attempt.timer = schedule(() => {
+                if (pending !== attempt) return;
+                pending = null;
+                show('failed');
+            }, 10000);
+            socket.emit('save_notepad', {text}, result => {
+                if (pending !== attempt) return;
+                cancel(attempt.timer);
+                pending = null;
+                if (result?.success !== true) return show('failed');
+                if (revision !== attempt.revision) return save();
+                dirty = false;
+                show('saved');
+            });
+        }
+        socket.on('disconnect', () => {
+            cancel(timer);
+            if (pending) cancel(pending.timer);
+            pending = null;
+            if (dirty) show('offline');
+        });
+        return {
+            changed() {
+                dirty = true;
+                edited = true;
+                revision += 1;
+                cancel(timer);
+                show(socket.connected ? 'saving' : 'offline');
+                timer = schedule(save, 300);
+            },
+            receive(text) {
+                // A reconnect read must never replace this page's local edits,
+                // even if an older read arrives after the save acknowledgement.
+                if (!edited) write(text);
+            },
+            reconnect: save,
+            hasUnsaved: () => dirty,
+            render: () => status(state),
+        };
+    }
+    return {create};
+}));

--- a/static/js/notepad-controller.js
+++ b/static/js/notepad-controller.js
@@ -33,14 +33,15 @@
             attempt.timer = schedule(() => {
                 if (pending !== attempt) return;
                 pending = null;
+                if (revision !== attempt.revision) return save();
                 show('failed');
             }, 10000);
             socket.emit('save_notepad', {text}, result => {
                 if (pending !== attempt) return;
                 cancel(attempt.timer);
                 pending = null;
-                if (result?.success !== true) return show('failed');
                 if (revision !== attempt.revision) return save();
+                if (result?.success !== true) return show('failed');
                 dirty = false;
                 show('saved');
             });

--- a/templates/index.html
+++ b/templates/index.html
@@ -1229,13 +1229,15 @@
             </div>
             <div class="modal-body">
                 <form id="dropUploadForm">
+                    <p id="dropUploadTarget"></p>
                     <div class="form-group">
                         <label for="dropUploadFileName" data-i18n="files.localFile">File</label>
                         <input type="text" id="dropUploadFileName" class="form-control" readonly>
                     </div>
                     <div class="form-group">
-                        <label for="dropUploadPath" data-i18n="files.remotePath">Remote Path</label>
-                        <input type="text" id="dropUploadPath" class="form-control" placeholder="./file.txt" required>
+                        <label for="dropUploadPath" data-i18n="dropUpload.folder">Destination folder</label>
+                        <input type="text" id="dropUploadPath" class="form-control" value="." required aria-describedby="dropUploadPathHint">
+                        <p id="dropUploadPathHint" data-i18n="dropUpload.folderHint">Relative paths start in the SFTP home directory, not the terminal working directory.</p>
                     </div>
                     <div class="form-actions">
                         <button type="button" class="btn btn-secondary" id="cancelDropUploadBtn" data-i18n="common.cancel">Cancel</button>
@@ -1458,6 +1460,8 @@
     <script src="{{ static_asset_url(filename='js/connection-history.js') }}"></script>
     <script src="{{ static_asset_url(filename='js/primary-workspace-controller.js') }}"></script>
     <script src="{{ static_asset_url(filename='js/socket-reconnect-policy.js') }}"></script>
+    <script src="{{ static_asset_url(filename='js/notepad-controller.js') }}"></script>
+    <script src="{{ static_asset_url(filename='js/connection-validation.js') }}"></script>
     <script src="{{ static_asset_url(filename='js/app.js') }}"></script>
     <script>
         const flashedMessages = {{ get_flashed_messages(with_categories=true) | tojson }};

--- a/tests/e2e/review-regressions.spec.js
+++ b/tests/e2e/review-regressions.spec.js
@@ -1,0 +1,80 @@
+const {test, expect} = require('playwright/test');
+const {login, assertNoExternalRequests} = require('./helpers');
+
+test.afterEach(async ({page}) => assertNoExternalRequests(page));
+
+test('Quick Connect accepts IPv6 and dotted usernames with localized validation', async ({page}) => {
+    await login(page);
+    await page.locator('.profile-launcher-new').click();
+    await page.locator('#hostInput').fill('2001:db8::10');
+    await page.locator('#usernameInput').fill('first.last');
+    await expect(page.locator('#hostInput')).not.toHaveClass(/is-invalid/);
+    await expect(page.locator('#usernameInput')).not.toHaveClass(/is-invalid/);
+    await page.evaluate(() => i18n.setLanguage('de'));
+    await page.locator('#hostInput').fill(':::');
+    await expect(page.locator('#hostHint')).toHaveText('Hostname oder IPv4-/IPv6-Adresse eingeben.');
+});
+
+test('German settings navigation stays within the sidebar at intermediate widths', async ({page}, testInfo) => {
+    await login(page);
+    await page.goto('/settings#preferences');
+    await page.locator('#settingsLanguageSelect').selectOption('de');
+    await page.evaluate(() => document.fonts.ready);
+    for (const width of [900, 768, 601, 1024]) {
+        await page.setViewportSize({width, height: 800});
+        const geometry = await page.evaluate(() => {
+            const sidebar = document.querySelector('.admin-navigation').getBoundingClientRect();
+            return Array.from(document.querySelectorAll('.settings-center-navigation .admin-tab'))
+                .map(button => ({right: button.getBoundingClientRect().right, limit: sidebar.right,
+                    scroll: button.scrollWidth, width: button.clientWidth}));
+        });
+        if (width === 900) await page.screenshot({path: testInfo.outputPath('settings-de-900.png')});
+        for (const button of geometry) {
+            expect(button.right).toBeLessThanOrEqual(button.limit);
+            expect(button.scroll).toBeLessThanOrEqual(button.width + 1);
+        }
+    }
+});
+
+test('notes confirm real persistence and remain unsaved while offline', async ({page}) => {
+    await page.setViewportSize({width: 1440, height: 900});
+    await login(page);
+    await expect(page.locator('#sessionNotepad')).toBeVisible();
+    await page.locator('#sessionNotepad').fill('Review note persisted');
+    await expect(page.locator('#notepadSaveStatus')).toHaveText('Saved');
+    await page.reload();
+    await expect(page.locator('#sessionNotepad')).toHaveValue('Review note persisted');
+    await page.evaluate(() => window.socket.disconnect());
+    await page.locator('#sessionNotepad').fill('Offline review edit');
+    await expect(page.locator('#notepadSaveStatus')).toHaveText('Offline — not saved');
+    await page.evaluate(() => window.socket.connect());
+    await expect(page.locator('#notepadSaveStatus')).toHaveText('Saved');
+    await page.reload();
+    await expect(page.locator('#sessionNotepad')).toHaveValue('Offline review edit');
+});
+
+test('terminal drop prompts once and binds the target before any upload', async ({page}) => {
+    await login(page);
+    await page.evaluate(() => {
+        const sessions = {
+            first: {id: 'first', username: 'alice', host: 'first.example', connected: true},
+            active: {id: 'active', username: 'bob', host: 'active.example', connected: true},
+        };
+        SessionManager.getAllSessions = () => Object.values(sessions);
+        SessionManager.getWorkspaceSession = () => 'active';
+        SessionManager.getSession = id => sessions[id];
+        window.__reviewUploads = [];
+        FileTransferManager.uploadFile = (...args) => window.__reviewUploads.push(args);
+        const transfer = new DataTransfer();
+        transfer.items.add(new File(['review'], 'note.txt', {type: 'text/plain'}));
+        document.querySelector('#workspace').dispatchEvent(new DragEvent('drop', {bubbles: true, dataTransfer: transfer}));
+    });
+    await expect(page.locator('#dropUploadModal')).toBeVisible();
+    await expect(page.locator('#dropUploadTarget')).toHaveText('bob@active.example:22');
+    expect(await page.evaluate(() => window.__reviewUploads.length)).toBe(0);
+    await page.locator('#dropUploadPath').fill('/chosen');
+    await page.evaluate(() => { SessionManager.getWorkspaceSession = () => 'first'; });
+    await page.locator('#dropUploadForm button[type="submit"]').click();
+    expect(await page.evaluate(() => window.__reviewUploads.map(([source, file, path]) => ({source, name: file.name, path}))))
+        .toEqual([{source: 'sftp-session:active', name: 'note.txt', path: '/chosen/note.txt'}]);
+});

--- a/tests/js/connection-validation.test.js
+++ b/tests/js/connection-validation.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const validation = require('../../static/js/connection-validation');
+
+test('accepts hostname, IDN, IPv4 and IPv6 inputs supported by SSH validation', () => {
+    for (const host of ['server', 'server.example.', 'münchen.example', '192.0.2.1',
+        '2001:db8::10', '[2001:db8::10]', '::1', '::ffff:192.0.2.1', 'fe80::1%eth0']) {
+        assert.equal(validation.isValidHost(host), true, host);
+    }
+    for (const host of ['', ':::', '2001:db8::gg', 'bad host', 'host/path', '-host', 'x'.repeat(64)]) {
+        assert.equal(validation.isValidHost(host), false, host);
+    }
+});
+
+test('username and port hints match backend-supported formats', () => {
+    assert.equal(validation.isValidUsername('first.last'), true);
+    assert.equal(validation.isValidUsername('user_name-1'), true);
+    assert.equal(validation.isValidUsername('alice@example.com'), false);
+    for (const port of ['0', '65536', '22x', '22.5', '1e3', '']) assert.equal(validation.isValidPort(port), false, port);
+    for (const port of ['1', '22', '65535']) assert.equal(validation.isValidPort(port), true, port);
+});

--- a/tests/js/notepad-controller.test.js
+++ b/tests/js/notepad-controller.test.js
@@ -1,0 +1,83 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {create} = require('../../static/js/notepad-controller');
+
+function harness() {
+    const timers = new Map();
+    const handlers = {};
+    const requests = [];
+    const state = {text: '', status: ''};
+    let next = 0;
+    const socket = {connected: true, on: (name, handler) => { handlers[name] = handler; },
+        emit: (name, payload, ack) => requests.push({name, payload, ack})};
+    const controller = create({socket, read: () => state.text,
+        write: value => { state.text = value; }, status: value => { state.status = value; },
+        setTimeout: (fn, ms) => { const id = ++next; timers.set(id, {fn, ms}); return id; },
+        clearTimeout: id => timers.delete(id)});
+    return {controller, state, socket, requests,
+        edit(text) { state.text = text; controller.changed(); },
+        disconnect() { socket.connected = false; handlers.disconnect(); },
+        tick(ms) { for (const [id, timer] of [...timers]) if (timer.ms === ms) {timers.delete(id); timer.fn();} },
+    };
+}
+
+test('waits for successful persistence acknowledgement before saying saved', () => {
+    const h = harness();
+    h.edit('note'); h.tick(300);
+    assert.equal(h.state.status, 'saving');
+    assert.equal(h.controller.hasUnsaved(), true);
+    h.requests[0].ack({success: false});
+    assert.equal(h.state.status, 'failed');
+    assert.equal(h.controller.hasUnsaved(), true);
+    h.edit('retry'); h.tick(300); h.requests[1].ack({success: true});
+    assert.equal(h.state.status, 'saved');
+    assert.equal(h.controller.hasUnsaved(), false);
+});
+
+test('keeps offline edits through reconnect reads and ignores stale acknowledgements', () => {
+    const h = harness();
+    h.edit('first'); h.tick(300); h.disconnect();
+    h.edit('offline'); h.tick(300);
+    assert.equal(h.requests.length, 1);
+    assert.equal(h.state.status, 'offline');
+    h.controller.receive('old server note');
+    assert.equal(h.state.text, 'offline');
+    h.socket.connected = true; h.controller.reconnect();
+    h.requests[0].ack({success: true});
+    assert.equal(h.controller.hasUnsaved(), true);
+    assert.equal(h.requests[1].payload.text, 'offline');
+    h.requests[1].ack({success: true});
+    h.controller.receive('late old read');
+    assert.equal(h.state.text, 'offline');
+    assert.equal(h.state.status, 'saved');
+});
+
+test('serializes edits made while a save is pending', () => {
+    const h = harness();
+    h.edit('one'); h.tick(300); h.edit('two'); h.tick(300);
+    assert.equal(h.requests.length, 1);
+    h.requests[0].ack({success: true});
+    assert.equal(h.requests.length, 2);
+    assert.equal(h.requests[1].payload.text, 'two');
+    assert.equal(h.state.status, 'saving');
+    h.requests[1].ack({success: true});
+    assert.equal(h.state.status, 'saved');
+});
+
+test('timeout leaves the note dirty and late acknowledgement cannot clear newer edits', () => {
+    const h = harness();
+    h.edit('one'); h.tick(300); h.tick(10000);
+    assert.equal(h.state.status, 'failed');
+    h.edit('two'); h.tick(300); h.requests[0].ack({success: true});
+    assert.equal(h.controller.hasUnsaved(), true);
+    assert.equal(h.state.status, 'saving');
+});
+
+test('checks the server character limit without rejecting valid non-BMP text', () => {
+    const h = harness();
+    h.edit('😀'.repeat(100001)); h.tick(300);
+    assert.equal(h.requests.length, 0);
+    assert.equal(h.state.status, 'tooLarge');
+    h.edit('😀'.repeat(100000)); h.tick(300);
+    assert.equal(h.requests.length, 1);
+});

--- a/tests/js/notepad-controller.test.js
+++ b/tests/js/notepad-controller.test.js
@@ -29,6 +29,8 @@ test('waits for successful persistence acknowledgement before saying saved', () 
     h.requests[0].ack({success: false});
     assert.equal(h.state.status, 'failed');
     assert.equal(h.controller.hasUnsaved(), true);
+    h.tick(300); h.tick(10000);
+    assert.equal(h.requests.length, 1);
     h.edit('retry'); h.tick(300); h.requests[1].ack({success: true});
     assert.equal(h.state.status, 'saved');
     assert.equal(h.controller.hasUnsaved(), false);
@@ -71,6 +73,38 @@ test('timeout leaves the note dirty and late acknowledgement cannot clear newer 
     h.edit('two'); h.tick(300); h.requests[0].ack({success: true});
     assert.equal(h.controller.hasUnsaved(), true);
     assert.equal(h.state.status, 'saving');
+});
+
+for (const outcome of ['failure', 'timeout']) {
+    test(`saves queued edits after ${outcome} without retrying an unchanged revision`, () => {
+        const h = harness();
+        h.edit('one'); h.tick(300);
+        h.edit('two'); h.tick(300);
+        h.edit('latest'); h.tick(300);
+        assert.equal(h.requests.length, 1);
+        if (outcome === 'failure') h.requests[0].ack({success: false});
+        else h.tick(10000);
+        assert.equal(h.requests.length, 2);
+        assert.equal(h.requests[1].payload.text, 'latest');
+        assert.equal(h.state.status, 'saving');
+        assert.equal(h.controller.hasUnsaved(), true);
+        h.requests[0].ack({success: true});
+        assert.equal(h.controller.hasUnsaved(), true);
+        h.requests[1].ack({success: true});
+        assert.equal(h.state.status, 'saved');
+        assert.equal(h.controller.hasUnsaved(), false);
+        h.tick(300); h.tick(10000);
+        assert.equal(h.requests.length, 2);
+    });
+}
+
+test('does not automatically retry a timed out unchanged revision', () => {
+    const h = harness();
+    h.edit('one'); h.tick(300); h.tick(10000);
+    h.tick(300); h.tick(10000);
+    assert.equal(h.requests.length, 1);
+    assert.equal(h.state.status, 'failed');
+    assert.equal(h.controller.hasUnsaved(), true);
 });
 
 test('checks the server character limit without rejecting valid non-BMP text', () => {

--- a/tests/js/socket-protocol.test.js
+++ b/tests/js/socket-protocol.test.js
@@ -397,3 +397,14 @@ test('restricted session storage degrades to the manual reload action', () => {
     assert.equal(controller.handleMismatch({ required_revision: 2 }), 'manual');
     assert.equal(manualReloads, 1);
 });
+
+test('unsaved notes warn before leaving even with no connected SSH session', () => {
+    const harness = loadAppSocketHarness();
+    harness.browserGlobal.notepadController = {hasUnsaved: () => true};
+    const beforeUnload = harness.windowHandlers.get('beforeunload')?.at(-1);
+    let prevented = false;
+    const event = {preventDefault() {prevented = true;}};
+    beforeUnload(event);
+    assert.equal(prevented, true);
+    assert.ok(event.returnValue);
+});

--- a/tests/js/terminal-drop.test.js
+++ b/tests/js/terminal-drop.test.js
@@ -1,0 +1,91 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const DragDropManager = require('../../static/js/drag-drop-manager');
+
+function harness() {
+    const listeners = new Map();
+    const dom = new Map();
+    const uploads = [];
+    const requests = [];
+    const notifications = [];
+    const first = {id: 'first', username: 'alice', host: 'first.example', connected: true};
+    const active = {id: 'active', username: 'bob', host: 'active.example', connected: true};
+    const state = {activeId: active.id, visible: false};
+    const element = id => {
+        if (!dom.has(id)) dom.set(id, {value: '', textContent: '', handlers: {},
+            classList: {contains: () => state.visible},
+            addEventListener(name, fn) {this.handlers[name] = fn;}});
+        return dom.get(id);
+    };
+    global.document = {getElementById: element, addEventListener() {}};
+    global.window = {
+        socket: {connected: true, on(name, fn) {if (!listeners.has(name)) listeners.set(name, new Set()); listeners.get(name).add(fn);},
+            off(name, fn) {listeners.get(name)?.delete(fn);}, emit(name, payload) {requests.push({name, payload});}},
+        SessionManager: {getWorkspaceSession: () => state.activeId, getActiveSession: () => first.id,
+            getSession: id => [first, active].find(s => s.id === id)},
+        ModalManager: {open() {state.visible = true;}, close() {state.visible = false;}},
+        showNotification: message => notifications.push(message),
+    };
+    global.FileTransferManager = {uploadFile: (...args) => uploads.push(args)};
+    const manager = new DragDropManager();
+    manager.setupUploadDialog();
+    return {manager, first, active, state, uploads, requests, notifications, element,
+        receive(name, data) {for (const fn of [...(listeners.get(name) || [])]) fn(data);},
+        listenerCount: () => [...listeners.values()].reduce((n, set) => n + set.size, 0),
+        drop() {manager.handleDrop({preventDefault() {}, stopPropagation() {},
+            dataTransfer: {types: ['Files'], files: [{name: 'note.txt', size: 1}]}});},
+        submit: () => element('dropUploadForm').handlers.submit({preventDefault() {}}),
+    };
+}
+
+test('binds the active target at drop time, requires confirmation and honors destination folder', async () => {
+    const h = harness(); h.drop();
+    assert.equal(h.uploads.length, 0);
+    assert.equal(h.element('dropUploadTarget').textContent, 'bob@active.example:22');
+    assert.equal(h.element('dropUploadPath').value, '.');
+    h.state.activeId = h.first.id;
+    h.element('dropUploadPath').value = '/chosen/';
+    await h.submit();
+    assert.equal(h.uploads.length, 1);
+    assert.equal(h.uploads[0][0], 'sftp-session:active');
+    assert.equal(h.uploads[0][2], '/chosen/note.txt');
+});
+
+test('cancel sends nothing and a disconnected target never falls back to another server', async () => {
+    const h = harness(); h.drop();
+    h.element('cancelDropUploadBtn').handlers.click(); await h.submit();
+    assert.equal(h.uploads.length, 0);
+    h.drop(); h.active.connected = false; await h.submit();
+    assert.equal(h.uploads.length, 0);
+    assert.equal(h.notifications.length, 1);
+    h.state.activeId = null;
+    assert.equal(h.manager.getActiveSession(), null);
+});
+
+test('reads every directory batch and waits for correlated mkdir success before uploading children', async () => {
+    const h = harness(); let reads = 0;
+    const file = name => ({name, isFile: true, file: done => done({name, size: 1})});
+    const directory = {name: 'folder', createReader: () => ({readEntries(done) {
+        reads++; done(reads <= 2 ? Array.from({length: 100}, (_, i) => file(`${reads}-${i}.txt`)) : []);
+    }})};
+    const operation = h.manager.uploadDirectory(directory, h.active, '.');
+    assert.equal(reads, 0); assert.equal(h.uploads.length, 0);
+    const request = h.requests[0].payload;
+    h.receive('directory_created', {...request, request_id: 'unrelated'});
+    assert.equal(reads, 0);
+    h.receive('directory_created', request);
+    await operation;
+    assert.equal(reads, 3); assert.equal(h.uploads.length, 200);
+    assert.equal(h.uploads[199][2], './folder/2-99.txt');
+    assert.equal(h.listenerCount(), 0);
+});
+
+test('mkdir failure or disconnect stops children and releases response listeners', async () => {
+    for (const failure of ['error', 'disconnect']) {
+        const h = harness(); let read = false;
+        const operation = h.manager.uploadDirectory({name: 'folder', createReader() {read = true;}}, h.active, '.');
+        h.receive(failure, {...h.requests[0].payload, error: 'Permission denied'});
+        await assert.rejects(operation);
+        assert.equal(read, false); assert.equal(h.uploads.length, 0); assert.equal(h.listenerCount(), 0);
+    }
+});

--- a/tests/js/transfer-client.test.js
+++ b/tests/js/transfer-client.test.js
@@ -758,6 +758,7 @@ test('FileTransferManager and DragDropManager use the shared socket coordinator'
     const dragDropManager = new DragDropManager();
     dragDropManager.createOverlay = () => {};
     dragDropManager.attachGlobalListeners = () => {};
+    dragDropManager.setupUploadDialog = () => {};
     dragDropManager.init();
 
     assert.equal(FileTransferManager.getTransferClient(), shared);
@@ -787,4 +788,20 @@ test('FileTransferManager and DragDropManager use the shared socket coordinator'
         'Transfer failed: report.txt — No write permission for the destination.',
         'error',
     ]);
+});
+
+test('terminal uploads report preflight failures without leaking ownership', async () => {
+    const transport = controlledSocket();
+    const notifications = [];
+    global.window = {socket: transport.socket, BinaryTransferClient,
+        WEBSSH_TRANSFER_LIMITS: {uploadBytes: 10},
+        showNotification: (...args) => notifications.push(args)};
+    delete require.cache[require.resolve('../../static/js/file-transfer.js')];
+    const manager = require('../../static/js/file-transfer.js');
+    manager.uploadFile('sftp-session:active', {name: 'large.txt', size: 11}, './large.txt');
+    await flushTasks();
+    assert.equal(transport.preparations.length, 0);
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0][1], 'error');
+    assert.equal(manager.ownedTransfers.size, 0);
 });

--- a/tests/test_command_set_socket_events.py
+++ b/tests/test_command_set_socket_events.py
@@ -2966,3 +2966,43 @@ def test_convert_legacy_profile_reports_safe_corrupt_profile_store(
         'code': 'storage_error',
     }
     assert emitted == [('error', result)]
+
+
+def test_notepad_acknowledges_only_successful_persistence(app, monkeypatch):
+    from app import user_settings
+    import app.socket_events as socket_events
+
+    user_id, sid = create_socket_user(app, 'notepad_ack')
+    result, emitted = call_socket_handler(
+        app, monkeypatch, socket_events.handle_save_notepad, sid,
+        {'text': 'Persisted note'},
+    )
+    assert result == {'success': True}
+    assert emitted == []
+    with app.app_context():
+        assert user_settings.get_user_settings(user_id)['notepad'] == 'Persisted note'
+
+    monkeypatch.setattr(socket_events, 'save_user_settings', lambda *_args: False)
+    result, emitted = call_socket_handler(
+        app, monkeypatch, socket_events.handle_save_notepad, sid,
+        {'text': 'Unsaved note'},
+    )
+    assert result == {'success': False, 'error': 'Failed to save notepad'}
+    assert emitted == [('error', result)]
+    with app.app_context():
+        assert user_settings.get_user_settings(user_id)['notepad'] == 'Persisted note'
+
+
+def test_notepad_rejects_oversized_text_before_writing(app, monkeypatch):
+    import app.socket_events as socket_events
+
+    _user_id, sid = create_socket_user(app, 'notepad_limit')
+    writes = []
+    monkeypatch.setattr(socket_events, 'save_user_settings', lambda *args: writes.append(args))
+    result, emitted = call_socket_handler(
+        app, monkeypatch, socket_events.handle_save_notepad, sid,
+        {'text': 'x' * 100001},
+    )
+    assert result['success'] is False
+    assert emitted == [('error', result)]
+    assert writes == []


### PR DESCRIPTION
## Changes

Fix the terminal drop flow so files are queued only after confirming the destination. A single handler receives the real session manager, captures the active target at drop time, and keeps that target if the user switches sessions. The dialog shows the server and destination folder; relative paths explicitly refer to the SFTP home directory. Disconnected targets fail instead of falling back to another session.

- Read every directory-entry batch and await the matching directory-creation response before uploading children. Stop on creation failure, disconnect, or timeout.
- Show notes as saved only after a successful server acknowledgement. Preserve dirty text across reconnects and late responses, serialize pending saves, report failures/offline state, enforce the character limit, and warn before leaving with unsaved notes.
- Accept IPv6 and IDN hosts in Quick Connect hints, align dotted usernames with the existing backend policy, and localize validation/status text in all six locales.
- Constrain the settings navigation grid and wrap translated labels so the German sidebar no longer overlaps content at intermediate widths.

## Validation

- 2,826 Python tests passed across the full suite and a separate socket-capacity run; 29 skipped. The capacity test required local socket permissions unavailable in the initial sandbox run.
- All 43 JavaScript test files passed; ESLint and `git diff --check` passed.
- 22 browser tests passed, covering the new regressions and existing Quick Connect, File Manager, and account-menu flows.
- Directory tests cover 200 entries across multiple batches, response correlation, failure cleanup, cancellation, and target binding. Browser tests verify real note persistence/reconnect and sidebar bounds at 601, 768, 900, and 1024 pixels.

Browser checks used the isolated E2E instance. SSH targets and transfers in the drop regression were simulated; no external SSH/SFTP/SMB server was contacted.